### PR TITLE
More keyboard shortcuts for the emscripten platform.

### DIFF
--- a/ion/src/emscripten/events_keyboard.cpp
+++ b/ion/src/emscripten/events_keyboard.cpp
@@ -47,10 +47,10 @@ static constexpr Event sEventForASCIICharAbove32[95] = {
 
 Event getEvent(int * timeout) {
   Ion::Display::Emscripten::refresh();
-  if (sEvent != Ion::Events::None) {
-    Ion::Events::Event event = sEvent;
+  if (sEvent != None) {
+    Event event = sEvent;
     updateModifiersFromEvent(event);
-    sEvent = Ion::Events::None;
+    sEvent = None;
     return event;
   }
   SDL_Event event;
@@ -58,26 +58,26 @@ Event getEvent(int * timeout) {
     if (event.type == SDL_KEYDOWN) {
       switch(event.key.keysym.sym) {
         case SDLK_UP:
-          return Ion::Events::Up;
+          return Up;
         case SDLK_DOWN:
-          return Ion::Events::Down;
+          return Down;
         case SDLK_LEFT:
-          return Ion::Events::Left;
+          return Left;
         case SDLK_RIGHT:
-          return Ion::Events::Right;
+          return Right;
         case SDLK_RETURN:
-          return Ion::Events::EXE;
+          return EXE;
         case SDLK_ESCAPE:
-          return Ion::Events::Back;
+          return Back;
         case SDLK_BACKSPACE:
-          return Ion::Events::Backspace;
+          return Backspace;
       }
       if (event.key.keysym.unicode >= 32 && event.key.keysym.unicode < 127) {
         return sEventForASCIICharAbove32[event.key.keysym.unicode-32];
       }
     }
   }
-  return Ion::Events::None;
+  return None;
 }
 
 }

--- a/ion/src/emscripten/events_keyboard.cpp
+++ b/ion/src/emscripten/events_keyboard.cpp
@@ -56,6 +56,66 @@ Event getEvent(int * timeout) {
   SDL_Event event;
   if (SDL_PollEvent(&event)) {
     if (event.type == SDL_KEYDOWN) {
+      if (event.key.keysym.mod & KMOD_CTRL) {
+        switch (event.key.keysym.sym) {
+          case SDLK_BACKSPACE:
+            return Clear;
+          case SDLK_x:
+            return Cut;
+          case SDLK_c:
+            return Copy;
+          case SDLK_v:
+            return Paste;
+        }
+      }
+      if (event.key.keysym.mod & KMOD_ALT) {
+        if (event.key.keysym.mod & KMOD_SHIFT) {
+          switch (event.key.keysym.sym) {
+            case SDLK_s:
+              return Arcsine;
+            case SDLK_c:
+              return Arccosine;
+            case SDLK_t:
+              return Arctangent;
+          }
+        }
+        switch (event.key.keysym.sym) {
+          case SDLK_ESCAPE:
+            return Home;
+          case SDLK_RETURN:
+            return OK;
+          case SDLK_v:
+            return Var;
+          case SDLK_BACKSPACE:
+            return Clear;
+          case SDLK_x:
+            return Exp;
+          case SDLK_n:
+            return Ln;
+          case SDLK_l:
+            return Log;
+          case SDLK_i:
+            return Imaginary;
+          case SDLK_EQUALS:
+            return Sto;
+          case SDLK_s:
+            return Sine;
+          case SDLK_c:
+            return Cosine;
+          case SDLK_t:
+            return Tangent;
+          case SDLK_p:
+            return Pi;
+          case SDLK_r:
+            return Sqrt;
+          case SDLK_2:
+            return Square;
+          case SDLK_e:
+            return EE;
+          case SDLK_a:
+            return Ans;
+        }
+      }
       switch(event.key.keysym.sym) {
         case SDLK_UP:
           return Up;
@@ -69,6 +129,8 @@ Event getEvent(int * timeout) {
           return EXE;
         case SDLK_ESCAPE:
           return Back;
+        case SDLK_TAB:
+          return Toolbox;
         case SDLK_BACKSPACE:
           return Backspace;
       }

--- a/ion/src/emscripten/events_keyboard.cpp
+++ b/ion/src/emscripten/events_keyboard.cpp
@@ -5,7 +5,7 @@ extern "C" {
 #include <SDL/SDL.h>
 }
 
-Ion::Events::Event sEvent = Ion::Events::None;
+static Ion::Events::Event sEvent = Ion::Events::None;
 
 void IonEventsEmscriptenPushEvent(int eventNumber) {
   sEvent = Ion::Events::Event((Ion::Keyboard::Key)eventNumber, Ion::Events::isShiftActive(), Ion::Events::isAlphaActive());


### PR DESCRIPTION
This allows typing &#x1D07;, &pi;, imaginary i, and newline from the keyboard on the online simulator.