### PR TITLE
[liba] Optimize int_fast_t typedefs for arm.

### DIFF
--- a/liba/include/stdint.h
+++ b/liba/include/stdint.h
@@ -14,13 +14,13 @@ typedef signed long long int64_t;
 typedef unsigned int uintptr_t;
 typedef signed int intptr_t;
 
-typedef uint8_t uint_fast8_t;
-typedef uint16_t uint_fast16_t;
+typedef uint32_t uint_fast8_t;
+typedef uint32_t uint_fast16_t;
 typedef uint32_t uint_fast32_t;
 typedef uint64_t uint_fast64_t;
 
-typedef int8_t int_fast8_t;
-typedef int16_t int_fast16_t;
+typedef int32_t int_fast8_t;
+typedef int32_t int_fast16_t;
 typedef int32_t int_fast32_t;
 typedef int64_t int_fast64_t;
 


### PR DESCRIPTION
Saves a handful of bytes.