### PR TITLE
Fix #115 by fixing the math.h and cmath includes.

### DIFF
--- a/apps/calculation/calculation.cpp
+++ b/apps/calculation/calculation.cpp
@@ -1,6 +1,6 @@
 #include "calculation.h"
 #include <string.h>
-#include <math.h>
+#include <cmath>
 using namespace Poincare;
 
 namespace Calculation {

--- a/apps/graph/graph/graph_controller.cpp
+++ b/apps/graph/graph/graph_controller.cpp
@@ -69,7 +69,7 @@ void GraphController::initCursorParameters() {
   do {
     CartesianFunction * firstFunction = functionStore()->activeFunctionAtIndex(functionIndex++);
     y = firstFunction->evaluateAtAbscissa(x, myApp->localContext());
-  } while (isnan(y) && functionIndex < functionStore()->numberOfActiveFunctions());
+  } while (std::isnan(y) && functionIndex < functionStore()->numberOfActiveFunctions());
   m_cursor->moveTo(x, y);
   interactiveCurveViewRange()->panToMakePointVisible(x, y, k_cursorTopMarginRatio, k_cursorRightMarginRatio, k_cursorBottomMarginRatio, k_cursorLeftMarginRatio);
 }

--- a/apps/probability/calculation/calculation.cpp
+++ b/apps/probability/calculation/calculation.cpp
@@ -1,6 +1,6 @@
 #include "calculation.h"
 #include <assert.h>
