### PR TITLE
build: fix warnings

### DIFF
--- a/escher/src/text_area.cpp
+++ b/escher/src/text_area.cpp
@@ -110,7 +110,7 @@ int TextArea::Text::removeRemainingLine(size_t index, int direction) {
   /* We stop at m_bufferSize-1 because:
    * - if direction > 0: jump >= k+1 so we will reach the 0 before m_bufferSize-1
    * - if direction < 0: k+1 will reach m_bufferSize. */
-  for (int k = index; k < m_bufferSize-1; k++) {
+  for (size_t k = index; k < m_bufferSize-1; k++) {
     if (direction > 0) {
       m_buffer[k] = m_buffer[jump++];
     } else {

--- a/liba/Makefile
+++ b/liba/Makefile
@@ -117,6 +117,7 @@ liba/src/external/openbsd/e_pow.o: CFLAGS += -w
 liba/src/external/openbsd/e_rem_pio2.o: CFLAGS += -w
 liba/src/external/openbsd/e_sinh.o: CFLAGS += -w
 liba/src/external/openbsd/k_rem_pio2.o: CFLAGS += -w
+liba/src/external/openbsd/k_rem_pio2f.o: CFLAGS += -w
 liba/src/external/openbsd/s_asinh.o: CFLAGS += -w
 liba/src/external/openbsd/s_log1p.o: CFLAGS += -w
 liba/src/external/openbsd/s_scalbn.o: CFLAGS += -w


### PR DESCRIPTION
Those two warnings showed up while building the whole thing, it wasn't very beautiful in the terminal :)

* `escher/src/text_area.cpp:113:25`: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
* `liba/src/external/openbsd/k_rem_pio2f.c:66:54`: warning: this 'for' clause does not guard this statement, but the latter is misleadingly indented as if it is guarded by the 'for' [-Wmisleading-indentation]