### PR TITLE
[poincare] Implement square root of negative real

### DIFF
--- a/poincare/src/square_root.cpp
+++ b/poincare/src/square_root.cpp
@@ -34,7 +34,7 @@ ExpressionLayout * SquareRoot::privateCreateLayout(FloatDisplayMode floatDisplay
 
 template<typename T>
 Complex<T> SquareRoot::templatedComputeComplex(const Complex<T> c) const {
-  if (c.b() == 0) {
+  if (c.a() >= 0 && c.b() == 0) {
     return Complex<T>::Float(std::sqrt(c.a()));
   }
   return Power::compute(c, Complex<T>::Float(0.5));


### PR DESCRIPTION
The current implementation of square root calls 'std::sqrt' if the
parameter is real, otherwise it uses calls Poincare's 'Power::compute'
with an exponent of 0.5.  Change it to only call 'std::sqrt' if the
parameter is a non-negative real number.