### PR TITLE
Removed the automatic insertion of 'ans' when pressing '-'.

### DIFF
--- a/apps/calculation/text_field.cpp
+++ b/apps/calculation/text_field.cpp
@@ -20,7 +20,6 @@ bool TextField::handleEvent(Ion::Events::Event event) {
   if (textLength() == 0 &&
       (event == Ion::Events::Multiplication ||
        event == Ion::Events::Plus ||
-       event == Ion::Events::Minus ||
        event == Ion::Events::Power ||
        event == Ion::Events::Square ||
        event == Ion::Events::Division)) {


### PR DESCRIPTION
My girlfriend was using the calculator and was becoming confused when it kept entering `ans-` when she pressed`-`. She was trying to do basic calculations with negative numbers and was getting held up.

Perhaps in future this could be a modal feature but for now I suggest removing the addition of `ans` when `-` is the first character pressed.

