### PR TITLE
Use container-based Travis environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,13 @@
 language: cpp
-sudo: required
+
+addons:
+  apt:
+    sources:
+    - sourceline: 'ppa:team-gcc-arm-embedded/ppa'
+    packages:
+    - gcc-arm-embedded
+    - libfltk1.3-dev
+
 matrix:
   include:
     - compiler: gcc
@@ -10,9 +18,6 @@ matrix:
       env: PLATFORM=blackbox TOOLCHAIN=host-clang EXT=bin QUIZ_USE_CONSOLE=1
 
 os: linux
-install:
-- if [ "$PLATFORM" = "device" ]; then wget https://developer.arm.com/-/media/Files/downloads/gnu-rm/6-2017q2/gcc-arm-none-eabi-6-2017-q2-update-linux.tar.bz2 && tar xfj gcc-arm-none-eabi-6-2017-q2-update-linux.tar.bz2 && export PATH=gcc-arm-none-eabi-6-2017-q2-update/bin:$PATH; fi
-- if [ "$PLATFORM" = "simulator" ]; then sudo apt-get install libfltk1.3-dev; fi
 script:
 - make clean && make app.$EXT test.$EXT
 - if [ "$PLATFORM" = "blackbox" ]; then ./test.$EXT; fi


### PR DESCRIPTION
We should be able to use a container-based Travis environment.
Faster boot times, no dependency on developer.arm.com being online.