### PR TITLE
A few misc. coverity fixes

### DIFF
--- a/apps/settings/main_controller.cpp
+++ b/apps/settings/main_controller.cpp
@@ -213,9 +213,6 @@ void MainController::willDisplayCellForIndex(HighlightCell * cell, int index) {
     case 1:
       myTextCell->setSubtitle(m_messageTreeModel->children(index)->children((int)Preferences::sharedPreferences()->displayMode())->label());
       break;
-    case 4:
-      myTextCell->setSubtitle(m_messageTreeModel->children(index)->children((int)GlobalPreferences::sharedGlobalPreferences()->language()-1)->label());
-      break;
     default:
       myTextCell->setSubtitle(I18n::Message::Default);
       break;

--- a/poincare/src/matrix.cpp
+++ b/poincare/src/matrix.cpp
@@ -156,9 +156,9 @@ Complex<T> * Matrix::createDeterminant() const {
     /* if the pivot is null, det = 0. */
     if (std::fabs(valuePivot) <= (sizeof(T) == sizeof(float) ? FLT_EPSILON : DBL_EPSILON)) {
       for (int i = 0; i < dim; i++) {
-        free(tempMat[i]);
+        delete[] tempMat[i];
       }
-      free(tempMat);
+      delete[] tempMat;
       return new Complex<T>(Complex<T>::Float(0.0));
     }
     /* Switch rows to have the pivot row as first row */
@@ -221,9 +221,9 @@ Matrix * Matrix::createInverse() const {
     /* if the pivot is null, the matrix in not invertible. */
     if (std::fabs(valuePivot) <= (sizeof(T) == sizeof(float) ? FLT_EPSILON : DBL_EPSILON)) {
       for (int i = 0; i < dim; i++) {
-        free(inv[i]);
+        delete[] inv[i];
       }
-      free(inv);
+      delete[] inv;
       return nullptr;
     }
     /* Switch rows to have the pivot row as first row */


### PR DESCRIPTION
Those are quite minor, so the fixes are trivial, but other (more important) issues exist (for instance [that one](https://scan4.coverity.com/reports.htm#v15949/p12091/fileInstanceId=28662377&defectInstanceId=5676388&mergedDefectId=200502), buffer overflow) but I haven't really looked into them yet.
There was a false-positive, too, involving an out-of-bounds access regarding w_n, but that's fine for now since it's not in use yet (and when it will be, the vector will be correctly sized).