### PR TITLE
Add shift activated text (Fix #22)

### DIFF
--- a/apps/Makefile
+++ b/apps/Makefile
@@ -13,7 +13,6 @@ include apps/code/Makefile
 #include apps/picview/Makefile
 
 app_objs += $(addprefix apps/,\
-  alpha_lock_view.o\
   apps_container.o\
   apps_window.o\
   battery_timer.o\
@@ -29,6 +28,7 @@ app_objs += $(addprefix apps/,\
   main.o\
   math_toolbox.o\
   node.o\
+  shift_alpha_lock_view.o\
   suspend_timer.o\
   title_bar_view.o\
   toolbox_node.o\

--- a/apps/apps_window.cpp
+++ b/apps/apps_window.cpp
@@ -31,7 +31,7 @@ void AppsWindow::refreshPreferences() {
 }
 
 bool AppsWindow::updateAlphaLock() {
-  return m_titleBarView.setAlphaLockStatus(Ion::Events::shiftAlphaStatus());
+  return m_titleBarView.setShiftAlphaLockStatus(Ion::Events::shiftAlphaStatus());
 }
 
 void AppsWindow::hideTitleBarView(bool hide) {

--- a/apps/i18n.cpp
+++ b/apps/i18n.cpp
@@ -316,12 +316,13 @@ constexpr static char leftIntegralFirstLegend[] = {'P', '(', 'X', Ion::Charset::
 constexpr static char finiteIntegralLegend[] = {Ion::Charset::LessEqual, 'X', Ion::Charset::LessEqual, 0};
 
 
-const char * universalMessages[241] {
+const char * universalMessages[242] {
   "",
   "Python",
   "PYTHON (BETA)",
   "alpha",
   "ALPHA",
+  "shift",
   "x",
   "y",
   "n",

--- a/apps/i18n.h
+++ b/apps/i18n.h
@@ -152,7 +152,7 @@ namespace I18n {
     ValueNotReachedBySequence,
     NColumn,
 
-  /* Statistics */
+    /* Statistics */
     StatsApp,
     StatsAppCapital,
     DataTab,
@@ -276,6 +276,7 @@ namespace I18n {
     CodeAppCapital,
     Alpha,
     CapitalAlpha,
+    Shift,
     X,
     Y,
     N,

--- a/apps/shift_alpha_lock_view.cpp
+++ b/apps/shift_alpha_lock_view.cpp
@@ -1,34 +1,34 @@
 #include "shift_alpha_lock_view.h"
 
-AlphaLockView::AlphaLockView() :
+ShiftAlphaLockView::ShiftAlphaLockView() :
   View(),
-  m_modifierView(KDText::FontSize::Small, I18n::Message::Default, 1.0f, 0.5f, KDColorWhite, Palette::YellowDark),
+  m_shiftAlphaView(KDText::FontSize::Small, I18n::Message::Default, 1.0f, 0.5f, KDColorWhite, Palette::YellowDark),
   m_status(Ion::Events::ShiftAlphaStatus::Default)
 {
 }
 
-void AlphaLockView::drawRect(KDContext * ctx, KDRect rect) const {
+void ShiftAlphaLockView::drawRect(KDContext * ctx, KDRect rect) const {
   ctx->fillRect(bounds(), Palette::YellowDark);
 }
 
-bool AlphaLockView::setStatus(Ion::Events::ShiftAlphaStatus status) {
+bool ShiftAlphaLockView::setStatus(Ion::Events::ShiftAlphaStatus status) {
   if (status != m_status) {
     m_status = status;
     switch (m_status) {
       case Ion::Events::ShiftAlphaStatus::Alpha:
       case Ion::Events::ShiftAlphaStatus::AlphaLock:
       case Ion::Events::ShiftAlphaStatus::AlphaLockShift:
-        m_modifierView.setMessage(I18n::Message::Alpha);
+        m_shiftAlphaView.setMessage(I18n::Message::Alpha);
         break;
       case Ion::Events::ShiftAlphaStatus::ShiftAlpha:
       case Ion::Events::ShiftAlphaStatus::ShiftAlphaLock:
-        m_modifierView.setMessage(I18n::Message::CapitalAlpha);
+        m_shiftAlphaView.setMessage(I18n::Message::CapitalAlpha);
         break;
       case Ion::Events::ShiftAlphaStatus::Shift:
-        m_modifierView.setMessage(I18n::Message::Shift);
+        m_shiftAlphaView.setMessage(I18n::Message::Shift);
         break;
       case Ion::Events::ShiftAlphaStatus::Default:
-        m_modifierView.setMessage(I18n::Message::Default);
+        m_shiftAlphaView.setMessage(I18n::Message::Default);
         break;
     }
     markRectAsDirty(bounds());
@@ -37,14 +37,14 @@ bool AlphaLockView::setStatus(Ion::Events::ShiftAlphaStatus status) {
   return false;
 }
 
-KDSize AlphaLockView::minimalSizeForOptimalDisplay() const {
+KDSize ShiftAlphaLockView::minimalSizeForOptimalDisplay() const {
   KDSize modifierSize = KDText::stringSize(I18n::translate(I18n::Message::Alpha), KDText::FontSize::Small);
   KDSize lockSize = m_lockView.minimalSizeForOptimalDisplay();
   KDCoordinate height = lockSize.height() > modifierSize.height() ? lockSize.height() : modifierSize.height();
   return KDSize(modifierSize.width() + lockSize.width() + k_lockRightMargin, height);
 }
 
-int AlphaLockView::numberOfSubviews() const {
+int ShiftAlphaLockView::numberOfSubviews() const {
   switch (m_status) {
     case Ion::Events::ShiftAlphaStatus::Alpha:
     case Ion::Events::ShiftAlphaStatus::Shift:
@@ -59,16 +59,16 @@ int AlphaLockView::numberOfSubviews() const {
   }
 }
 
-View * AlphaLockView::subviewAtIndex(int index) {
+View * ShiftAlphaLockView::subviewAtIndex(int index) {
   if (index == 0) {
-    return &m_modifierView;
+    return &m_shiftAlphaView;
   }
   return &m_lockView;
 }
 
-void AlphaLockView::layoutSubviews() {
+void ShiftAlphaLockView::layoutSubviews() {
   KDSize modifierSize = KDText::stringSize(I18n::translate(I18n::Message::Alpha), KDText::FontSize::Small);
-  m_modifierView.setFrame(KDRect(bounds().width() - modifierSize.width(), (bounds().height()- modifierSize.height())/2, modifierSize));
+  m_shiftAlphaView.setFrame(KDRect(bounds().width() - modifierSize.width(), (bounds().height()- modifierSize.height())/2, modifierSize));
 
   KDSize lockSize = m_lockView.minimalSizeForOptimalDisplay();
   m_lockView.setFrame(KDRect(bounds().width() - modifierSize.width() - lockSize.width() - k_lockRightMargin, (bounds().height()- lockSize.height())/2, lockSize));

--- a/apps/shift_alpha_lock_view.cpp
+++ b/apps/shift_alpha_lock_view.cpp
@@ -1,8 +1,8 @@
-#include "alpha_lock_view.h"
+#include "shift_alpha_lock_view.h"
 
 AlphaLockView::AlphaLockView() :
   View(),
-  m_alphaView(KDText::FontSize::Small, I18n::Message::Default, 1.0f, 0.5f, KDColorWhite, Palette::YellowDark),
+  m_modifierView(KDText::FontSize::Small, I18n::Message::Default, 1.0f, 0.5f, KDColorWhite, Palette::YellowDark),
   m_status(Ion::Events::ShiftAlphaStatus::Default)
 {
 }
@@ -14,18 +14,21 @@ void AlphaLockView::drawRect(KDContext * ctx, KDRect rect) const {
 bool AlphaLockView::setStatus(Ion::Events::ShiftAlphaStatus status) {
   if (status != m_status) {
     m_status = status;
-    switch (status) {
+    switch (m_status) {
       case Ion::Events::ShiftAlphaStatus::Alpha:
       case Ion::Events::ShiftAlphaStatus::AlphaLock:
       case Ion::Events::ShiftAlphaStatus::AlphaLockShift:
-        m_alphaView.setMessage(I18n::Message::Alpha);
+        m_modifierView.setMessage(I18n::Message::Alpha);
         break;
       case Ion::Events::ShiftAlphaStatus::ShiftAlpha:
       case Ion::Events::ShiftAlphaStatus::ShiftAlphaLock:
-        m_alphaView.setMessage(I18n::Message::CapitalAlpha);
+        m_modifierView.setMessage(I18n::Message::CapitalAlpha);
         break;
-      default:
-        m_alphaView.setMessage(I18n::Message::Default);
+      case Ion::Events::ShiftAlphaStatus::Shift:
+        m_modifierView.setMessage(I18n::Message::Shift);
+        break;
+      case Ion::Events::ShiftAlphaStatus::Default:
+        m_modifierView.setMessage(I18n::Message::Default);
         break;
     }
     markRectAsDirty(bounds());
@@ -35,37 +38,38 @@ bool AlphaLockView::setStatus(Ion::Events::ShiftAlphaStatus status) {
 }
 
 KDSize AlphaLockView::minimalSizeForOptimalDisplay() const {
-  KDSize alphaSize = KDText::stringSize(I18n::translate(I18n::Message::Alpha));
+  KDSize modifierSize = KDText::stringSize(I18n::translate(I18n::Message::Alpha), KDText::FontSize::Small);
   KDSize lockSize = m_lockView.minimalSizeForOptimalDisplay();
-  KDCoordinate height = lockSize.height() > alphaSize.height() ? lockSize.height() : alphaSize.height();
-  return KDSize(alphaSize.width() + lockSize.width() + k_lockRightMargin, height);
+  KDCoordinate height = lockSize.height() > modifierSize.height() ? lockSize.height() : modifierSize.height();
+  return KDSize(modifierSize.width() + lockSize.width() + k_lockRightMargin, height);
 }
 
 int AlphaLockView::numberOfSubviews() const {
   switch (m_status) {
     case Ion::Events::ShiftAlphaStatus::Alpha:
+    case Ion::Events::ShiftAlphaStatus::Shift:
     case Ion::Events::ShiftAlphaStatus::ShiftAlpha:
       return 1;
     case Ion::Events::ShiftAlphaStatus::AlphaLock:
     case Ion::Events::ShiftAlphaStatus::AlphaLockShift:
     case Ion::Events::ShiftAlphaStatus::ShiftAlphaLock:
       return 2;
-    default:
+    case Ion::Events::ShiftAlphaStatus::Default:
       return 0;
   }
 }
 
 View * AlphaLockView::subviewAtIndex(int index) {
   if (index == 0) {
-    return &m_alphaView;
+    return &m_modifierView;
   }
   return &m_lockView;
 }
 
 void AlphaLockView::layoutSubviews() {
-  KDSize alphaSize = KDText::stringSize(I18n::translate(I18n::Message::Alpha), KDText::FontSize::Small);
-  m_alphaView.setFrame(KDRect(bounds().width() - alphaSize.width(), (bounds().height()- alphaSize.height())/2, alphaSize));
+  KDSize modifierSize = KDText::stringSize(I18n::translate(I18n::Message::Alpha), KDText::FontSize::Small);
+  m_modifierView.setFrame(KDRect(bounds().width() - modifierSize.width(), (bounds().height()- modifierSize.height())/2, modifierSize));
 
   KDSize lockSize = m_lockView.minimalSizeForOptimalDisplay();
-  m_lockView.setFrame(KDRect(bounds().width() - alphaSize.width() - lockSize.width() - k_lockRightMargin, (bounds().height()- lockSize.height())/2, lockSize));
+  m_lockView.setFrame(KDRect(bounds().width() - modifierSize.width() - lockSize.width() - k_lockRightMargin, (bounds().height()- lockSize.height())/2, lockSize));
 }

--- a/apps/shift_alpha_lock_view.h
+++ b/apps/shift_alpha_lock_view.h
@@ -17,7 +17,7 @@ private:
   void layoutSubviews() override;
   View * subviewAtIndex(int index) override;
   LockView m_lockView;
-  MessageTextView m_alphaView;
+  MessageTextView m_modifierView;
   Ion::Events::ShiftAlphaStatus m_status;
 };
 

--- a/apps/shift_alpha_lock_view.h
+++ b/apps/shift_alpha_lock_view.h
@@ -1,13 +1,13 @@
-#ifndef APPS_ALPHA_LOCK_VIEW_H
-#define APPS_ALPHA_LOCK_VIEW_H
+#ifndef APPS_SHIFT_ALPHA_LOCK_VIEW_H
+#define APPS_SHIFT_ALPHA_LOCK_VIEW_H
 
 #include <escher.h>
 #include "lock_view.h"
 #include "i18n.h"
 
-class AlphaLockView : public View {
+class ShiftAlphaLockView : public View {
 public:
-  AlphaLockView();
+  ShiftAlphaLockView();
   void drawRect(KDContext * ctx, KDRect rect) const override;
   bool setStatus(Ion::Events::ShiftAlphaStatus status);
   KDSize minimalSizeForOptimalDisplay() const override;
@@ -17,7 +17,7 @@ private:
   void layoutSubviews() override;
   View * subviewAtIndex(int index) override;
   LockView m_lockView;
-  MessageTextView m_modifierView;
+  MessageTextView m_shiftAlphaView;
   Ion::Events::ShiftAlphaStatus m_status;
 };
 

--- a/apps/title_bar_view.cpp
+++ b/apps/title_bar_view.cpp
@@ -42,8 +42,8 @@ bool TitleBarView::setIsPlugged(bool isPlugged) {
   return m_batteryView.setIsPlugged(isPlugged);
 }
 
-bool TitleBarView::setAlphaLockStatus(Ion::Events::ShiftAlphaStatus status) {
-  return m_alphaLockView.setStatus(status);
+bool TitleBarView::setShiftAlphaLockStatus(Ion::Events::ShiftAlphaStatus status) {
+  return m_shiftAlphaLockView.setStatus(status);
 }
 
 int TitleBarView::numberOfSubviews() const {
@@ -61,7 +61,7 @@ View * TitleBarView::subviewAtIndex(int index) {
     return &m_examModeIconView;
   }
   if (index == 3) {
-    return &m_alphaLockView;
+    return &m_shiftAlphaLockView;
   }
   return &m_batteryView;
 }
@@ -81,8 +81,8 @@ void TitleBarView::layoutSubviews() {
   } else {
     m_examModeIconView.setFrame(KDRectZero);
   }
-  KDSize alphaLockSize = m_alphaLockView.minimalSizeForOptimalDisplay();
-  m_alphaLockView.setFrame(KDRect(bounds().width()-batterySize.width()-k_batteryRightMargin-k_alphaRightMargin-alphaLockSize.width(), (bounds().height()- alphaLockSize.height())/2, alphaLockSize));
+  KDSize shiftAlphaLockSize = m_shiftAlphaLockView.minimalSizeForOptimalDisplay();
+  m_shiftAlphaLockView.setFrame(KDRect(bounds().width()-batterySize.width()-k_batteryRightMargin-k_alphaRightMargin-shiftAlphaLockSize.width(), (bounds().height()- shiftAlphaLockSize.height())/2, shiftAlphaLockSize));
 }
 
 void TitleBarView::refreshPreferences() {

--- a/apps/title_bar_view.h
+++ b/apps/title_bar_view.h
@@ -3,7 +3,7 @@
 
 #include <escher.h>
 #include "battery_view.h"
-#include "alpha_lock_view.h"
+#include "shift_alpha_lock_view.h"
 #include "i18n.h"
 
 class TitleBarView : public View {

--- a/apps/title_bar_view.h
+++ b/apps/title_bar_view.h
@@ -29,7 +29,7 @@ private:
   View * subviewAtIndex(int index) override;
   MessageTextView m_titleView;
   BatteryView m_batteryView;
-  AlphaLockView m_alphaLockView;
+  ShiftAlphaLockView m_alphaLockView;
   BufferTextView m_preferenceView;
   ImageView m_examModeIconView;
 };

--- a/apps/title_bar_view.h
+++ b/apps/title_bar_view.h
@@ -15,7 +15,7 @@ public:
   bool setChargeState(Ion::Battery::Charge chargeState);
   bool setIsCharging(bool isCharging);
   bool setIsPlugged(bool isPlugged);
-  bool setAlphaLockStatus(Ion::Events::ShiftAlphaStatus status);
+  bool setShiftAlphaLockStatus(Ion::Events::ShiftAlphaStatus status);
   void refreshPreferences();
 private:
   constexpr static KDCoordinate k_batteryRightMargin = 5;
@@ -29,7 +29,7 @@ private:
   View * subviewAtIndex(int index) override;
   MessageTextView m_titleView;
   BatteryView m_batteryView;
-  ShiftAlphaLockView m_alphaLockView;
+  ShiftAlphaLockView m_shiftAlphaLockView;
   BufferTextView m_preferenceView;
   ImageView m_examModeIconView;
 };


### PR DESCRIPTION
This adds the text 'shift' when the shift key is activated. No functionality changes were made.