### PR TITLE
Fix #108 and #109 storing expressions containing variables

### DIFF
--- a/poincare/src/store.cpp
+++ b/poincare/src/store.cpp
@@ -75,7 +75,9 @@ ExpressionLayout * Store::privateCreateLayout(FloatDisplayMode floatDisplayMode,
 
 template<typename T>
 Evaluation<T> * Store::templatedEvaluate(Context& context, AngleUnit angleUnit) const {
-  context.setExpressionForSymbolName(m_value, m_symbol);
+  Evaluation<T> * valueEvaluation = m_value->evaluate<T>(context, angleUnit);
+  context.setExpressionForSymbolName(valueEvaluation, m_symbol);
+  delete valueEvaluation;
   if (context.expressionForSymbol(m_symbol) != nullptr) {
     return context.expressionForSymbol(m_symbol)->evaluate<T>(context, angleUnit);
   }


### PR DESCRIPTION
When m_value was passed to setExpressionForSymbolName directly, and the m_symbol existed in the global context, it ended up evaluating the expression relative to the global context instead of the current context.