### PR TITLE
Makefile: Use POSIX shell redirection syntax for app_flash target

### DIFF
--- a/build/platform.device.mak
+++ b/build/platform.device.mak
@@ -15,6 +15,6 @@ EXE = elf
 	@echo "DFU     $@"
 	@echo "INFO    About to flash your device. Please plug your device to your computer"
 	@echo "        using an USB cable and press the RESET button the back of your device."
-	@until dfu-util -l | grep "Internal Flash" &> /dev/null; do sleep 1;done
+	@until dfu-util -l | grep "Internal Flash" > /dev/null 2>&1; do sleep 1;done
 	@echo "DFU     $@"
 	@dfu-util -i 0 -a 0 -s 0x08000000:leave -D $<


### PR DESCRIPTION
The recipe for the 'app_flash' target uses an 'until' loop to wait for
the DFU device to be connected.  The command uses &> to redirect both
standard output and standard error output to a file (/dev/null).  This
works for shells such as Bash and Z Shell, but not dash or Korn shell.
Replace it with a combination of > and 2>&1 for portability.