### PR TITLE
Enable instruction and data cache

### DIFF
--- a/ion/src/device/device.cpp
+++ b/ion/src/device/device.cpp
@@ -164,6 +164,10 @@ void initClocks() {
    * The spec tells us that at 2.8V and over 90MHz the flash expects 3 WS. */
   FLASH.ACR()->setLATENCY(3);
 
+  /* Set flash instruction and data cache */
+  FLASH.ACR()->setDCEN(true);
+  FLASH.ACR()->setICEN(true);
+
   /* We're using the high-speed internal oscillator as a clock source. It runs
    * at a fixed 16 MHz frequency, but by piping it through the PLL we can derive
    * faster oscillations. Combining default values and a PLLQ of 4 can provide
@@ -229,4 +233,3 @@ void shutdownClocks() {
 
 }
 }
-

--- a/ion/src/device/regs/flash.h
+++ b/ion/src/device/regs/flash.h
@@ -8,6 +8,9 @@ public:
   class ACR : public Register32 {
   public:
     REGS_FIELD(LATENCY, uint8_t, 3, 0);
+    REGS_BOOL_FIELD(PRFTEN, 8);
+    REGS_BOOL_FIELD(ICEN, 9);
+    REGS_BOOL_FIELD(DCEN, 10);
   };
 
   constexpr FLASH() {};


### PR DESCRIPTION
Enabling instruction and data cache speed up the calculator a little bit.

For example, the mandelbrot set in the python application takes 1 minutes 30 seconds to render with this modification, and about 2 minutes without.

This should not raise power consumption  as stated [here](http://www.st.com/content/ccc/resource/technical/document/application_note/13/0a/06/b9/1e/2f/4d/9d/DM00096220.pdf/files/DM00096220.pdf/jcr:content/translations/en.DM00096220.pdf) (but not clearly) or [here](http://www.st.com/content/ccc/resource/technical/document/application_note/77/74/4f/da/9b/9c/43/e7/DM00033348.pdf/files/DM00033348.pdf/jcr:content/translations/en.DM00033348.pdf) (for the F2 family) in the section ART accelerator.

Instruction prefetch may be also enabled, but this can make the power consumption raise by 10%