-#include <math.h>
+#include <cmath>
 
 namespace Probability {
 

--- a/apps/probability/calculation_controller.cpp
+++ b/apps/probability/calculation_controller.cpp
@@ -219,7 +219,7 @@ bool CalculationController::textFieldDidFinishEditing(TextField * textField, con
   App * probaApp = (App *)app();
   Context * globalContext = probaApp->container()->globalContext();
   double floatBody = Expression::approximate<double>(text, *globalContext);
-  if (isnan(floatBody) || isinf(floatBody)) {
+  if (std::isnan(floatBody) || std::isinf(floatBody)) {
     app()->displayWarning(I18n::Message::UndefinedValue);
     return false;
   }

--- a/apps/probability/law/binomial_law.cpp
+++ b/apps/probability/law/binomial_law.cpp
@@ -61,7 +61,7 @@ float BinomialLaw::yMin() {
 float BinomialLaw::yMax() {
   int maxAbscissa = m_parameter2 < 1.0f ? (m_parameter1+1)*m_parameter2 : m_parameter1;
   float result = evaluateAtAbscissa(maxAbscissa);
-  if (result <= 0.0f || isnan(result)) {
+  if (result <= 0.0f || std::isnan(result)) {
     result = 1.0f;
   }
   return result*(1.0f+ k_displayTopMarginRatio);

--- a/apps/probability/law/exponential_law.cpp
+++ b/apps/probability/law/exponential_law.cpp
@@ -53,7 +53,7 @@ float ExponentialLaw::yMin() {
 
 float ExponentialLaw::yMax() {
   float result = m_parameter1;
-  if (result <= 0.0f || isnan(result)) {
+  if (result <= 0.0f || std::isnan(result)) {
     result = 1.0f;
   }
   if (result <= 0.0f) {

--- a/apps/probability/law/law.cpp
+++ b/apps/probability/law/law.cpp
@@ -76,7 +76,7 @@ double Law::cumulativeDistributiveInverseForProbability(double * probability) {
     return INFINITY;
   }
   *probability = p;
-  if (isnan(*probability)) {
+  if (std::isnan(*probability)) {
     return NAN;
   }
   return k-1.0f;
@@ -103,7 +103,7 @@ double Law::rightIntegralInverseForProbability(double * probability) {
     return INFINITY;
   }
   *probability = 1.0 - (p - evaluateAtDiscreteAbscissa(k-1));
-  if (isnan(*probability)) {
+  if (std::isnan(*probability)) {
     return NAN;
   }
   return k-1.0;

--- a/apps/probability/law/normal_law.cpp
+++ b/apps/probability/law/normal_law.cpp
@@ -62,7 +62,7 @@ float NormalLaw::yMin() {
 float NormalLaw::yMax() {
   float maxAbscissa = m_parameter1;
   float result = evaluateAtAbscissa(maxAbscissa);
-  if (isnan(result) || result <= 0.0f) {
+  if (std::isnan(result) || result <= 0.0f) {
     result = 1.0f;
   }
   return result*(1.0f+ k_displayTopMarginRatio);

--- a/apps/regression/go_to_parameter_controller.cpp
+++ b/apps/regression/go_to_parameter_controller.cpp
@@ -51,7 +51,7 @@ bool GoToParameterController::setParameterAtIndex(int parameterIndex, double f) 
     app()->displayWarning(I18n::Message::ForbiddenValue);
     return false;
   }
-  if (isnan(x)) {
+  if (std::isnan(x)) {
     if (m_store->slope() < DBL_EPSILON && f == m_store->yIntercept()) {
       m_graphController->selectRegressionCurve();
       m_cursor->moveTo(m_cursor->x(), f);

--- a/apps/regression/graph_controller.cpp
+++ b/apps/regression/graph_controller.cpp
@@ -24,7 +24,7 @@ ViewController * GraphController::initialisationParameterController() {
 }
 
 bool GraphController::isEmpty() const {
-  if (m_store->numberOfPairs() < 2 || isinf(m_store->slope()) || isnan(m_store->slope())) {
+  if (m_store->numberOfPairs() < 2 || std::isinf(m_store->slope()) || std::isnan(m_store->slope())) {
     return true;
   }
   return false;

--- a/apps/sequence/graph/curve_view_range.cpp
+++ b/apps/sequence/graph/curve_view_range.cpp
@@ -19,7 +19,7 @@ void CurveViewRange::roundAbscissa() {
   float xMax = m_xMax;
   float newXMin = clipped(std::round((xMin+xMax)/2) - (float)Ion::Display::Width/2.0f, false);
   float newXMax = clipped(std::round((xMin+xMax)/2) + (float)Ion::Display::Width/2.0f-1.0f, true);
-  if (isnan(newXMin) || isnan(newXMax)) {
+  if (std::isnan(newXMin) || std::isnan(newXMax)) {
     return;
   }
   m_xMin = newXMin;
@@ -41,7 +41,7 @@ void CurveViewRange::normalize() {
   float yMax = m_yMax;
   float newXMin = clipped((xMin+xMax)/2 - 5.3f, false);
   float newXMax = clipped((xMin+xMax)/2 + 5.3f, true);
-  if (!isnan(newXMin) && !isnan(newXMax)) {
+  if (!std::isnan(newXMin) && !std::isnan(newXMax)) {
     m_xMin = newXMin;
     m_xMax = newXMax;
     m_xGridUnit = computeGridUnit(Axis::X, m_xMin, m_xMax);
@@ -53,7 +53,7 @@ void CurveViewRange::normalize() {
   m_yAuto = false;
   float newYMin = clipped((yMin+yMax)/2 - 3.1f, false);
   float newYMax = clipped((yMin+yMax)/2 + 3.1f, true);
-  if (!isnan(newYMin) && !isnan(newYMax)) {
+  if (!std::isnan(newYMin) && !std::isnan(newYMax)) {
     m_yMin = newYMin;
     m_yMax = newYMax;
     m_yGridUnit = computeGridUnit(Axis::Y, m_yMin, m_yMax);

--- a/apps/sequence/graph/graph_controller.cpp
+++ b/apps/sequence/graph/graph_controller.cpp
@@ -78,7 +78,7 @@ void GraphController::initCursorParameters() {
   do {
     Sequence * firstFunction = m_sequenceStore->activeFunctionAtIndex(functionIndex++);
     y = firstFunction->evaluateAtAbscissa(x, myApp->localContext());
-  } while (isnan(y) && functionIndex < m_sequenceStore->numberOfActiveFunctions());
+  } while (std::isnan(y) && functionIndex < m_sequenceStore->numberOfActiveFunctions());
   m_cursor->moveTo(x, y);
   m_graphRange->panToMakePointVisible(x, y, k_cursorTopMarginRatio, k_cursorRightMarginRatio, k_cursorBottomMarginRatio, k_cursorLeftMarginRatio);
 }

--- a/apps/sequence/graph/graph_view.cpp
+++ b/apps/sequence/graph/graph_view.cpp
@@ -30,7 +30,7 @@ void GraphView::drawRect(KDContext * ctx, KDRect rect) const {
     int step = std::ceil(windowRange/resolution());
     for (int x = rectXMin; x < rectXMax; x += step) {
       float y = evaluateModelWithParameter(s, x);
-      if (isnan(y)) {
+      if (std::isnan(y)) {
         continue;
       }
       drawDot(ctx, rect, x, y, s->color());

--- a/apps/sequence/local_context.cpp
+++ b/apps/sequence/local_context.cpp
@@ -1,5 +1,5 @@
 #include "local_context.h"
-#include <math.h>
+#include <cmath>
 
 using namespace Poincare;
 

--- a/apps/shared/curve_view.cpp
+++ b/apps/shared/curve_view.cpp
@@ -314,7 +314,7 @@ void CurveView::drawCurve(KDContext * ctx, KDRect rect, Model * curve, KDColor c
       return;
     }
     float y = evaluateModelWithParameter(curve, x);
-    if (isnan(y)|| isinf(y)) {
+    if (std::isnan(y)|| std::isinf(y)) {
       continue;
     }
     float pxf = floatToPixel(Axis::Horizontal, x);
@@ -327,7 +327,7 @@ void CurveView::drawCurve(KDContext * ctx, KDRect rect, Model * curve, KDColor c
       ctx->fillRect(colorRect, color);
     }
     stampAtLocation(ctx, rect, pxf, pyf, color);
-    if (x <= rectMin || isnan(evaluateModelWithParameter(curve, x-xStep))) {
+    if (x <= rectMin || std::isnan(evaluateModelWithParameter(curve, x-xStep))) {
       continue;
     }
     if (continuously) {
@@ -358,7 +358,7 @@ void CurveView::drawHistogram(KDContext * ctx, KDRect rect, Model * model, float
     }
     float centerX = fillBar ? x+barWidth/2.0f : x;
     float y = evaluateModelWithParameter(model, centerX);
-    if (isnan(y)) {
+    if (std::isnan(y)) {
       continue;
     }
     KDCoordinate pxf = std::round(floatToPixel(Axis::Horizontal, x));
@@ -396,7 +396,7 @@ KDSize CurveView::cursorSize() {
 void CurveView::jointDots(KDContext * ctx, KDRect rect, Model * curve, float x, float y, float u, float v, KDColor color, int maxNumberOfRecursion) const {
   float pyf = floatToPixel(Axis::Vertical, y);
   float pvf = floatToPixel(Axis::Vertical, v);
-  if (isnan(pyf) || isnan(pvf)) {
+  if (std::isnan(pyf) || std::isnan(pvf)) {
     return;
   }
   // No need to draw if both dots are outside visible area
@@ -404,10 +404,10 @@ void CurveView::jointDots(KDContext * ctx, KDRect rect, Model * curve, float x, 
     return;
   }
   // If one of the dot is infinite, we cap it with a dot outside area
-  if (isinf(pyf)) {
+  if (std::isinf(pyf)) {
     pyf = pyf > 0 ? pixelLength(Axis::Vertical)+stampSize : -stampSize;
   }
-  if (isinf(pvf)) {
+  if (std::isinf(pvf)) {
     pvf = pvf > 0 ? pixelLength(Axis::Vertical)+stampSize : -stampSize;
   }
   if (pyf - (float)circleDiameter/2.0f < pvf && pvf < pyf + (float)circleDiameter/2.0f) {
@@ -422,7 +422,7 @@ void CurveView::jointDots(KDContext * ctx, KDRect rect, Model * curve, float x, 
      * can draw a 'straight' line between the two */
     float pxf = floatToPixel(Axis::Horizontal, x);
     float puf = floatToPixel(Axis::Horizontal, u);
-    if (isnan(pxf) || isnan(puf)) {
+    if (std::isnan(pxf) || std::isnan(puf)) {
       return;
     }
     straightJoinDots(ctx, rect, pxf, pyf, puf, pvf, color);
@@ -484,8 +484,8 @@ void CurveView::layoutSubviews() {
       KDCoordinate bannerHeight = m_bannerView != nullptr ? m_bannerView->minimalSizeForOptimalDisplay().height() : 0;
       cursorFrame = KDRect(xCursorPixelPosition - cursorSize().width()/2, 0, cursorSize().width(),bounds().height()-bannerHeight);
     }
-    if (!m_mainViewSelected || isnan(m_curveViewCursor->x()) || isnan(m_curveViewCursor->y())
-        || isinf(m_curveViewCursor->x()) || isinf(m_curveViewCursor->y())) {
+    if (!m_mainViewSelected || std::isnan(m_curveViewCursor->x()) || std::isnan(m_curveViewCursor->y())
+        || std::isinf(m_curveViewCursor->x()) || std::isinf(m_curveViewCursor->y())) {
       cursorFrame = KDRectZero;
     }
     m_cursorView->setFrame(cursorFrame);

--- a/apps/shared/curve_view.h
+++ b/apps/shared/curve_view.h
@@ -3,7 +3,7 @@
 
 #include <escher.h>
 #include <poincare.h>
-#include <math.h>
+#include <cmath>
 #include "curve_view_range.h"
 #include "curve_view_cursor.h"
 #include "banner_view.h"

--- a/apps/shared/curve_view_cursor.cpp
+++ b/apps/shared/curve_view_cursor.cpp
@@ -1,5 +1,5 @@
 #include "curve_view_cursor.h"
-#include <math.h>
+#include <cmath>
 
 namespace Shared {
 

--- a/apps/shared/editable_cell_table_view_controller.cpp
+++ b/apps/shared/editable_cell_table_view_controller.cpp
@@ -24,7 +24,7 @@ bool EditableCellTableViewController::textFieldDidFinishEditing(TextField * text
   AppsContainer * appsContainer = ((TextFieldDelegateApp *)app())->container();
   Context * globalContext = appsContainer->globalContext();
   double floatBody = Expression::approximate<double>(text, *globalContext);
-  if (isnan(floatBody) || isinf(floatBody)) {
+  if (std::isnan(floatBody) || std::isinf(floatBody)) {
     app()->displayWarning(I18n::Message::UndefinedValue);
     return false;
   }

--- a/apps/shared/float_pair_store.cpp
+++ b/apps/shared/float_pair_store.cpp
@@ -1,5 +1,5 @@
 #include "float_pair_store.h"
-#include <math.h>
+#include <cmath>
 #include <assert.h>
 #include <stddef.h>
 #include <ion.h>

--- a/apps/shared/float_parameter_controller.cpp
+++ b/apps/shared/float_parameter_controller.cpp
@@ -119,7 +119,7 @@ bool FloatParameterController::textFieldDidFinishEditing(TextField * textField, 
   AppsContainer * appsContainer = ((TextFieldDelegateApp *)app())->container();
   Context * globalContext = appsContainer->globalContext();
   double floatBody = Expression::approximate<double>(text, *globalContext);
-  if (isnan(floatBody) || isinf(floatBody)) {
+  if (std::isnan(floatBody) || std::isinf(floatBody)) {
     app()->displayWarning(I18n::Message::UndefinedValue);
     return false;
   }

--- a/apps/shared/function.cpp
+++ b/apps/shared/function.cpp
@@ -1,6 +1,6 @@
 #include "function.h"
 #include <string.h>
-#include <math.h>
+#include <cmath>
 #include <assert.h>
 
 using namespace Poincare;

--- a/apps/shared/function_go_to_parameter_controller.cpp
+++ b/apps/shared/function_go_to_parameter_controller.cpp
@@ -28,7 +28,7 @@ bool FunctionGoToParameterController::setParameterAtIndex(int parameterIndex, do
     app()->displayWarning(I18n::Message::ForbiddenValue);
     return false;
   }
-  if (isnan(y) || isinf(y)) {
+  if (std::isnan(y) || std::isinf(y)) {
     app()->displayWarning(I18n::Message::ValueNotReachedByFunction);
     return false;
   }

--- a/apps/shared/function_graph_controller.cpp
+++ b/apps/shared/function_graph_controller.cpp
@@ -1,7 +1,7 @@
 #include "function_graph_controller.h"
 #include "text_field_delegate_app.h"
 #include <assert.h>
-#include <math.h>
+#include <cmath>
 #include <float.h>
 
 using namespace Poincare;

--- a/apps/shared/function_graph_controller.cpp
+++ b/apps/shared/function_graph_controller.cpp
@@ -100,7 +100,7 @@ InteractiveCurveViewRangeDelegate::Range FunctionGraphController::computeYRange(
     for (int i = 0; i <= curveView()->resolution(); i++) {
       float x = xMin + i*step;
       y = f->evaluateAtAbscissa(x, myApp->localContext());
-      if (!isnan(y) && !isinf(y)) {
+      if (!std::isnan(y) && !std::isinf(y)) {
         min = min < y ? min : y;
         max = max > y ? max : y;
       }

--- a/apps/shared/function_graph_view.cpp
+++ b/apps/shared/function_graph_view.cpp
@@ -1,6 +1,6 @@
 #include "function_graph_view.h"
 #include <assert.h>
-#include <math.h>
+#include <cmath>
 #include <float.h>
 using namespace Poincare;
 

--- a/apps/shared/initialisation_parameter_controller.cpp
+++ b/apps/shared/initialisation_parameter_controller.cpp
@@ -1,6 +1,6 @@
 #include "initialisation_parameter_controller.h"
 #include <assert.h>
-#include <math.h>
+#include <cmath>
 
 namespace Shared {
 

--- a/apps/shared/interactive_curve_view_controller.cpp
+++ b/apps/shared/interactive_curve_view_controller.cpp
@@ -1,6 +1,6 @@
 #include "interactive_curve_view_controller.h"
 #include "text_field_delegate_app.h"
-#include <math.h>
+#include <cmath>
 #include <assert.h>
 
 using namespace Poincare;

--- a/apps/shared/interactive_curve_view_range.cpp
+++ b/apps/shared/interactive_curve_view_range.cpp
@@ -95,14 +95,14 @@ void InteractiveCurveViewRange::zoom(float ratio, float x, float y) {
   }
   float newXMin = clipped(x*(1.0f-ratio)+ratio*xMin, false);
   float newXMax = clipped(x*(1.0f-ratio)+ratio*xMax, true);
-  if (!isnan(newXMin) && !isnan(newXMax)) {
+  if (!std::isnan(newXMin) && !std::isnan(newXMax)) {
     m_xMax = newXMax;
     MemoizedCurveViewRange::setXMin(newXMin);
   }
   m_yAuto = false;
   float newYMin = clipped(y*(1.0f-ratio)+ratio*yMin, false);
   float newYMax = clipped(y*(1.0f-ratio)+ratio*yMax, true);
-  if (!isnan(newYMin) && !isnan(newYMax)) {
+  if (!std::isnan(newYMin) && !std::isnan(newYMax)) {
     m_yMax = newYMax;
     MemoizedCurveViewRange::setYMin(newYMin);
   }
@@ -110,7 +110,7 @@ void InteractiveCurveViewRange::zoom(float ratio, float x, float y) {
 
 void InteractiveCurveViewRange::panWithVector(float x, float y) {
   m_yAuto = false;
-  if (clipped(m_xMin + x, false) != m_xMin + x || clipped(m_xMax + x, true) != m_xMax + x || clipped(m_yMin + y, false) != m_yMin + y || clipped(m_yMax + y, true) != m_yMax + y || isnan(clipped(m_xMin + x, false)) || isnan(clipped(m_xMax + x, true)) || isnan(clipped(m_yMin + y, false)) || isnan(clipped(m_yMax + y, true))) {
+  if (clipped(m_xMin + x, false) != m_xMin + x || clipped(m_xMax + x, true) != m_xMax + x || clipped(m_yMin + y, false) != m_yMin + y || clipped(m_yMax + y, true) != m_yMax + y || std::isnan(clipped(m_xMin + x, false)) || std::isnan(clipped(m_xMax + x, true)) || std::isnan(clipped(m_yMin + y, false)) || std::isnan(clipped(m_yMax + y, true))) {
     return;
   }
   m_xMax = clipped(m_xMax + x, true);
@@ -124,7 +124,7 @@ void InteractiveCurveViewRange::roundAbscissa() {
   float xMax = m_xMax;
   float newXMin = clipped(std::round((xMin+xMax)/2) - (float)Ion::Display::Width/2.0f, false);
   float newXMax = clipped(std::round((xMin+xMax)/2) + (float)Ion::Display::Width/2.0f-1.0f, true);
-  if (isnan(newXMin) || isnan(newXMax)) {
+  if (std::isnan(newXMin) || std::isnan(newXMax)) {
     return;
   }
   m_xMax = newXMax;
@@ -141,14 +141,14 @@ void InteractiveCurveViewRange::normalize() {
   float yMax = m_yMax;
   float newXMin = clipped((xMin+xMax)/2 - 5.3f, false);
   float newXMax = clipped((xMin+xMax)/2 + 5.3f, true);
-  if (!isnan(newXMin) && !isnan(newXMax)) {
+  if (!std::isnan(newXMin) && !std::isnan(newXMax)) {
     m_xMax = newXMax;
     MemoizedCurveViewRange::setXMin(newXMin);
   }
   m_yAuto = false;
   float newYMin = clipped((yMin+yMax)/2 - 3.1f, false);
   float newYMax = clipped((yMin+yMax)/2 + 3.1f, true);
-  if (!isnan(newYMin) && !isnan(newYMax)) {
+  if (!std::isnan(newYMin) && !std::isnan(newYMax)) {
     m_yMax = newYMax;
     MemoizedCurveViewRange::setYMin(newYMin);
   }
@@ -173,7 +173,7 @@ void InteractiveCurveViewRange::setDefault() {
 }
 
 void InteractiveCurveViewRange::centerAxisAround(Axis axis, float position) {
-  if (isnan(position)) {
+  if (std::isnan(position)) {
     return;
   }
   if (axis == Axis::X) {
@@ -197,24 +197,24 @@ void InteractiveCurveViewRange::centerAxisAround(Axis axis, float position) {
 void InteractiveCurveViewRange::panToMakePointVisible(float x, float y, float topMarginRatio, float rightMarginRatio, float bottomMarginRation, float leftMarginRation) {
   float xRange = m_xMax - m_xMin;
   float yRange = m_yMax - m_yMin;
-  if (x < m_xMin + leftMarginRation*xRange && !isinf(x) && !isnan(x)) {
+  if (x < m_xMin + leftMarginRation*xRange && !std::isinf(x) && !std::isnan(x)) {
     float newXMin = clipped(x - leftMarginRation*xRange, false);
     m_xMax = clipped(newXMin + xRange, true);
     MemoizedCurveViewRange::setXMin(newXMin);
     m_yAuto = false;
   }
-  if (x > m_xMax - rightMarginRatio*xRange && !isinf(x) && !isnan(x)) {
+  if (x > m_xMax - rightMarginRatio*xRange && !std::isinf(x) && !std::isnan(x)) {
     m_xMax = clipped(x + rightMarginRatio*xRange, true);
     MemoizedCurveViewRange::setXMin(clipped(m_xMax - xRange, false));
     m_yAuto = false;
   }
-  if (y < m_yMin + bottomMarginRation*yRange && !isinf(y) && !isnan(y)) {
+  if (y < m_yMin + bottomMarginRation*yRange && !std::isinf(y) && !std::isnan(y)) {
     float newYMin = clipped(y - bottomMarginRation*yRange, false);
     m_yMax = clipped(newYMin + yRange, true);
     MemoizedCurveViewRange::setYMin(newYMin);
     m_yAuto = false;
   }
-  if (y > m_yMax - topMarginRatio*yRange && !isinf(y) && !isnan(y)) {
+  if (y > m_yMax - topMarginRatio*yRange && !std::isinf(y) && !std::isnan(y)) {
     m_yMax = clipped(y + topMarginRatio*yRange, true);
     MemoizedCurveViewRange::setYMin(clipped(m_yMax - yRange, false));
     m_yAuto = false;

--- a/apps/shared/interactive_curve_view_range_delegate.cpp
+++ b/apps/shared/interactive_curve_view_range_delegate.cpp
@@ -2,7 +2,6 @@
 #include "interactive_curve_view_range.h"
 #include <cmath>
 #include <float.h>
-#include <math.h>
 
 namespace Shared {
 

--- a/apps/shared/interactive_curve_view_range_delegate.cpp
+++ b/apps/shared/interactive_curve_view_range_delegate.cpp
@@ -40,10 +40,10 @@ bool InteractiveCurveViewRangeDelegate::didChangeRange(InteractiveCurveViewRange
   }
   interactiveCurveViewRange->setYMin(addMargin(min, range, true));
   interactiveCurveViewRange->setYMax(addMargin(max, range, false));
-  if (isinf(interactiveCurveViewRange->xMin())) {
+  if (std::isinf(interactiveCurveViewRange->xMin())) {
     interactiveCurveViewRange->setYMin(-FLT_MAX);
   }
-  if (isinf(interactiveCurveViewRange->xMax())) {
+  if (std::isinf(interactiveCurveViewRange->xMax())) {
     interactiveCurveViewRange->setYMax(FLT_MAX);
   }
   return true;

--- a/apps/shared/memoized_curve_view_range.cpp
+++ b/apps/shared/memoized_curve_view_range.cpp
@@ -1,6 +1,5 @@
 #include "memoized_curve_view_range.h"
 #include <cmath>
-#include <math.h>
 #include <assert.h>
 #include <ion.h>
 

--- a/apps/shared/memoized_curve_view_range.cpp
+++ b/apps/shared/memoized_curve_view_range.cpp
@@ -41,7 +41,7 @@ float MemoizedCurveViewRange::yGridUnit() {
 }
 
 void MemoizedCurveViewRange::setXMin(float xMin) {
-  if (isnan(xMin)) {
+  if (std::isnan(xMin)) {
     return;
   }
   m_xMin = xMin;
@@ -52,7 +52,7 @@ void MemoizedCurveViewRange::setXMin(float xMin) {
 }
 
 void MemoizedCurveViewRange::setXMax(float xMax) {
-  if (isnan(xMax)) {
+  if (std::isnan(xMax)) {
     return;
   }
   m_xMax = xMax;
@@ -63,7 +63,7 @@ void MemoizedCurveViewRange::setXMax(float xMax) {
 }
 
 void MemoizedCurveViewRange::setYMin(float yMin) {
-  if (isnan(yMin)) {
+  if (std::isnan(yMin)) {
     return;
   }
   m_yMin = yMin;
@@ -74,7 +74,7 @@ void MemoizedCurveViewRange::setYMin(float yMin) {
 }
 
 void MemoizedCurveViewRange::setYMax(float yMax) {
-  if (isnan(yMax)) {
+  if (std::isnan(yMax)) {
     return;
   }
   m_yMax = yMax;

--- a/apps/shared/text_field_delegate_app.cpp
+++ b/apps/shared/text_field_delegate_app.cpp
@@ -1,6 +1,6 @@
 #include "text_field_delegate_app.h"
 #include "../apps_container.h"
-#include <math.h>
+#include <cmath>
 #include <string.h>
 
 using namespace Poincare;

--- a/apps/shared/zoom_parameter_controller.cpp
+++ b/apps/shared/zoom_parameter_controller.cpp
@@ -1,6 +1,6 @@
 #include "zoom_parameter_controller.h"
 #include <assert.h>
-#include <math.h>
+#include <cmath>
 
 namespace Shared {
 

--- a/apps/statistics/histogram_view.cpp
+++ b/apps/statistics/histogram_view.cpp
@@ -1,6 +1,6 @@
 #include "histogram_view.h"
 #include <assert.h>
-#include <math.h>
+#include <cmath>
 
 using namespace Shared;
 

--- a/kandinsky/src/line.cpp
+++ b/kandinsky/src/line.cpp
@@ -59,7 +59,7 @@ void KDDrawLine(KDPoint p1, KDPoint p2, KDColor c) {
   }
 }
 /*
-#include <math.h>
+#include <cmath>
 #include <stdlib.h>
 
 void KDDrawAntiAliasedLine(KDPoint p1, KDPoint p2, KDCoordinate width, KDColor frontColor, KDColor backColor) {

--- a/liba/Makefile
+++ b/liba/Makefile
@@ -140,6 +140,7 @@ tests += $(addprefix liba/test/, \
   double.c \
   ieee754.c \
   long.c \
+  math.c \
   setjmp.c \
   stddef.c \
   stdint.c \

--- a/liba/Makefile
+++ b/liba/Makefile
@@ -12,10 +12,6 @@ objs += $(addprefix liba/src/, \
   fpclassify.o \
   fpclassifyf.o \
   ieee754.o \
-  isnand.o \
-  isnanf.o \
-  isinfd.o \
-  isinff.o \
   malloc.o \
   memcmp.o \
   memcpy.o \

--- a/liba/include/math.h
+++ b/liba/include/math.h
@@ -6,13 +6,28 @@
 
 LIBA_BEGIN_DECLS
 
-#define NAN (0.0f/0.0f)
+typedef float float_t;
+typedef double double_t;
+
+#define M_E        2.71828182845904524
+#define M_LOG2E    1.44269504088896341
+#define M_LOG10E   0.43429448190325183
+#define M_LN2      0.69314718055994531
+#define M_LN10     2.30258509299404568
+#define M_PI       3.14159265358979324
+#define M_PI_2     1.57079632679489662
+#define M_PI_4     0.78539816339744831
+#define M_1_PI     0.31830988618379067
+#define M_2_PI     0.63661977236758134
+#define M_2_SQRTPI 1.12837916709551257
+#define M_SQRT2    1.41421356237309505
+#define M_SQRT1_2  0.70710678118654752
+
+#define MAXFLOAT FLT_MAX
+#define HUGE_VAL __builtin_huge_val()
+#define HUGE_VALF __builtin_huge_valf()
 #define INFINITY __builtin_inff()
-#define M_E 2.71828182845904523536028747135266250
-#define M_PI 3.14159265358979323846264338327950288
-#define M_PI_2 1.57079632679489661923132169163975144
-#define M_PI_4 0.78539816339744830961566084581987572
-#define M_SQRT2 1.41421356237309504880168872420969808
+#define NAN __builtin_nanf("")
 
 #define FP_INFINITE 0x01
 #define FP_NAN 0x02
@@ -20,21 +35,11 @@ LIBA_BEGIN_DECLS
 #define FP_SUBNORMAL 0x08
 #define FP_ZERO 0x10
 
-/* The C99 standard requires isinf and isnan to be defined as macros that can
- * handle arbitrary precision float numbers. The names of the functions called
- * by those macros (depending on the argument size) are not standardized though.
- * We're chosing isinff/isnanf for single-precision functions, and isinfd/isnand
- * for double-precision functions. */
-
-int isinff(float x);
-int isinfd(double d);
-#define isinf(x) (sizeof(x) == sizeof(float) ? isinff(x) : isinfd(x))
-int isnanf(float x);
-int isnand(double x);
-#define isnan(x) (sizeof(x) == sizeof(float) ? isnanf(x) : isnand(x))
-int __fpclassifyf(float x);
-int __fpclassify(double x);
-#define fpclassify(x) ((sizeof (x) == sizeof (float)) ? __fpclassifyf(x) :  __fpclassify(x))
+#define fpclassify(x) __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, x)
+#define isfinite(x) __builtin_isfinite(x)
+#define isnormal(x) __builtin_isnormal(x)
+#define isnan(x) __builtin_isnan(x)
+#define isinf(x) __builtin_isinf(x)
 
 float acosf(float x);
 float acoshf(float x);
@@ -68,6 +73,38 @@ float sqrtf(float x);
 float tanf(float x);
 float tanhf(float x);
 
+#define acosf(x) __builtin_acosf(x)
+#define acoshf(x) __builtin_acoshf(x)
+#define asinf(x) __builtin_asinf(x)
+#define asinhf(x) __builtin_asinhf(x)
+#define atanf(x) __builtin_atanf(x)
+#define atan2f(y, x) __builtin_atan2f(y, x)
+#define atanhf(x) __builtin_atanhf(x)
+#define ceilf(x) __builtin_ceilf(x)
+#define copysignf(x, y) __builtin_copysignf(x, y)
+#define cosf(x) __builtin_cosf(x)
+#define coshf(x) __builtin_coshf(x)
+#define expf(x) __builtin_expf(x)
+#define expm1f(x) __builtin_expm1f(x)
+#define fabsf(x) __builtin_fabsf(x)
+#define floorf(x) __builtin_floorf(x)
+#define fmodf(x, y) __builtin_fmodf(x, y)
+#define lgammaf(x) __builtin_lgammaf(x)
+#define lgammaf_r(x, signgamp) __builtin_lgammaf_r(x, signgamp)
+#define log1pf(x) __builtin_log1pf(x)
+#define log10f(x) __builtin_log10f(x)
+#define logf(x) __builtin_logf(x)
+#define nanf(s) __builtin_nanf(s)
+#define nearbyintf(x) __builtin_nearbyintf(x)
+#define powf(x, y) __builtin_powf(x, y)
+#define roundf(x) __builtin_roundf(x)
+#define scalbnf(x, n) __builtin_scalbnf(x, n)
+#define sinf(x) __builtin_sinf(x)
+#define sinhf(x) __builtin_sinhf(x)
+#define sqrtf(x) __builtin_sqrtf(x)
+#define tanf(x) __builtin_tanf(x)
+#define tanhf(x) __builtin_tanhf(x)
+
 double acos(double x);
 double acosh(double x);
 double asin(double x);
@@ -95,6 +132,36 @@ double sinh(double x);
 double sqrt(double x);
 double tan(double x);
 double tanh(double x);
+
+#define acos(x) __builtin_acos(x)
+#define acosh(x) __builtin_acosh(x)
+#define asin(x) __builtin_asin(x)
+#define asinh(x) __builtin_asinh(x)
+#define atan(x) __builtin_atan(x)
+#define atanh(x) __builtin_atanh(x)
+#define ceil(x) __builtin_ceil(x)
+#define copysign(x, y) __builtin_copysign(x, y)
+#define cos(x) __builtin_cos(x)
+#define cosh(x) __builtin_cosh(x)
+#define exp(x) __builtin_exp(x)
+#define expm1(x) __builtin_expm1(x)
+#define fabs(x) __builtin_fabs(x)
+#define floor(x) __builtin_floor(x)
+#define lgamma(x) __builtin_lgamma(x)
+#define lgamma_r(x, signgamp) __builtin_lgamma_r(x, signgamp)
+#define log1p(x) __builtin_log1p(x)
+#define log10(x) __builtin_log10(x)
+#define log(x) __builtin_log(x)
+#define pow(x, y) __builtin_pow(x, y)
+#define round(x) __builtin_round(x)
+#define scalbn(x, n) __builtin_scalbn(x, n)
+#define sin(x) __builtin_sin(x)
+#define sinh(x) __builtin_sinh(x)
+#define sqrt(x) __builtin_sqrt(x)
+#define tan(x) __builtin_tan(x)
+#define tanh(x) __builtin_tanh(x)
+
+extern int signgam;
 
 LIBA_END_DECLS
 

--- a/liba/src/aeabi-rt/double.c
+++ b/liba/src/aeabi-rt/double.c
@@ -42,6 +42,10 @@ int __aeabi_dcmplt(aeabi_double_t a, aeabi_double_t b) {
   return f64_lt(f64(a), f64(b));
 }
 
+int __aeabi_dcmpun(aeabi_double_t a, aeabi_double_t b) {
+  return !f64_eq(f64(a), f64(a)) || !f64_eq(f64(b), f64(b));
+}
+
 // Arithmetics
 
 aeabi_double_t __aeabi_dadd(aeabi_double_t a, aeabi_double_t b) {

--- a/liba/src/external/openbsd/s_roundf.c
+++ b/liba/src/external/openbsd/s_roundf.c
@@ -34,7 +34,7 @@ roundf(float x)
 {
 	float t;
 
-	if (isinff(x) || isnanf(x))
+	if (isinf(x) || isnan(x))
 		return (x);
 
 	if (x >= 0.0) {

--- a/liba/src/isinfd.c
+++ b/liba/src/isinfd.c
@@ -1,6 +1,0 @@
-#include <math.h>
-#include <private/ieee754.h>
-
-int isinfd(double x) {
-  return (ieee754exp64(x) == 0x7FF && ieee754man64(x) == 0);
-}

--- a/liba/src/isinff.c
+++ b/liba/src/isinff.c
@@ -1,6 +1,0 @@
-#include <math.h>
-#include <private/ieee754.h>
-
-int isinff(float x) {
-  return (ieee754exp32(x) == 0xFF && ieee754man32(x) == 0);
-}

--- a/liba/src/isnand.c
+++ b/liba/src/isnand.c
@@ -1,6 +1,0 @@
-#include <math.h>
-#include <private/ieee754.h>
-
-int isnand(double x) {
-  return (ieee754exp64(x) == 0x7FF && ieee754man64(x) != 0);
-}

--- a/liba/src/isnanf.c
+++ b/liba/src/isnanf.c
@@ -1,6 +1,0 @@
-#include <math.h>
-#include <private/ieee754.h>
-
-int isnanf(float x) {
-  return (ieee754exp32(x) == 0xFF && ieee754man32(x) != 0);
-}

--- a/liba/test/math.c
+++ b/liba/test/math.c
@@ -1,0 +1,210 @@
+// This file tests that each math fuction links.
+#include <math.h>
+
+int test_fpclassifyf(float x) {
+  return fpclassify(x);
+}
+int test_isfinitef(float x) {
+  return isfinite(x);
+}
+int test_isnormalf(float x) {
+  return isnormal(x);
+}
+int test_isnanf(float x) {
+  return isnan(x);
+}
+int test_isinff(float x) {
+  return isinf(x);
+}
+
+float test_acosf(float x) {
+  return acosf(x);
+}
+float test_acoshf(float x) {
+  return acoshf(x);
+}
+float test_asinf(float x) {
+  return asinf(x);
+}
+float test_asinhf(float x) {
+  return asinhf(x);
+}
+float test_atanf(float x) {
+  return atanf(x);
+}
+float test_atan2f(float y, float x) {
+  return atan2f(y, x);
+}
+float test_atanhf(float x) {
+  return atanhf(x);
+}
+float test_ceilf(float x) {
+  return ceilf(x);
+}
+float test_copysignf(float x, float y) {
+  return copysignf(x, y);
+}
+float test_cosf(float x) {
+  return cosf(x);
+}
+float test_coshf(float x) {
+  return coshf(x);
+}
+float test_expf(float x) {
+  return expf(x);
+}
+float test_expm1f(float x) {
+  return expm1f(x);
+}
+float test_fabsf(float x) {
+  return fabsf(x);
+}
+float test_floorf(float x) {
+  return floorf(x);
+}
+float test_fmodf(float x, float y) {
+  return fmodf(x, y);
+}
+float test_lgammaf(float x) {
+  return lgammaf(x);
+}
+float test_lgammaf_r(float x, int *signgamp) {
+  return lgammaf_r(x, signgamp);
+}
+float test_log1pf(float x) {
+  return log1pf(x);
+}
+float test_log10f(float x) {
+  return log10f(x);
+}
+float test_logf(float x) {
+  return logf(x);
+}
+float test_nanf(const char *s) {
+  return nanf(s);
+}
+float test_nearbyintf(float x) {
+  return nearbyintf(x);
+}
+float test_powf(float x, float y) {
+  return powf(x, y);
+}
+float test_roundf(float x) {
+  return roundf(x);
+}
+float test_scalbnf(float x, int n) {
+  return scalbnf(x, n);
+}
+float test_sinf(float x) {
+  return sinf(x);
+}
+float test_sinhf(float x) {
+  return sinhf(x);
+}
+float test_sqrtf(float x) {
+  return sqrtf(x);
+}
+float test_tanf(float x) {
+  return tanf(x);
+}
+float test_tanhf(float x) {
+  return tanhf(x);
+}
+
+int test_fpclassify(double x) {
+  return fpclassify(x);
+}
+int test_isfinite(double x) {
+  return isfinite(x);
+}
+int test_isnormal(double x) {
+  return isnormal(x);
+}
+int test_isnan(double x) {
+  return isnan(x);
+}
+int test_isinf(double x) {
+  return isinf(x);
+}
+
+double test_acos(double x) {
+  return acos(x);
+}
+double test_acosh(double x) {
+  return acosh(x);
+}
+double test_asin(double x) {
+  return asin(x);
+}
+double test_asinh(double x) {
+  return asinh(x);
+}
+double test_atan(double x) {
+  return atan(x);
+}
+double test_atanh(double x) {
+  return atanh(x);
+}
+double test_ceil(double x) {
+  return ceil(x);
+}
+double test_copysign(double x, double y) {
+  return copysign(x, y);
+}
+double test_cos(double x) {
+  return cos(x);
+}
+double test_cosh(double x) {
+  return cosh(x);
+}
+double test_exp(double x) {
+  return exp(x);
+}
+double test_expm1(double x) {
+  return expm1(x);
+}
+double test_fabs(double x) {
+  return fabs(x);
+}
+double test_floor(double x) {
+  return floor(x);
+}
+double test_lgamma(double x) {
+  return lgamma(x);
+}
+double test_lgamma_r(double x, int *signgamp) {
+  return lgamma_r(x, signgamp);
+}
+double test_log1p(double x) {
+  return log1p(x);
+}
+double test_log10(double x) {
+  return log10(x);
+}
+double test_log(double x) {
+  return log(x);
+}
+double test_pow(double x, double y) {
+  return pow(x, y);
+}
+double test_round(double x) {
+  return round(x);
+}
+double test_scalbn(double x, int n) {
+  return scalbn(x, n);
+}
+double test_sin(double x) {
+  return sin(x);
+}
+double test_sinh(double x) {
+  return sinh(x);
+}
+double test_sqrt(double x) {
+  return sqrt(x);
+}
+double test_tan(double x) {
+  return tan(x);
+}
+double test_tanh(double x) {
+  return tanh(x);
+}

--- a/libaxx/include/cmath
+++ b/libaxx/include/cmath
@@ -1,58 +1,133 @@
 #ifndef LIBAXX_CMATH
 #define LIBAXX_CMATH
 
-extern "C" {
 #include <math.h>
-}
+
+#undef fpclassify
+#undef isfinite
+#undef isnormal
+#undef isnan
+#undef isinf
+
+#undef acosf
+#undef acoshf
+#undef asinf
+#undef asinhf
+#undef atanf
+#undef atan2f
+#undef atanhf
+#undef ceilf
+#undef copysignf
+#undef cosf
+#undef coshf
+#undef expf
+#undef expm1f
+#undef fabsf
+#undef floorf
+#undef fmodf
+#undef lgammaf
+#undef lgammaf_r
+#undef log1pf
+#undef log10f
+#undef logf
+#undef nanf
+#undef nearbyintf
+#undef powf
+#undef roundf
+#undef scalbnf
+#undef sinf
+#undef sinhf
+#undef sqrtf
+#undef tanf
+#undef tanhf
+
+#undef acos
+#undef acosh
+#undef asin
+#undef asinh
+#undef atan
+#undef atanh
+#undef ceil
+#undef copysign
+#undef cos
+#undef cosh
+#undef exp
+#undef expm1
+#undef fabs
+#undef floor
+#undef lgamma
+#undef lgamma_r
+#undef log1p
+#undef log10
+#undef log
+#undef pow
+#undef round
+#undef scalbn
+#undef sin
+#undef sinh
+#undef sqrt
+#undef tan
+#undef tanh
 
 namespace std {
 
-static inline double acos(double x) { return ::acos(x); }
-static inline float acos(float x) { return ::acosf(x); }
-static inline double acosh(double x) { return ::acosh(x); }
-static inline float acosh(float x) { return ::acoshf(x); }
-static inline double asin(double x) { return ::asin(x); }
-static inline float asin(float x) { return ::asinf(x); }
-static inline double asinh(double x) { return ::asinh(x); }
-static inline float asinh(float x) { return ::asinhf(x); }
-static inline double atan(double x) { return ::atan(x); }
-static inline float atan(float x) { return ::atanf(x); }
-static inline double atanh(double x) { return ::atanh(x); }
-static inline float atanh(float x) { return ::atanhf(x); }
-static inline double ceil(double x) { return ::ceil(x); }
-static inline float ceil(float x) { return ::ceilf(x); }
-static inline double copysign(double x, double y) { return ::copysign(x, y); }
-static inline float copysign(float x, float y) { return ::copysignf(x, y); }
-static inline double cos(double x) { return ::cos(x); }
-static inline float cos(float x) { return ::cosf(x); }
-static inline double cosh(double x) { return ::cosh(x); }
-static inline float cosh(float x) { return ::coshf(x); }
-static inline double exp(double x) { return ::exp(x); }
-static inline float exp(float x) { return ::expf(x); }
-static inline double fabs(double x) { return ::fabs(x); }
-static inline float fabs(float x) { return ::fabsf(x); }
-static inline double floor(double x) { return ::floor(x); }
-static inline float floor(float x) { return ::floorf(x); }
-static inline double lgamma(double x) { return ::lgamma(x); }
-static inline float lgamma(float x) { return ::lgammaf(x); }
-static inline double log10(double x) { return ::log10(x); }
-static inline float log10(float x) { return ::log10f(x); }
-static inline double log(double x) { return ::log(x); }
-static inline float log(float x) { return ::logf(x); }
-static inline double pow(double x, double y) { return ::pow(x, y); }
-static inline float pow(float x, float y) { return ::powf(x, y); }
-static inline double round(double x) { return ::round(x); }
-static inline float round(float x) { return ::roundf(x); }
-static inline double sin(double x) { return ::sin(x); }
-static inline float sin(float x) { return ::sinf(x); }
-static inline double sinh(double x) { return ::sinh(x); }
-static inline float sinh(float x) { return ::sinhf(x); }
-static inline double sqrt(double x) { return ::sqrt(x); }
-static inline float sqrt(float x) { return ::sqrtf(x); }
-static inline double tan(double x) { return ::tan(x); }
-static inline float tan(float x) { return ::tanf(x); }
-static inline double tanh(double x) { return ::tanh(x); }
-static inline float tanh(float x) { return ::tanhf(x); }
+
+static inline double acos(double x) { return __builtin_acos(x); }
+static inline float acos(float x) { return __builtin_acosf(x); }
+static inline double acosh(double x) { return __builtin_acosh(x); }
+static inline float acosh(float x) { return __builtin_acoshf(x); }
+static inline double asin(double x) { return __builtin_asin(x); }
+static inline float asin(float x) { return __builtin_asinf(x); }
+static inline double asinh(double x) { return __builtin_asinh(x); }
+static inline float asinh(float x) { return __builtin_asinhf(x); }
+static inline double atan(double x) { return __builtin_atan(x); }
+static inline float atan(float x) { return __builtin_atanf(x); }
+static inline double atanh(double x) { return __builtin_atanh(x); }
+static inline float atanh(float x) { return __builtin_atanhf(x); }
+static inline double ceil(double x) { return __builtin_ceil(x); }
+static inline float ceil(float x) { return __builtin_ceilf(x); }
+static inline double copysign(double x, double y) { return __builtin_copysign(x, y); }
+static inline float copysign(float x, float y) { return __builtin_copysignf(x, y); }
+static inline double cos(double x) { return __builtin_cos(x); }
+static inline float cos(float x) { return __builtin_cosf(x); }
+static inline double cosh(double x) { return __builtin_cosh(x); }
+static inline float cosh(float x) { return __builtin_coshf(x); }
+static inline double exp(double x) { return __builtin_exp(x); }
+static inline float exp(float x) { return __builtin_expf(x); }
+static inline double fabs(double x) { return __builtin_fabs(x); }
+static inline float fabs(float x) { return __builtin_fabsf(x); }
+static inline double floor(double x) { return __builtin_floor(x); }
+static inline float floor(float x) { return __builtin_floorf(x); }
+static inline int fpclassify(double x) { return __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, x); }
+static inline int fpclassify(float x) { return __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, x); }
+static inline bool isfinite(double x) { return __builtin_isfinite(x); }
+static inline bool isfinite(float x) { return __builtin_isfinite(x); }
+static inline bool isinf(double x) { return __builtin_isinf(x); }
+static inline bool isinf(float x) { return __builtin_isinf(x); }
+static inline bool isnan(double x) { return __builtin_isnan(x); }
+static inline bool isnan(float x) { return __builtin_isnan(x); }
+static inline bool isnormal(double x) { return __builtin_isnormal(x); }
+static inline bool isnormal(float x) { return __builtin_isnormal(x); }
+static inline double lgamma(double x) { return __builtin_lgamma(x); }
+static inline float lgamma(float x) { return __builtin_lgammaf(x); }
+static inline double log10(double x) { return __builtin_log10(x); }
+static inline float log10(float x) { return __builtin_log10f(x); }
+static inline double log(double x) { return __builtin_log(x); }
+static inline float log(float x) { return __builtin_logf(x); }
+static inline double pow(double x, double y) { return __builtin_pow(x, y); }
+static inline float pow(float x, float y) { return __builtin_powf(x, y); }
+static inline double round(double x) { return __builtin_round(x); }
+static inline float round(float x) { return __builtin_roundf(x); }
+static inline double sin(double x) { return __builtin_sin(x); }
+static inline float sin(float x) { return __builtin_sinf(x); }
+static inline double sinh(double x) { return __builtin_sinh(x); }
+static inline float sinh(float x) { return __builtin_sinhf(x); }
+static inline double sqrt(double x) { return __builtin_sqrt(x); }
+static inline float sqrt(float x) { return __builtin_sqrtf(x); }
+static inline double tan(double x) { return __builtin_tan(x); }
+static inline float tan(float x) { return __builtin_tanf(x); }
+static inline double tanh(double x) { return __builtin_tanh(x); }
+static inline float tanh(float x) { return __builtin_tanhf(x); }
 
 }
 

--- a/poincare/include/poincare/function.h
+++ b/poincare/include/poincare/function.h
@@ -5,7 +5,7 @@
 #include <poincare/list_data.h>
 #include <poincare/complex.h>
 #include <poincare/complex_matrix.h>
-#include <math.h>
+#include <cmath>
 
 namespace Poincare {
 

--- a/poincare/src/binomial_coefficient.cpp
+++ b/poincare/src/binomial_coefficient.cpp
@@ -37,7 +37,7 @@ Evaluation<T> * BinomialCoefficient::templatedEvaluate(Context& context, AngleUn
   T k = kInput->toScalar();
   delete nInput;
   delete kInput;
-  if (isnan(n) || isnan(k) || n != (int)n || k != (int)k || k > n || k < 0 || n < 0) {
+  if (std::isnan(n) || std::isnan(k) || n != (int)n || k != (int)k || k > n || k < 0 || n < 0) {
     return new Complex<T>(Complex<T>::Float(NAN));
   }
   T result = 1;

--- a/poincare/src/complex.cpp
+++ b/poincare/src/complex.cpp
@@ -6,7 +6,6 @@ extern "C" {
 #include <float.h>
 }
 #include <cmath>
-#include <math.h>
 #include <poincare/complex_matrix.h>
 #include "layout/string_layout.h"
 #include "layout/baseline_relative_layout.h"

--- a/poincare/src/complex.cpp
+++ b/poincare/src/complex.cpp
@@ -271,7 +271,7 @@ template <class T>
 int Complex<T>::convertComplexToText(char * buffer, int bufferSize, Expression::FloatDisplayMode displayMode, Expression::ComplexFormat complexFormat) const {
   assert(displayMode != Expression::FloatDisplayMode::Default);
   int numberOfChars = 0;
-  if (isnan(m_a) || isnan(m_b)) {
+  if (std::isnan(m_a) || std::isnan(m_b)) {
     return convertFloatToText(NAN, buffer, bufferSize, k_numberOfSignificantDigits, displayMode);
   }
   if (complexFormat == Expression::ComplexFormat::Polar) {
@@ -304,7 +304,7 @@ int Complex<T>::convertComplexToText(char * buffer, int bufferSize, Expression::
 
   if (m_a != 0 || m_b == 0) {
     numberOfChars = convertFloatToText(m_a, buffer, bufferSize, k_numberOfSignificantDigits, displayMode);
-    if (m_b > 0 && !isnan(m_b) && bufferSize > numberOfChars+1) {
+    if (m_b > 0 && !std::isnan(m_b) && bufferSize > numberOfChars+1) {
       buffer[numberOfChars++] = '+';
       // Ensure that the string is null terminated even if buffer size is to small
       buffer[numberOfChars] = 0;
@@ -328,7 +328,7 @@ template <class T>
 int Complex<T>::convertFloatToTextPrivate(T f, char * buffer, int numberOfSignificantDigits, Expression::FloatDisplayMode mode) {
   assert(mode != Expression::FloatDisplayMode::Default);
   assert(numberOfSignificantDigits > 0);
-  if (isinf(f)) {
+  if (std::isinf(f)) {
     int currentChar = 0;
     if (f < 0) {
       buffer[currentChar++] = '-';
@@ -340,7 +340,7 @@ int Complex<T>::convertFloatToTextPrivate(T f, char * buffer, int numberOfSignif
     return currentChar;
   }
 
-  if (isnan(f)) {
+  if (std::isnan(f)) {
     int currentChar = 0;
     buffer[currentChar++] = 'u';
     buffer[currentChar++] = 'n';
@@ -380,20 +380,20 @@ int Complex<T>::convertFloatToTextPrivate(T f, char * buffer, int numberOfSignif
   /* if availableCharsForMantissaWithoutSign - 1 - numberOfDigitBeforeDecimal
    * is too big (or too small), mantissa is now inf. We handle this case by
    * using logarithm function. */
-  if (isnan(mantissa) || isinf(mantissa)) {
+  if (std::isnan(mantissa) || std::isinf(mantissa)) {
     mantissa = std::round(std::pow(10, std::log10(std::fabs(f))+(T)(availableCharsForMantissaWithoutSign - 1 - numberOfDigitBeforeDecimal)));
     mantissa = std::copysign(mantissa, f);
   }
   /* We update the exponent in base 10 (if 0.99999999 was rounded to 1 for
    * instance) */
   T truncatedMantissa = (int)(f * std::pow(10, (T)(availableCharsForMantissaWithoutSign - 1 - numberOfDigitBeforeDecimal)));
-  if (isinf(truncatedMantissa) || isnan(truncatedMantissa)) {
+  if (std::isinf(truncatedMantissa) || std::isnan(truncatedMantissa)) {
     truncatedMantissa = (int)(std::pow(10, std::log10(std::fabs(f))+(T)(availableCharsForMantissaWithoutSign - 1 - numberOfDigitBeforeDecimal)));
     truncatedMantissa = std::copysign(truncatedMantissa, f);
   }
   if (mantissa != truncatedMantissa) {
     T newLogBase10 = mantissa != 0 ? std::log10(std::fabs(mantissa/std::pow((T)10, (T)(availableCharsForMantissaWithoutSign - 1 - numberOfDigitBeforeDecimal)))) : 0;
-    if (isnan(newLogBase10) || isinf(newLogBase10)) {
+    if (std::isnan(newLogBase10) || std::isinf(newLogBase10)) {
       newLogBase10 = std::log10(std::fabs((T)mantissa)) - (T)(availableCharsForMantissaWithoutSign - 1 - numberOfDigitBeforeDecimal);
     }
     exponentInBase10 = std::floor(newLogBase10);
@@ -457,7 +457,7 @@ ExpressionLayout * Complex<T>::createPolarLayout(Expression::FloatDisplayMode fl
   char bufferSuperscript[k_maxFloatBufferLength+2];
   int numberOfCharInSuperscript = 0;
 
-  if (isnan(r()) || isnan(th())) {
+  if (std::isnan(r()) || std::isnan(th())) {
     numberOfCharInBase = convertFloatToText(NAN, bufferBase, k_maxComplexBufferLength, k_numberOfSignificantDigits, floatDisplayMode);
     return new StringLayout(bufferBase, numberOfCharInBase);
   }

--- a/poincare/src/confidence_interval.cpp
+++ b/poincare/src/confidence_interval.cpp
@@ -33,7 +33,7 @@ Evaluation<T> * ConfidenceInterval::templatedEvaluate(Context& context, AngleUni
   T n = nInput->toScalar();
   delete fInput;
   delete nInput;
-  if (isnan(f) || isnan(n) || n != (int)n || n < 0 || f < 0 || f > 1) {
+  if (std::isnan(f) || std::isnan(n) || n != (int)n || n < 0 || f < 0 || f > 1) {
     return new Complex<T>(Complex<T>::Float(NAN));
   }
   Complex<T> operands[2];

--- a/poincare/src/derivative.cpp
+++ b/poincare/src/derivative.cpp
@@ -42,7 +42,7 @@ Evaluation<T> * Derivative::templatedEvaluate(Context& context, AngleUnit angleU
   delete fInput;
 
   // No complex/matrix version of Derivative
-  if (isnan(x) || isnan(functionValue)) {
+  if (std::isnan(x) || std::isnan(functionValue)) {
   return new Complex<T>(Complex<T>::Float(NAN));
   }
 
@@ -100,7 +100,7 @@ Evaluation<T> * Derivative::templatedEvaluate(Context& context, AngleUnit angleU
     }
   }
   /* if the error is too big regarding the value, do not return the answer */
-  if (err/ans > k_maxErrorRateOnApproximation || isnan(err)) {
+  if (err/ans > k_maxErrorRateOnApproximation || std::isnan(err)) {
     return new Complex<T>(Complex<T>::Float(NAN));
   }
   if (err < min) {

--- a/poincare/src/division_quotient.cpp
+++ b/poincare/src/division_quotient.cpp
@@ -32,7 +32,7 @@ Evaluation<T> * DivisionQuotient::templatedEvaluate(Context& context, AngleUnit 
   T f2 = f2Input->toScalar();
   delete f1Input;
   delete f2Input;
-  if (isnan(f1) || isnan(f2) || f1 != (int)f1 || f2 != (int)f2) {
+  if (std::isnan(f1) || std::isnan(f2) || f1 != (int)f1 || f2 != (int)f2) {
     return new Complex<T>(Complex<T>::Float(NAN));
   }
   return new Complex<T>(Complex<T>::Float(std::floor(f1/f2)));

--- a/poincare/src/division_remainder.cpp
+++ b/poincare/src/division_remainder.cpp
@@ -32,7 +32,7 @@ Evaluation<T> * DivisionRemainder::templatedEvaluate(Context& context, AngleUnit
   T f2 = f2Input->toScalar();
   delete f1Input;
   delete f2Input;
-  if (isnan(f1) || isnan(f2) || f1 != (int)f1 || f2 != (int)f2) {
+  if (std::isnan(f1) || std::isnan(f2) || f1 != (int)f1 || f2 != (int)f2) {
     return new Complex<T>(Complex<T>::Float(NAN));
   }
   return new Complex<T>(Complex<T>::Float(std::round(f1-f2*std::floor(f1/f2))));

--- a/poincare/src/expression_lexer.l
+++ b/poincare/src/expression_lexer.l
@@ -38,7 +38,7 @@
  * which is not installed by default on MacOS, we thus made the choice to prefer
  * compatibility with MacOS's default version (2.3) instead of using the code
  * requires feature. */
-#include <math.h>
+#include <cmath>
 #include <poincare.h>
 #include "expression_parser.hpp"
 using namespace Poincare;

--- a/poincare/src/factorial.cpp
+++ b/poincare/src/factorial.cpp
@@ -28,13 +28,13 @@ Expression * Factorial::cloneWithDifferentOperands(Expression** newOperands,
 template<typename T>
 Complex<T> Factorial::templatedComputeComplex(const Complex<T> c) const {
   T n = c.a();
-  if (c.b() != 0 || isnan(n) || n != (int)n || n < 0) {
+  if (c.b() != 0 || std::isnan(n) || n != (int)n || n < 0) {
     return Complex<T>::Float(NAN);
   }
   T result = 1;
   for (int i = 1; i <= (int)n; i++) {
     result *= (T)i;
-    if (isinf(result)) {
+    if (std::isinf(result)) {
       return Complex<T>::Float(result);
     }
   }

--- a/poincare/src/great_common_divisor.cpp
+++ b/poincare/src/great_common_divisor.cpp
@@ -33,7 +33,7 @@ Evaluation<T> * GreatCommonDivisor::templatedEvaluate(Context& context, AngleUni
   T f2 = f2Input->toScalar();
   delete f1Input;
   delete f2Input;
-  if (isnan(f1) || isnan(f2) || f1 != (int)f1 || f2 != (int)f2) {
+  if (std::isnan(f1) || std::isnan(f2) || f1 != (int)f1 || f2 != (int)f2) {
     return new Complex<T>(Complex<T>::Float(NAN));
   }
   int a = (int)f2;

--- a/poincare/src/integer.cpp
+++ b/poincare/src/integer.cpp
@@ -3,8 +3,8 @@ extern "C" {
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
-#include <math.h>
 }
+#include <cmath>
 #include <poincare/complex.h>
 #include "layout/string_layout.h"
 

--- a/poincare/src/integer.cpp
+++ b/poincare/src/integer.cpp
@@ -319,7 +319,7 @@ Evaluation<float> * Integer::privateEvaluate(SinglePrecision p, Context& context
 
   /* If exponent is 255 and the float is undefined, we have exceed IEEE 754
    * representable float. */
-  if (exponent == 255 && isnan(float_result)) {
+  if (exponent == 255 && std::isnan(float_result)) {
     return new Complex<float>(Complex<float>::Float(INFINITY));
   }
 
@@ -389,7 +389,7 @@ Evaluation<double> * Integer::privateEvaluate(DoublePrecision p, Context& contex
 
   /* If exponent is 2047 and the double is undefined, we have exceed IEEE 754
    * representable double. */
-  if (exponent == 2047 && isnan(double_result)) {
+  if (exponent == 2047 && std::isnan(double_result)) {
     return new Complex<double>(Complex<double>::Float(INFINITY));
   }
   return new Complex<double>(Complex<double>::Float(double_result));

--- a/poincare/src/integral.cpp
+++ b/poincare/src/integral.cpp
@@ -40,7 +40,7 @@ Evaluation<T> * Integral::templatedEvaluate(Context & context, AngleUnit angleUn
   Evaluation<T> * bInput = m_args[2]->evaluate<T>(context, angleUnit);
   T b = bInput->toScalar();
   delete bInput;
-  if (isnan(a) || isnan(b)) {
+  if (std::isnan(a) || std::isnan(b)) {
     return new Complex<T>(Complex<T>::Float(NAN));
   }
 #ifdef LAGRANGE_METHOD

--- a/poincare/src/least_common_multiple.cpp
+++ b/poincare/src/least_common_multiple.cpp
@@ -33,7 +33,7 @@ Evaluation<T> * LeastCommonMultiple::templatedEvaluate(Context& context, AngleUn
   T f2 = f2Input->toScalar();
   delete f1Input;
   delete f2Input;
-  if (isnan(f1) || isnan(f2) || f1 != (int)f1 || f2 != (int)f2 || f1 == 0.0f || f2 == 0.0f) {
+  if (std::isnan(f1) || std::isnan(f2) || f1 != (int)f1 || f2 != (int)f2 || f1 == 0.0f || f2 == 0.0f) {
     return new Complex<T>(Complex<T>::Float(NAN));
   }
   int a = (int)f2;

--- a/poincare/src/permute_coefficient.cpp
+++ b/poincare/src/permute_coefficient.cpp
@@ -33,7 +33,7 @@ Evaluation<T> * PermuteCoefficient::templatedEvaluate(Context& context, AngleUni
   T k = kInput->toScalar();
   delete nInput;
   delete kInput;
-  if (isnan(n) || isnan(k) || n != (int)n || k != (int)k || n < 0.0f || k < 0.0f) {
+  if (std::isnan(n) || std::isnan(k) || n != (int)n || k != (int)k || n < 0.0f || k < 0.0f) {
 
     return new Complex<T>(Complex<T>::Float(NAN));
   }

--- a/poincare/src/power.cpp
+++ b/poincare/src/power.cpp
@@ -3,7 +3,6 @@ extern "C" {
 #include <stdlib.h>
 }
 #include <cmath>
-#include <math.h>
 #include <poincare/power.h>
 #include <poincare/multiplication.h>
 #include <poincare/opposite.h>

--- a/poincare/src/power.cpp
+++ b/poincare/src/power.cpp
@@ -58,7 +58,7 @@ template<typename T> Evaluation<T> * Power::templatedComputeOnComplexMatrixAndCo
     return new Complex<T>(Complex<T>::Float(NAN));
   }
   T power = d->toScalar();
-  if (isnan(power) || isinf(power) || power != (int)power || std::fabs(power) > k_maxNumberOfSteps) {
+  if (std::isnan(power) || std::isinf(power) || power != (int)power || std::fabs(power) > k_maxNumberOfSteps) {
     return new Complex<T>(Complex<T>::Float(NAN));
   }
   if (power < 0) {

--- a/poincare/src/prediction_interval.cpp
+++ b/poincare/src/prediction_interval.cpp
@@ -32,7 +32,7 @@ Evaluation<T> * PredictionInterval::templatedEvaluate(Context& context, AngleUni
   T n = nInput->toScalar();
   delete pInput;
   delete nInput;
-  if (isnan(p) || isnan(n) || n != (int)n || n < 0 || p < 0 || p > 1) {
+  if (std::isnan(p) || std::isnan(n) || n != (int)n || n < 0 || p < 0 || p > 1) {
     return new Complex<T>(Complex<T>::Float(NAN));
   }
   Complex<T> operands[2];

--- a/poincare/src/round.cpp
+++ b/poincare/src/round.cpp
@@ -32,7 +32,7 @@ Evaluation<T> * Round::templatedEvaluate(Context& context, AngleUnit angleUnit) 
   T f2 = f2Entry->toScalar();
   delete f1Entry;
   delete f2Entry;
-  if (isnan(f2) || f2 != (int)f2) {
+  if (std::isnan(f2) || f2 != (int)f2) {
     return new Complex<T>(Complex<T>::Float(NAN));
   }
   T err = std::pow(10, std::floor(f2));

--- a/poincare/src/sequence.cpp
+++ b/poincare/src/sequence.cpp
@@ -34,7 +34,7 @@ Evaluation<T> * Sequence::templatedEvaluate(Context& context, AngleUnit angleUni
   T end = bInput->toScalar();
   delete aInput;
   delete bInput;
-  if (isnan(start) || isnan(end) || start != (int)start || end != (int)end || end - start > k_maxNumberOfSteps) {
+  if (std::isnan(start) || std::isnan(end) || start != (int)start || end != (int)end || end - start > k_maxNumberOfSteps) {
     return new Complex<T>(Complex<T>::Float(NAN));
   }
   VariableContext<T> nContext = VariableContext<T>('n', &context);

--- a/poincare/src/tangent.cpp
+++ b/poincare/src/tangent.cpp
@@ -32,7 +32,7 @@ Expression::Type Tangent::type() const {
 template<typename T>
 Complex<T> Tangent::templatedComputeComplex(const Complex<T> c, AngleUnit angleUnit) const {
   Complex<T> result = Fraction::compute(Sine::compute(c, angleUnit), Cosine::compute(c, angleUnit));
-  if (!isnan(result.a()) && !isnan(result.b())) {
+  if (!std::isnan(result.a()) && !std::isnan(result.b())) {
     return result;
   }
   Complex<T> tanh = HyperbolicTangent::compute(Multiplication::compute(Complex<T>::Cartesian(0, -1), c));

--- a/poincare/src/variable_context.cpp
+++ b/poincare/src/variable_context.cpp
@@ -1,9 +1,7 @@
 #include <poincare/variable_context.h>
 #include <poincare/preferences.h>
 #include <assert.h>
-extern "C" {
-#include <math.h>
-}
+#include <cmath>
 
 namespace Poincare {
 


### PR DESCRIPTION
By delegating all of the math function to the builtin ones, we enable things like constant propagation through math functions, but the compiler will still fallback to the usual c function.  This fixes #115 and saves about 1560 bytes on my device build.