### PR TITLE
[various apps] StringLayout: fix buffer overflow and use auto size

### DIFF
--- a/apps/sequence/graph/term_sum_controller.cpp
+++ b/apps/sequence/graph/term_sum_controller.cpp
@@ -197,10 +197,10 @@ void TermSumController::LegendView::setSumSubscript(float start) {
     delete m_sumLayout;
     m_sumLayout = nullptr;
   }
-  const char sigma[3] = {' ',Ion::Charset::CapitalSigma, 0};
+  const char sigma[] = {' ',Ion::Charset::CapitalSigma};
   char buffer[PrintFloat::bufferSizeForFloatsWithPrecision(Constant::LargeNumberOfSignificantDigits)];
   Complex<float>::convertFloatToText(start, buffer, PrintFloat::bufferSizeForFloatsWithPrecision(Constant::LargeNumberOfSignificantDigits), Constant::LargeNumberOfSignificantDigits, Expression::FloatDisplayMode::Decimal);
-  m_sumLayout = new CondensedSumLayout(new StringLayout(sigma, 2), new StringLayout(buffer, strlen(buffer), KDText::FontSize::Small), nullptr);
+  m_sumLayout = new CondensedSumLayout(new StringLayout(sigma, sizeof(sigma)), new StringLayout(buffer, strlen(buffer), KDText::FontSize::Small), nullptr);
  m_sum.setExpression(m_sumLayout);
  m_sum.setAlignment(0.0f, 0.5f);
 }
@@ -210,12 +210,12 @@ void TermSumController::LegendView::setSumSuperscript(float start, float end) {
     delete m_sumLayout;
     m_sumLayout = nullptr;
   }
-  const char sigma[3] = {' ', Ion::Charset::CapitalSigma, 0};
+  const char sigma[] = {' ', Ion::Charset::CapitalSigma};
   char bufferStart[PrintFloat::bufferSizeForFloatsWithPrecision(Constant::LargeNumberOfSignificantDigits)];
   Complex<float>::convertFloatToText(start, bufferStart, PrintFloat::bufferSizeForFloatsWithPrecision(Constant::LargeNumberOfSignificantDigits), Constant::LargeNumberOfSignificantDigits, Expression::FloatDisplayMode::Decimal);
   char bufferEnd[PrintFloat::bufferSizeForFloatsWithPrecision(Constant::LargeNumberOfSignificantDigits)];
   Complex<float>::convertFloatToText(end, bufferEnd, PrintFloat::bufferSizeForFloatsWithPrecision(Constant::LargeNumberOfSignificantDigits), Constant::LargeNumberOfSignificantDigits, Expression::FloatDisplayMode::Decimal);
-  m_sumLayout = new CondensedSumLayout(new StringLayout(sigma, 2), new StringLayout(bufferStart, strlen(bufferStart), KDText::FontSize::Small), new StringLayout(bufferEnd, strlen(bufferEnd), KDText::FontSize::Small));
+  m_sumLayout = new CondensedSumLayout(new StringLayout(sigma, sizeof(sigma)), new StringLayout(bufferStart, strlen(bufferStart), KDText::FontSize::Small), new StringLayout(bufferEnd, strlen(bufferEnd), KDText::FontSize::Small));
   m_sum.setExpression(m_sumLayout);
   m_sum.setAlignment(0.0f, 0.5f);
 }

--- a/apps/settings/main_controller.cpp
+++ b/apps/settings/main_controller.cpp
@@ -151,12 +151,12 @@ void MainController::willDisplayCellForIndex(HighlightCell * cell, int index) {
       m_complexFormatLayout = nullptr;
     }
     if (Preferences::sharedPreferences()->complexFormat() == Expression::ComplexFormat::Cartesian) {
-      const char text[6] = {'a','+', Ion::Charset::IComplex, 'b', ' ', 0};
-      m_complexFormatLayout = new StringLayout(text, 6, KDText::FontSize::Small);
+      const char text[] = {'a','+', Ion::Charset::IComplex, 'b', ' '};
+      m_complexFormatLayout = new StringLayout(text, sizeof(text), KDText::FontSize::Small);
     } else {
-      const char base[3] = {'r', Ion::Charset::Exponential, 0};
-      const char superscrit[4] = {Ion::Charset::IComplex, Ion::Charset::SmallTheta, ' ', 0};
-      m_complexFormatLayout = new BaselineRelativeLayout(new StringLayout(base, 4, KDText::FontSize::Small), new StringLayout(superscrit, 3, KDText::FontSize::Small), BaselineRelativeLayout::Type::Superscript);
+      const char base[] = {'r', Ion::Charset::Exponential};
+      const char superscript[] = {Ion::Charset::IComplex, Ion::Charset::SmallTheta, ' '};
+      m_complexFormatLayout = new BaselineRelativeLayout(new StringLayout(base, sizeof(base), KDText::FontSize::Small), new StringLayout(superscript, sizeof(superscript), KDText::FontSize::Small), BaselineRelativeLayout::Type::Superscript);
     }
     MessageTableCellWithChevronAndExpression * myExpCell = (MessageTableCellWithChevronAndExpression *)cell;
     myExpCell->setExpression(m_complexFormatLayout);

