### PR TITLE
Correct wrong output of python complex object.

### DIFF
--- a/apps/code/executor_controller.cpp
+++ b/apps/code/executor_controller.cpp
@@ -39,7 +39,7 @@ static const ExecutorController::ContentView * sCurrentView = nullptr;
 extern "C"
 void mp_hal_stdout_tx_strn_cooked(const char * str, size_t len) {
   assert(sCurrentView != nullptr);
-  sCurrentView->print(str);
+  sCurrentView->print(str, len);
 }
 
 ExecutorController::ContentView::ContentView(Program * program) :
@@ -63,9 +63,9 @@ void ExecutorController::ContentView::drawRect(KDContext * ctx, KDRect rect) con
   sCurrentView = nullptr;
 }
 
-void ExecutorController::ContentView::print(const char * str) const {
+void ExecutorController::ContentView::print(const char * str, int len) const {
   KDContext * ctx = KDIonContext::sharedContext();
-  m_printLocation = ctx->drawString(str, m_printLocation);
+  m_printLocation = ctx->drawString(str, m_printLocation, KDText::FontSize::Large, KDColorBlack, KDColorWhite, len);
   if (bounds().height() < m_printLocation.y()) {
     clearScreen(ctx);
     m_printLocation = KDPoint(m_printLocation.x(), 0);

--- a/apps/code/executor_controller.h
+++ b/apps/code/executor_controller.h
@@ -15,7 +15,7 @@ public:
   public:
     ContentView(Program * program);
     void drawRect(KDContext * ctx, KDRect rect) const override;
-    void print(const char * str) const;
+    void print(const char * str, int len) const;
   private:
     void runPython() const;
     void clearScreen(KDContext * ctx) const;
@@ -29,4 +29,3 @@ private:
 }
 
 #endif
-


### PR DESCRIPTION
For example "print(complex(1,1))" was "(%s1+1j)" instead of "(1+1j)"