### PR TITLE
Switching from horizontal to vertical scrolling on the main menu

### DIFF
--- a/apps/home/app_cell.cpp
+++ b/apps/home/app_cell.cpp
@@ -13,7 +13,7 @@ AppCell::AppCell() :
 
 void AppCell::drawRect(KDContext * ctx, KDRect rect) const {
   KDSize nameSize = m_nameView.minimalSizeForOptimalDisplay();
-  ctx->fillRect(KDRect(0,  bounds().height()-nameSize.height() - 2*k_nameHeightMargin, bounds().width(), nameSize.height()+2*k_nameHeightMargin), KDColorWhite);
+  ctx->fillRect(KDRect(0,  k_iconHeight+42-nameSize.height() - 2*k_nameHeightMargin, bounds().width(), k_iconHeight+42+2*k_nameHeightMargin), KDColorWhite);
 }
 
 int AppCell::numberOfSubviews() const {
@@ -28,7 +28,7 @@ View * AppCell::subviewAtIndex(int index) {
 void AppCell::layoutSubviews() {
   m_iconView.setFrame(KDRect((bounds().width()-k_iconWidth)/2, k_iconMargin, k_iconWidth,k_iconHeight));
   KDSize nameSize = m_nameView.minimalSizeForOptimalDisplay();
-  m_nameView.setFrame(KDRect((bounds().width()-nameSize.width())/2-k_nameWidthMargin, bounds().height()-nameSize.height() - 2*k_nameHeightMargin, nameSize.width()+2*k_nameWidthMargin, nameSize.height()+2*k_nameHeightMargin));
+  m_nameView.setFrame(KDRect((bounds().width()-nameSize.width())/2-k_nameWidthMargin, k_iconHeight+42-nameSize.height() - 2*k_nameHeightMargin, nameSize.width()+2*k_nameWidthMargin, nameSize.height()+2*k_nameHeightMargin));
 }
 
 void AppCell::setAppDescriptor(::App::Descriptor * descriptor) {

--- a/apps/home/controller.cpp
+++ b/apps/home/controller.cpp
@@ -22,7 +22,7 @@ void Controller::ContentView::drawRect(KDContext * ctx, KDRect rect) const {
 
 void Controller::ContentView::reloadBottomRightCorner(SimpleTableViewDataSource * dataSource) {
   /* We mark the bottom right corner (where an empty space can be) as dirty. */
-  markRectAsDirty(KDRect(dataSource->cellWidth()*2, dataSource->cellHeight(), dataSource->cellWidth(), dataSource->cellHeight()));
+  markRectAsDirty(KDRect(dataSource->cellWidth(), dataSource->cellHeight(), dataSource->cellWidth()*2, dataSource->cellHeight()));
 }
 
 int Controller::ContentView::numberOfSubviews() const {
@@ -117,15 +117,15 @@ int Controller::numberOfIcons() {
 }
 
 void Controller::tableViewDidChangeSelection(SelectableTableView * t, int previousSelectedCellX, int previousSelectedCellY) {
-  /* If the number of apps (including home) is odd, when we display the
-   * rightest icon, the icon below is empty. As no icon is thus redrawn on the
+  /* If the number of apps is not a multiple of three, when we display the
+   * bottomest icons, the icon below is empty. As no icon is thus redrawn on the
    * previous one, the cell is not cleaned. We need to redraw a white rect on
    * the cell to hide the dirtyness below. Ideally, we would have redrawn all
    * the background in white and then redraw visible cells. However, the
    * redrawing takes time and is visible at scrolling. Here, we avoid the
    * background complete redrawing but the code is a bit
    * clumsy. */
-  if (m_container->numberOfApps()%2 == 0 && t->selectedColumn() == k_numberOfColumns -1) {
+  if ((m_container->numberOfApps()-1)%3 != 0 && t->selectedRow() == numberOfRows() - 1) {
     m_view.reloadBottomRightCorner(this);
   }
   /* To prevent the selectable table view to select cells that are unvisible,

--- a/apps/home/controller.h
+++ b/apps/home/controller.h
@@ -42,13 +42,12 @@ private:
   };
   AppsContainer * m_container;
   static constexpr KDCoordinate k_sideMargin = 4;
-  static constexpr KDCoordinate k_indicatorThickness = 28;
-  static constexpr KDCoordinate k_indicatorMargin = 116;
-  static constexpr int k_numberOfColumns = 4;
-  static constexpr int k_numberOfApps = 10;
+  static constexpr KDCoordinate k_indicatorThickness = 20;
+  static constexpr KDCoordinate k_indicatorMargin = 14;
+  static constexpr int k_numberOfColumns = 3;
   static constexpr int k_maxNumberOfCells = 16;
-  static constexpr int k_cellHeight = 98;
-  static constexpr int k_cellWidth = 104;
+  static constexpr int k_cellHeight = 111;
+  static constexpr int k_cellWidth = 97;
   ContentView m_view;
   AppCell m_cells[k_maxNumberOfCells];
   SelectableTableViewDataSource * m_selectionDataSource;

--- a/build/config.mak
+++ b/build/config.mak
@@ -6,7 +6,7 @@ DEBUG ?= 0
 EPSILON_VERSION ?= 1.3.0
 EPSILON_ONBOARDING_APP ?= 1
 EPSILON_SOFTWARE_UPDATE_PROMPT ?= 1
-EPSILON_APPS ?= calculation graph sequence settings statistics probability regression code
+EPSILON_APPS ?= calculation graph sequence statistics probability regression code settings
 EPSILON_I18N ?= en fr es de pt
 
 include build/defaults.mak


### PR DESCRIPTION
Once again, it's proof-of-concept time.

The first commit simply adds the variable `EPSILON_APPS` that contains the list of apps to include. It's the bare minimum so that I can make my own apps without polluting `apps/Makefile`.

The second commit switches the main menu from horizontal to vertical scrolling. There are a bunch of reasons for doing that:
- Going above 8 apps makes the home menu go berserk and I couldn't be bothered to fix it ;
- Scrolling down brings 3 new icons whereas scrolling right brings only 2, so it should be more wieldy with large numbers of apps ;
- It acts like a file explorer window and thus the order of apps follows intuitively what's declared inside `EPSILON_APPS`.

I can see a couple of drawbacks:
- Less horizontal space for app labels ;
- Up to 2 empty spaces with a lone icon on the bottom row ;
- We do lose somewhat a bit on the alignment combo (for lack of better words) ;
- Less PlayStation 4-like, more Casio-like ;
- NumWorks would have to touch up a bunch of artwork ;
- Currently, having 6 or less apps does not reclaim the scroll bar space.

I don't actually _expect_ this to be merged, but it's a neat trick nonetheless.