### PR TITLE
[escher] table view: ability to jump to top/bottom

### DIFF
--- a/escher/src/selectable_table_view.cpp
+++ b/escher/src/selectable_table_view.cpp
@@ -60,11 +60,29 @@ void SelectableTableView::deselectTable() {
 }
 
 bool SelectableTableView::selectCellAtLocation(int i, int j) {
-  if (i < 0 || i >= dataSource()->numberOfColumns()) {
-    return false;
+  int nbrColumns = dataSource()->numberOfColumns();
+  int nbrRows    = dataSource()->numberOfRows();
+  if (i < 0) {
+    if (nbrColumns <= 2) {
+      return false;
+    }
+    i = nbrColumns-1;
+  } else if (i >= nbrColumns) {
+    if (nbrColumns <= 2) {
+      return false;
+    }
+    i = 0;
   }
-  if (j < 0 || j >= dataSource()->numberOfRows()) {
-    return false;
+  if (j < 0) {
+    if (nbrRows <= 2) {
+      return false;
+    }
+    j = nbrRows-1;
+  } else if (j >= nbrRows) {
+    if (nbrRows <= 2) {
+      return false;
+    }
+    j = 0;
   }
   unhighlightSelectedCell();
   int previousX = selectedColumn();


### PR DESCRIPTION
When you're at the top of a list, you can press [up] to go to the bottom instantly, and same with [down] to go to the top when at the bottom.
Similarly, works with columns with left/right.

This feature is only enabled when it's 2x2 or more because otherwise:
 - it may cause confusion
 - it would break the specific behaviour of submenus.

(I haven't tested it much, but so far so good... Please try it and report back :D)

Screenshot:
![On the math toolbox](http://i.imgur.com/1BF5pFx.gif)