### PR TITLE
shift alpha lock view: fix gcc warning about a missing return in numberOfSubviews

### DIFF
--- a/apps/shift_alpha_lock_view.cpp
+++ b/apps/shift_alpha_lock_view.cpp
@@ -57,6 +57,7 @@ int ShiftAlphaLockView::numberOfSubviews() const {
     case Ion::Events::ShiftAlphaStatus::Default:
       return 0;
   }
+  return 0;
 }
 
 View * ShiftAlphaLockView::subviewAtIndex(int index) {


### PR DESCRIPTION
ARM GCC 6.3 was complaining about it, for some reason.