### PR TITLE
Numerical bases support

### DIFF
--- a/poincare/Makefile
+++ b/poincare/Makefile
@@ -58,6 +58,7 @@ objs += $(addprefix poincare/src/,\
   matrix.o\
   multiplication.o\
   naperian_logarithm.o\
+  to_base.o\
   nth_root.o\
   opposite.o\
   parenthesis.o\
@@ -142,6 +143,7 @@ tests += $(addprefix poincare/test/,\
   subtraction.cpp\
   symbol.cpp\
   store.cpp\
+  to_base.cpp\
   trigo.cpp\
   vertical_offset_layout.cpp\
 )

--- a/poincare/include/poincare.h
+++ b/poincare/include/poincare.h
@@ -52,6 +52,7 @@
 #include <poincare/multiplication.h>
 #include <poincare/naperian_logarithm.h>
 #include <poincare/nth_root.h>
+#include <poincare/to_base.h>
 #include <poincare/opposite.h>
 #include <poincare/parenthesis.h>
 #include <poincare/permute_coefficient.h>

--- a/poincare/include/poincare/expression.h
+++ b/poincare/include/poincare/expression.h
@@ -58,6 +58,7 @@ class Expression {
   friend class MatrixTrace;
   friend class MatrixTranspose;
   friend class NaperianLogarithm;
+  friend class ToBase;
   friend class NthRoot;
   friend class Opposite;
   friend class Parenthesis;
@@ -123,6 +124,7 @@ public:
     Logarithm,
     MatrixTrace,
     NaperianLogarithm,
+    ToBase,
     NthRoot,
     Opposite,
     Parenthesis,

--- a/poincare/include/poincare/integer.h
+++ b/poincare/include/poincare/integer.h
@@ -22,14 +22,15 @@ public:
   typedef uint64_t double_native_uint_t;
 
   // FIXME: This constructor should be constexpr
-  Integer(native_int_t i = 0) :
+  Integer(native_int_t i = 0, int base = 10) :
     m_digit(i>0 ? i : -i),
     m_numberOfDigits(1),
-    m_negative(i<0)
+    m_negative(i<0),
+    m_base(base)
   {
   }
-  Integer(double_native_int_t i);
-  Integer(const char * digits, bool negative = false); // Digits are NOT NULL-terminated
+  Integer(double_native_int_t i, int base = 10);
+  Integer(const char * digits, bool negative = false, int input_base = 10); // Digits are NOT NULL-terminated
   static Integer exponent(int fractionalPartLength, const char * exponent, int exponentLength, bool exponentNegative);
   static Integer numerator(const char * integralPart, int integralPartLength, const char * fractionalPart, int fractionalPartLength, bool negative, Integer * exponent);
   static Integer denominator(Integer * exponent);
@@ -43,12 +44,14 @@ public:
   // Getter & Setter
   bool isNegative() const { return m_negative; }
   void setNegative(bool negative);
+  void setBase(int base);
   int extractedInt() const { assert(m_numberOfDigits == 1 && m_digit <= k_maxExtractableInteger); return m_negative ? -m_digit : m_digit; }
 
   // Comparison
   static int NaturalOrder(const Integer & i, const Integer & j);
   bool isEqualTo(const Integer & other) const;
   bool isLowerThan(const Integer & other) const;
+  uint16_t numberOfDigits() const { return m_numberOfDigits; }
 
   // Layout
   int writeTextInBuffer(char * buffer, int bufferSize) const;
@@ -106,6 +109,7 @@ private:
   };
   uint16_t m_numberOfDigits; // In base native_uint_max
   bool m_negative; // Make sure zero cannot be negative
+  uint8_t m_base; // For display purposes
 
   static_assert(sizeof(native_int_t) <= sizeof(native_uint_t), "native_uint_t should be able to contain native_int_t data");
   static_assert(sizeof(double_native_uint_t) == 2*sizeof(native_uint_t), "double_native_uint_t should be twice the size of native_uint_t");

--- a/poincare/include/poincare/layout_engine.h
+++ b/poincare/include/poincare/layout_engine.h
@@ -16,6 +16,7 @@ public:
   static ExpressionLayout * createParenthesedLayout(ExpressionLayout * layout, bool cloneLayout);
   static ExpressionLayout * createStringLayout(const char * buffer, int bufferSize, KDText::FontSize fontSize = KDText::FontSize::Large);
   static ExpressionLayout * createLogLayout(ExpressionLayout * argument, ExpressionLayout * index);
+  static ExpressionLayout * createBaseLayout(ExpressionLayout * argument, ExpressionLayout * index);
 
   /* Expression to Text */
   static int writeInfixExpressionTextInBuffer(

--- a/poincare/include/poincare/to_base.h
+++ b/poincare/include/poincare/to_base.h
@@ -1,0 +1,33 @@
+#ifndef POINCARE_NUMERICAL_BASE_H
+#define POINCARE_NUMERICAL_BASE_H
+
+#include <poincare/layout_engine.h>
+#include <poincare/static_hierarchy.h>
+#include <poincare/complex.h>
+#include <poincare/approximation_engine.h>
+
+namespace Poincare {
+
+class ToBase : public StaticHierarchy<2> {
+public:
+  using StaticHierarchy<2>::StaticHierarchy;
+  Type type() const override;
+  Expression * clone() const override;
+  int polynomialDegree(char symbolName) const override;
+private:
+  /* Simplification */
+  Expression * shallowReduce(Context& context, AngleUnit angleUnit) override;
+  /* Layout */
+  ExpressionLayout * privateCreateLayout(PrintFloat::Mode floatDisplayMode, ComplexFormat complexFormat) const override;
+  int writeTextInBuffer(char * buffer, int bufferSize, int numberOfSignificantDigits = PrintFloat::k_numberOfStoredSignificantDigits) const override;
+  /* Evaluation */
+  template<typename T> static Complex<T> computeOnComplex(const Complex<T> c, AngleUnit angleUnit);
+  Expression * privateApproximate(SinglePrecision p, Context& context, AngleUnit angleUnit) const override { return ApproximationEngine::map<float>(this, context, angleUnit, computeOnComplex<float>); }
+  Expression * privateApproximate(DoublePrecision p, Context& context, AngleUnit angleUnit) const override { return ApproximationEngine::map<double>(this, context, angleUnit, computeOnComplex<double>); }
+  template<typename T> Complex<T> * templatedApproximate(Context& context, AngleUnit angleUnit) const;
+};
+
+}
+
+#endif
+

--- a/poincare/src/expression_lexer.l
+++ b/poincare/src/expression_lexer.l
@@ -83,6 +83,7 @@ using namespace Poincare;
    * starting with \x. */
 
 [0-9]+ { poincare_expression_yylval.string.address = yytext; poincare_expression_yylval.string.length = yyleng; return DIGITS; }
+[0-9a-z]+:[0-9]+ { poincare_expression_yylval.string.address = yytext; poincare_expression_yylval.string.length = yyleng; return RADIX_DIGITS; }
 [A-Zxn] { poincare_expression_yylval.character = yytext[0]; return SYMBOL; }
 M[0-9] { poincare_expression_yylval.character = Symbol::matrixSymbol(yytext[1]); return SYMBOL; }
 u\(n\) { poincare_expression_yylval.character = Symbol::SpecialSymbols::un; return SYMBOL; }
@@ -161,6 +162,7 @@ inf { poincare_expression_yylval.expression = new Undefined(); return UNDEFINED;
 \} { return RIGHT_BRACE; }
 \[ { return LEFT_BRACKET; }
 \] { return RIGHT_BRACKET; }
+: { return COLON; }
 \, { return COMMA; }
 \. { return DOT; }
 \_ { return UNDERSCORE; }

--- a/poincare/src/layout_engine.cpp
+++ b/poincare/src/layout_engine.cpp
@@ -80,6 +80,13 @@ ExpressionLayout * LayoutEngine::createLogLayout(ExpressionLayout * argument, Ex
   return resultLayout;
 }
 
+ExpressionLayout * LayoutEngine::createBaseLayout(ExpressionLayout * argument, ExpressionLayout * index) {
+  HorizontalLayout * resultLayout = static_cast<HorizontalLayout *>(argument);
+  VerticalOffsetLayout * offsetLayout = new VerticalOffsetLayout(index, VerticalOffsetLayout::Type::Subscript, false);
+  resultLayout->addChildAtIndex(offsetLayout, resultLayout->numberOfChildren());
+  return resultLayout;
+}
+
 int LayoutEngine::writeInfixExpressionTextInBuffer(const Expression * expression, char * buffer, int bufferSize, int numberOfDigits, const char * operatorName) {
   return writeInfixExpressionOrExpressionLayoutTextInBuffer(expression, nullptr, buffer, bufferSize, numberOfDigits, operatorName, 0, -1, [](const char * operatorName) { return true; });
 }

--- a/poincare/src/to_base.cpp
+++ b/poincare/src/to_base.cpp
@@ -1,0 +1,82 @@
+#include <poincare/to_base.h>
+#include <ion.h>
+#include <poincare/complex.h>
+#include <poincare/undefined.h>
+#include <poincare/rational.h>
+#include "layout/char_layout.h"
+#include "layout/horizontal_layout.h"
+
+extern "C" {
+#include <assert.h>
+}
+#include <cmath>
+
+namespace Poincare {
+
+Expression::Type ToBase::type() const {
+  return Type::ToBase;
+}
+
+Expression * ToBase::clone() const {
+  ToBase * a = new ToBase(m_operands, true);
+  return a;
+}
+
+int ToBase::polynomialDegree(char symbolName) const {
+  return -1;
+}
+
+Expression * ToBase::shallowReduce(Context& context, AngleUnit angleUnit) {
+  Expression * e = Expression::shallowReduce(context, angleUnit);
+  if (e != this) {
+    return e;
+  }
+  Expression * op0 = editableOperand(0);
+  Expression * op1 = editableOperand(1);
+  if (op0->type() != Type::Rational || op1->type() != Type::Rational) {
+    return replaceWith(new Undefined(), true);
+  }
+  Rational * r0 = static_cast<Rational *>(op0);
+  Rational * r1 = static_cast<Rational *>(op1);
+
+  // Grab base
+  Integer intBase = r1->numerator();
+  if (!r0->denominator().isOne() || !r1->denominator().isOne() || intBase.isLowerThan(Integer(2)) || Integer(36).isLowerThan(intBase)) {
+    return replaceWith(new Undefined(), true);
+  }
+  int base;
+  for (base = 1; !intBase.isEqualTo(Integer(base)); base++);
+
+  Integer newNumerator(r0->numerator());
+  newNumerator.setBase(base);
+  return replaceWith(new Rational(newNumerator), true);
+}
+
+ExpressionLayout * ToBase::privateCreateLayout(PrintFloat::Mode floatDisplayMode, ComplexFormat complexFormat) const {
+  assert(floatDisplayMode != PrintFloat::Mode::Default);
+  assert(complexFormat != ComplexFormat::Default);
+  HorizontalLayout * result = new HorizontalLayout();
+  result->addOrMergeChildAtIndex(operand(0)->createLayout(floatDisplayMode, complexFormat), 0, false);
+  result->addChildAtIndex(new CharLayout(Ion::Charset::Sto), result->numberOfChildren());
+  result->addChildAtIndex(new CharLayout(':'), result->numberOfChildren());
+  result->addOrMergeChildAtIndex(operand(1)->createLayout(floatDisplayMode, complexFormat), result->numberOfChildren(), false);
+  return result;
+}
+
+int ToBase::writeTextInBuffer(char * buffer, int bufferSize, int numberOfSignificantDigits) const {
+  int size = operand(0)->writeTextInBuffer(buffer, bufferSize, numberOfSignificantDigits);
+  if (size + 5 > bufferSize) {
+    return size;
+  }
+  buffer[size++] = Ion::Charset::Sto;
+  buffer[size++] = ':';
+  return size+operand(1)->writeTextInBuffer(buffer+size, bufferSize-size, numberOfSignificantDigits);
+}
+
+template<typename T>
+Complex<T> ToBase::computeOnComplex(const Complex<T> c, AngleUnit angleUnit) {
+  return c;
+}
+
+}
+

--- a/poincare/test/integer.cpp
+++ b/poincare/test/integer.cpp
@@ -10,8 +10,12 @@ QUIZ_CASE(poincare_integer) {
   assert(!Integer("-123").isEqualTo(Integer(123)));
   assert(Integer("-123").isEqualTo(Integer(-123)));
   assert(Integer((int64_t)1234567891011121314).isEqualTo(Integer((int64_t)1234567891011121314)));
-  //FIXME: assert(Integer("0x2BABE") == Integer(178878));
-  //FIXME: assert(Integer("0b1011") == Integer(11));
+  // Bases
+  assert(Integer("2babe", false, 16).isEqualTo(Integer(178878)));
+  assert(Integer("1011", false, 2).isEqualTo(Integer(11)));
+  assert(Integer(123).isEqualTo(Integer("123", false, 10)));
+  assert(Integer(123).isEqualTo(Integer("7b", false, 16)));
+  assert(Integer(123).isEqualTo(Integer("1111011", false, 2)));
 }
 
 QUIZ_CASE(poincare_integer_compare) {

--- a/poincare/test/to_base.cpp
+++ b/poincare/test/to_base.cpp
@@ -1,0 +1,17 @@
+#include <quiz.h>
+#include <poincare.h>
+#include <ion.h>
+#include <assert.h>
+#include <cmath>
+#include "helper.h"
+
+using namespace Poincare;
+
+QUIZ_CASE(poincare_tobase_simplify) {
+  assert_parsed_expression_simplify_to("123>:10", "123");
+  assert_parsed_expression_simplify_to("123>:2", "1111011:2");
+  assert_parsed_expression_simplify_to("123>:8", "173:8");
+  assert_parsed_expression_simplify_to("123>:16", "7b:16");
+  assert_parsed_expression_simplify_to("123>:3", "11120:3");
+  assert_parsed_expression_simplify_to("123>:32", "3r:32)");
+}


### PR DESCRIPTION
This fixes in part #133 by providing a mechanism to input constant numbers in hexadecimal, octal and binary (`hex(n)`, `oct(n)` and `bin(n)`).

These pseudo-functions are handled inside the lexer and they can't be used to output numbers in other bases. Implementing that will require deeper modifications to the code (I tried, but I got so confused I gave up...).

Translations in languages other than English and French are missing.