### PR TITLE
[Windows] Let's make the compiler work

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # No objects files.
 *.o
 *.elf
+*.exe
 
 # No dependency files
 *.d

--- a/apps/i18n.py
+++ b/apps/i18n.py
@@ -53,7 +53,7 @@ def parse_files(files):
             data[locale] = {}
         with open(path, "r") as file:
             for line in file:
-                name,definition = split_line(line)
+                name,definition = split_line(line.strip())
                 if locale == "universal":
                     if name in messages:
                         sys.stderr.write("Error: Redefinition of message \"" + name + "\" as universal\n")

--- a/build/platform.device.mak
+++ b/build/platform.device.mak
@@ -2,6 +2,10 @@ TOOLCHAIN ?= arm-gcc
 USE_LIBA = 1
 EXE = elf
 
+ifneq (,$(findstring MSYS_NT,$(shell uname)))
+TOOLCHAIN = mingw
+endif
+
 .PHONY: %_run
 %_run: %.$(EXE)
 	$(GDB) -x gdb_script.gdb $<


### PR DESCRIPTION
Trying to make `make` succeed on Windows.

**New doc:**
```
pacman -S mingw-w64-x86_64-gcc mingw-w64-x86_64-freetype mingw-w64-x86_64-fltk mingw-w64-x86_64-cmake git make bison python2
ln -s /usr/bin/python2.exe /usr/bin/python.exe
export PATH=/mingw64/bin:$PATH
```

Previous commands:
- fixed python 2 (python = python 3)
- missing depedencies (g++)

The patch:
- fixes "\r\n" being wrongly parsed
- adds exe to .gitignore + force LF
- detects MINGW when using MSYS2