### PR TITLE
[poincare] remove useless const qualifier on return type

### DIFF
--- a/poincare/include/poincare/symbol.h
+++ b/poincare/include/poincare/symbol.h
@@ -31,7 +31,7 @@ public:
   static SpecialSymbols matrixSymbol(char index);
   Symbol(char name);
   Type type() const override;
-  const char name() const;
+  char name() const;
   Expression * clone() const override;
   bool valueEquals(const Expression * e) const override;
   bool isMatrixSymbol() const;

--- a/poincare/src/symbol.cpp
+++ b/poincare/src/symbol.cpp
@@ -56,7 +56,7 @@ Expression::Type Symbol::type() const {
   return Expression::Type::Symbol;
 }
 
-const char Symbol::name() const {
+char Symbol::name() const {
   return m_name;
 }
 


### PR DESCRIPTION
This generated a lot of warnings in -Wextra: `'const' type qualifier on return type has no effect [-Wignored-qualifiers]`