### PR TITLE
Improve the [x,n,t] key.

### DIFF
--- a/apps/graph/app.cpp
+++ b/apps/graph/app.cpp
@@ -86,4 +86,8 @@ Context * App::localContext() {
   return TextFieldDelegateApp::localContext();
 }
 
+const char * App::XNT() {
+  return "x";
+}
+
 }

--- a/apps/graph/app.h
+++ b/apps/graph/app.h
@@ -38,6 +38,7 @@ public:
    * use a temporary local context (on the stack). That way, we avoid keeping
    * weird x values after drawing curves or displaying the value table. */
   Poincare::Context * localContext() override;
+  const char * XNT() override;
 private:
   App(Container * container, Snapshot * snapshot);
   Poincare::VariableContext<float> m_xContext;

--- a/apps/shared/text_field_delegate_app.cpp
+++ b/apps/shared/text_field_delegate_app.cpp
@@ -22,7 +22,7 @@ AppsContainer * TextFieldDelegateApp::container() {
 }
 
 const char * TextFieldDelegateApp::XNT() {
-  return "x";
+  return "X";
 }
 
 const char * TextFieldDelegateApp::privateXNT(TextField * textField) {

--- a/apps/shared/text_field_delegate_app.h
+++ b/apps/shared/text_field_delegate_app.h
@@ -21,7 +21,7 @@ public:
 protected:
   TextFieldDelegateApp(Container * container, Snapshot * snapshot, ViewController * rootViewController);
 private:
-  bool cursorInToken(TextField * textField, const char * token);
+  const char * privateXNT(TextField * textField);
 };
 
 }


### PR DESCRIPTION
Inside the first argument of `diff` or `int`, `x,n,t` should type `x`.
Inside the first argument of `product` or `sum`, `x,n,t` should type `n`.
Otherwise, fallback to `x` in the graph app, `n` in the sequence app, and `X` elsewhere since `x` would be useless.