### PR TITLE
[settings] allow left event to pop out of the lang controller (fix #180)

### DIFF
--- a/apps/settings/language_controller.cpp
+++ b/apps/settings/language_controller.cpp
@@ -3,7 +3,7 @@
 namespace Settings {
 
 bool LanguageController::handleEvent(Ion::Events::Event event) {
-  if (Shared::LanguageController::handleEvent(event)) {
+  if (Shared::LanguageController::handleEvent(event) || event == Ion::Events::Left) {
     static_cast<StackViewController *>(parentResponder())->pop();
     return true;
   }


### PR DESCRIPTION
The condition check is done last since the event could be handled by the deeper implementation (shared language controller) already.