### PR TITLE
[python] Fix type of n_args parameter of mp_builtin_open()

### DIFF
--- a/python/port/port.c
+++ b/python/port/port.c
@@ -47,7 +47,7 @@ mp_import_stat_t mp_import_stat(const char *path) {
     return MP_IMPORT_STAT_NO_EXIST;
 }
 
-mp_obj_t mp_builtin_open(uint n_args, const mp_obj_t *args, mp_map_t *kwargs) {
+mp_obj_t mp_builtin_open(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(mp_builtin_open_obj, 1, mp_builtin_open);


### PR DESCRIPTION
The n_args parameter of mp_builtin_open() has type size_t in
"python/src/py/builtin.h", and type uint in "python/port/port.c".
Change it to size_t.