### PR TITLE
Fix: invalid characters on windows simulator #240

### DIFF
--- a/ion/src/simulator/init.cpp
+++ b/ion/src/simulator/init.cpp
@@ -29,6 +29,10 @@ void init_platform() {
 
   Fl_Window * window = new Fl_Window(screen_width+2*margin, margin+screen_height+margin+keyboard_height+margin);
 
+#if defined(_WIN32) || defined(_WIN64)
+  Fl::set_font(FL_SYMBOL, "Arial Unicode MS");
+#endif
+
   KDColor * pixels = (KDColor *)malloc(Ion::Display::Width*Ion::Display::Height*sizeof(KDColor));
   sFrameBuffer = new KDFrameBuffer(pixels, KDSize(Ion::Display::Width, Ion::Display::Height));
   /*

--- a/ion/src/simulator/keyboard/fltkkbd.cpp
+++ b/ion/src/simulator/keyboard/fltkkbd.cpp
@@ -38,6 +38,9 @@ FltkKbd::FltkKbd(int x, int y, int w, int h) : Fl_Group(x, y, w, h) {
                                  key_width,
                                  key_height,
                                  kCharForKey[k]);
+#if defined(_WIN32) || defined(_WIN64)
+	m_buttons[k]->labelfont(FL_SYMBOL);
+#endif
     if (kCharForKey[k][0] == '\0') {
       m_buttons[k]->deactivate();
     }


### PR DESCRIPTION
Hi all,

A solution to fix #240, is to set font "Arial Unicode MS" for Windows platform. It's because, default Windows Arial is not fully unicode...

ion/src/simulator/init.cpp
Fl::set_font(FL_SYMBOL, "Arial Unicode MS");

ion/src/simulator/keyboard/fltkkbd.cpp
m_buttons[k]->labelfont(FL_SYMBOL);