### PR TITLE
Improve the app_flash command

### DIFF
--- a/build/platform.device.mak
+++ b/build/platform.device.mak
@@ -12,4 +12,9 @@ EXE = elf
 
 .PHONY: %_flash
 %_flash: %.bin
-	dfu-util -i 0 -a 0 -s 0x08000000:leave -D $<
+	@echo "DFU     $@"
+	@echo "INFO    About to flash your device. Please plug your device to your computer"
+	@echo "        using an USB cable and press the RESET button the back of your device."
+	@until dfu-util -l | grep "Internal Flash" &> /dev/null; do sleep 1;done
+	@echo "DFU     $@"
+	@dfu-util -i 0 -a 0 -s 0x08000000:leave -D $<


### PR DESCRIPTION
We now display a small inline tutorial, and wait for a device to be
connected.

Fix #83 