### PR TITLE
Fix simulator compile with gcc.

### DIFF
--- a/apps/probability/calculation_controller.cpp
+++ b/apps/probability/calculation_controller.cpp
@@ -11,6 +11,8 @@
 
 using namespace Poincare;
 using namespace Shared;
+using std::isinf;
+using std::isnan;
 
 namespace Probability {
 

--- a/apps/probability/law/binomial_law.cpp
+++ b/apps/probability/law/binomial_law.cpp
@@ -2,6 +2,9 @@
 #include <assert.h>
 #include <cmath>
 
+using std::isinf;
+using std::isnan;
+
 namespace Probability {
 
 BinomialLaw::BinomialLaw() :

--- a/apps/probability/law/exponential_law.cpp
+++ b/apps/probability/law/exponential_law.cpp
@@ -5,6 +5,8 @@
 #include <ion.h>
 
 namespace Probability {
+using std::isinf;
+using std::isnan;
 
 ExponentialLaw::ExponentialLaw() :
   OneParameterLaw(1.0f)

--- a/apps/probability/law/law.cpp
+++ b/apps/probability/law/law.cpp
@@ -2,6 +2,9 @@
 #include <cmath>
 #include <float.h>
 
+using std::isinf;
+using std::isnan;
+
 namespace Probability {
 
 Law::Law() :

--- a/apps/probability/law/normal_law.cpp
+++ b/apps/probability/law/normal_law.cpp
@@ -4,6 +4,9 @@
 #include <float.h>
 #include <ion.h>
 
+using std::isinf;
+using std::isnan;
+
 namespace Probability {
 
 NormalLaw::NormalLaw() :

--- a/apps/regression/go_to_parameter_controller.cpp
+++ b/apps/regression/go_to_parameter_controller.cpp
@@ -7,6 +7,8 @@
 
 using namespace Shared;
 using namespace Poincare;
+using std::isinf;
+using std::isnan;
 
 namespace Regression {
 

--- a/apps/regression/graph_controller.cpp
+++ b/apps/regression/graph_controller.cpp
@@ -4,6 +4,8 @@
 
 using namespace Poincare;
 using namespace Shared;
+using std::isinf;
+using std::isnan;
 
 namespace Regression {
 

--- a/apps/sequence/graph/curve_view_range.cpp
+++ b/apps/sequence/graph/curve_view_range.cpp
@@ -5,6 +5,8 @@
 
 using namespace Shared;
 using namespace Poincare;
+using std::isinf;
+using std::isnan;
 
 namespace Sequence {
 

--- a/apps/sequence/graph/graph_controller.cpp
+++ b/apps/sequence/graph/graph_controller.cpp
@@ -3,6 +3,8 @@
 
 using namespace Shared;
 using namespace Poincare;
+using std::isinf;
+using std::isnan;
 
 namespace Sequence {
 

--- a/apps/sequence/graph/graph_view.cpp
+++ b/apps/sequence/graph/graph_view.cpp
@@ -2,6 +2,8 @@
 #include <cmath>
 
 using namespace Shared;
+using std::isinf;
+using std::isnan;
 
 namespace Sequence {
 

--- a/apps/shared/curve_view.cpp
+++ b/apps/shared/curve_view.cpp
@@ -6,6 +6,8 @@
 #include <float.h>
 
 using namespace Poincare;
+using std::isinf;
+using std::isnan;
 
 namespace Shared {
 

--- a/apps/shared/function_go_to_parameter_controller.cpp
+++ b/apps/shared/function_go_to_parameter_controller.cpp
@@ -3,6 +3,9 @@
 #include <assert.h>
 #include <cmath>
 
+using std::isinf;
+using std::isnan;
+
 namespace Shared {
 
 FunctionGoToParameterController::FunctionGoToParameterController(Responder * parentResponder, InteractiveCurveViewRange * graphRange, CurveViewCursor * cursor, I18n::Message symbol) :

--- a/apps/shared/interactive_curve_view_range.cpp
+++ b/apps/shared/interactive_curve_view_range.cpp
@@ -6,6 +6,8 @@
 #include <assert.h>
 
 using namespace Poincare;
+using std::isinf;
+using std::isnan;
 
 namespace Shared {
 

--- a/apps/shared/interactive_curve_view_range_delegate.cpp
+++ b/apps/shared/interactive_curve_view_range_delegate.cpp
@@ -4,6 +4,9 @@
 #include <float.h>
 #include <math.h>
 
+using std::isinf;
+using std::isnan;
+
 namespace Shared {
 
 

--- a/apps/shared/memoized_curve_view_range.cpp
+++ b/apps/shared/memoized_curve_view_range.cpp
@@ -4,6 +4,9 @@
 #include <assert.h>
 #include <ion.h>
 
+using std::isinf;
+using std::isnan;
+
 namespace Shared {
 
 MemoizedCurveViewRange::MemoizedCurveViewRange() :

--- a/poincare/include/poincare/binomial_coefficient.h
+++ b/poincare/include/poincare/binomial_coefficient.h
@@ -2,6 +2,10 @@
 #define POINCARE_BINOMIAL_COEFFICIENT_H
 
 #include <poincare/function.h>
+#include <cmath>
+
+using std::isinf;
+using std::isnan;
 
 namespace Poincare {
 

--- a/poincare/include/poincare/confidence_interval.h
+++ b/poincare/include/poincare/confidence_interval.h
@@ -2,6 +2,10 @@
 #define POINCARE_CONFIDENCE_INTERVAL_H
 
 #include <poincare/function.h>
+#include <cmath>
+
+using std::isinf;
+using std::isnan;
 
 namespace Poincare {
 

--- a/poincare/include/poincare/derivative.h
+++ b/poincare/include/poincare/derivative.h
@@ -1,8 +1,12 @@
 #ifndef POINCARE_DERIVATIVE_H
 #define POINCARE_DERIVATIVE_H
 
+#include <cmath>
 #include <poincare/function.h>
 #include <poincare/variable_context.h>
+
+using std::isinf;
+using std::isnan;
 
 namespace Poincare {
 

--- a/poincare/include/poincare/division_quotient.h
+++ b/poincare/include/poincare/division_quotient.h
@@ -1,7 +1,11 @@
 #ifndef POINCARE_DIVISION_QUOTIENT_H
 #define POINCARE_DIVISION_QUOTIENT_H
 
+#include <cmath>
 #include <poincare/function.h>
+
+using std::isinf;
+using std::isnan;
 
 namespace Poincare {
 

--- a/poincare/include/poincare/division_remainder.h
+++ b/poincare/include/poincare/division_remainder.h
@@ -1,7 +1,11 @@
 #ifndef POINCARE_DIVISION_REMAINDER_H
 #define POINCARE_DIVISION_REMAINDER_H
 
+#include <cmath>
 #include <poincare/function.h>
+
+using std::isinf;
+using std::isnan;
 
 namespace Poincare {
 

--- a/poincare/include/poincare/factorial.h
+++ b/poincare/include/poincare/factorial.h
@@ -1,7 +1,11 @@
 #ifndef POINCARE_FACTORIAL_H
 #define POINCARE_FACTORIAL_H
 
+#include <cmath>
 #include <poincare/function.h>
+
+using std::isinf;
+using std::isnan;
 
 namespace Poincare {
 

--- a/poincare/include/poincare/least_common_multiple.h
+++ b/poincare/include/poincare/least_common_multiple.h
@@ -1,7 +1,11 @@
 #ifndef POINCARE_LEAST_COMMON_MULTIPLE_H
 #define POINCARE_LEAST_COMMON_MULTIPLE_H
 
+#include <cmath>
 #include <poincare/function.h>
+
+using std::isinf;
+using std::isnan;
 
 namespace Poincare {
 

--- a/poincare/src/complex.cpp
+++ b/poincare/src/complex.cpp
@@ -12,6 +12,9 @@ extern "C" {
 #include "layout/baseline_relative_layout.h"
 #include <ion.h>
 
+using std::isinf;
+using std::isnan;
+
 namespace Poincare {
 
 

--- a/poincare/src/expression_lexer.l
+++ b/poincare/src/expression_lexer.l
@@ -39,9 +39,12 @@
  * compatibility with MacOS's default version (2.3) instead of using the code
  * requires feature. */
 #include <math.h>
+#include <cmath>
 #include <poincare.h>
 #include "expression_parser.hpp"
 using namespace Poincare;
+using std::isinf;
+using std::isnan;
 
 /* Flex has provision for reading files. We'll never use this, so we're defining
  * YY_INPUT which effectively disables taking input from a file. */

--- a/poincare/src/great_common_divisor.cpp
+++ b/poincare/src/great_common_divisor.cpp
@@ -6,6 +6,9 @@ extern "C" {
 }
 #include <cmath>
 
+using std::isinf;
+using std::isnan;
+
 namespace Poincare {
 
 GreatCommonDivisor::GreatCommonDivisor() :

--- a/poincare/src/integral.cpp
+++ b/poincare/src/integral.cpp
@@ -12,6 +12,9 @@ extern "C" {
 #include "layout/string_layout.h"
 #include "layout/integral_layout.h"
 
+using std::isinf;
+using std::isnan;
+
 namespace Poincare {
 
 Integral::Integral() :

--- a/poincare/src/permute_coefficient.cpp
+++ b/poincare/src/permute_coefficient.cpp
@@ -6,6 +6,9 @@ extern "C" {
 }
 #include <cmath>
 
+using std::isinf;
+using std::isnan;
+
 namespace Poincare {
 
 PermuteCoefficient::PermuteCoefficient() :

--- a/poincare/src/power.cpp
+++ b/poincare/src/power.cpp
@@ -9,6 +9,9 @@ extern "C" {
 #include <poincare/opposite.h>
 #include "layout/baseline_relative_layout.h"
 
+using std::isinf;
+using std::isnan;
+
 namespace Poincare {
 
 Expression::Type Power::type() const {

--- a/poincare/src/prediction_interval.cpp
+++ b/poincare/src/prediction_interval.cpp
@@ -5,6 +5,9 @@ extern "C" {
 }
 #include <cmath>
 
+using std::isinf;
+using std::isnan;
+
 namespace Poincare {
 
 PredictionInterval::PredictionInterval() :

--- a/poincare/src/round.cpp
+++ b/poincare/src/round.cpp
@@ -5,6 +5,9 @@ extern "C" {
 }
 #include <cmath>
 
+using std::isinf;
+using std::isnan;
+
 namespace Poincare {
 
 Round::Round() :

--- a/poincare/src/sequence.cpp
+++ b/poincare/src/sequence.cpp
@@ -10,6 +10,9 @@ extern "C" {
 }
 #include <cmath>
 
+using std::isinf;
+using std::isnan;
+
 namespace Poincare {
 
 Sequence::Sequence(const char * name) :

--- a/poincare/src/tangent.cpp
+++ b/poincare/src/tangent.cpp
@@ -10,6 +10,9 @@ extern "C" {
 }
 #include <cmath>
 
+using std::isinf;
+using std::isnan;
+
 namespace Poincare {
 
 Tangent::Tangent() :


### PR DESCRIPTION
Building with `make PLATFORM=simulator CXX=g++ CC=gcc LD=g++`
would fail with errors about isnan and isinf missing.  They're
in the std namespace.

So added the relevant "using" lines for each function.

(Note: this would be an alternative to some part of #115)