--- a/apps/settings/sub_controller.cpp
+++ b/apps/settings/sub_controller.cpp
@@ -20,10 +20,10 @@ SubController::SubController(Responder * parentResponder) :
     m_cells[i].setAccessoryFontSize(KDText::FontSize::Small);
     m_cells[i].setAccessoryTextColor(Palette::GreyDark);
   }
-  const char text[] = {'a','+', Ion::Charset::IComplex, 'b', ' ', 0};
-  m_complexFormatLayout[0] = new StringLayout(text, 6);
-  const char base[] = {'r', Ion::Charset::Exponential, 0};
-  const char superscript[] = {Ion::Charset::IComplex, Ion::Charset::SmallTheta, ' ', 0};
+  const char text[] = {'a','+', Ion::Charset::IComplex, 'b', ' '};
+  m_complexFormatLayout[0] = new StringLayout(text, sizeof(text));
+  const char base[] = {'r', Ion::Charset::Exponential};
+  const char superscript[] = {Ion::Charset::IComplex, Ion::Charset::SmallTheta, ' '};
   m_complexFormatLayout[1] = new BaselineRelativeLayout(new StringLayout(base, sizeof(base)), new StringLayout(superscript, sizeof(superscript)), BaselineRelativeLayout::Type::Superscript);
   for (int i = 0; i < 2; i++) {
     m_complexFormatCells[i].setExpression(m_complexFormatLayout[i]);

--- a/poincare/src/symbol.cpp
+++ b/poincare/src/symbol.cpp
@@ -64,7 +64,7 @@ ExpressionLayout * Symbol::privateCreateLayout(FloatDisplayMode floatDisplayMode
   assert(floatDisplayMode != FloatDisplayMode::Default);
   assert(complexFormat != ComplexFormat::Default);
   if (m_name == SpecialSymbols::Ans) {
-    return new StringLayout("ans", 4);
+    return new StringLayout("ans", 3);
   }
   if (m_name == SpecialSymbols::un) {
     return new BaselineRelativeLayout(new StringLayout("u", 1), new StringLayout("n",1, KDText::FontSize::Small), BaselineRelativeLayout::Type::Subscript);
@@ -85,9 +85,8 @@ ExpressionLayout * Symbol::privateCreateLayout(FloatDisplayMode floatDisplayMode
     return new BaselineRelativeLayout(new StringLayout("w", 1), new StringLayout("n+1",3, KDText::FontSize::Small), BaselineRelativeLayout::Type::Subscript);
   }
   if (isMatrixSymbol()) {
-    char mi[3] = "M0";
-    mi[1] = m_name-(char)SpecialSymbols::M0+'0';
-    return new StringLayout(mi, 2);
+    const char mi[] = { 'M', (char)(m_name-(char)SpecialSymbols::M0+'0') };
+    return new StringLayout(mi, sizeof(mi));
   }
   return new StringLayout(&m_name, 1);
 }


### PR DESCRIPTION
Following a comment of mine [here](https://github.com/numworks/epsilon/pull/65/files#r136870515)...

* Another buffer overflow was happening when changing the complex format in the settings (instant crash with ASan)
* All const char arrays manually ending with a nul char were trimmed of it considering StringLayout allocs one already.
* Use automatic compile-time array-size when possible, it avoids mistakes.

I was tempted to make a macro like `#define AutoStringLayout(charArray) new StringLayout(charArray, sizeof(charArray))` but oh well :)