### PR TITLE
Fix: windows simulator: Assert error apps/i18n.cpp:2437 and Toolbox title "Zoom :" #267

### DIFF
--- a/apps/global_preferences.cpp
+++ b/apps/global_preferences.cpp
@@ -1,6 +1,8 @@
 #include "global_preferences.h"
 
+#if !defined(_WIN32) && !defined(_WIN64)
 static GlobalPreferences s_globalPreferences;
+#endif
 
 GlobalPreferences::GlobalPreferences() :
   m_language(I18n::Language::EN),
@@ -11,6 +13,9 @@ GlobalPreferences::GlobalPreferences() :
 }
 
 GlobalPreferences * GlobalPreferences::sharedGlobalPreferences() {
+#if defined(_WIN32) || defined(_WIN64)
+  static GlobalPreferences s_globalPreferences;
+#endif
   return &s_globalPreferences;
 }
 

--- a/apps/global_preferences.cpp
+++ b/apps/global_preferences.cpp
@@ -1,9 +1,5 @@
 #include "global_preferences.h"
 
-#if !defined(_WIN32) && !defined(_WIN64)
-static GlobalPreferences s_globalPreferences;
-#endif
-
 GlobalPreferences::GlobalPreferences() :
   m_language(I18n::Language::EN),
   m_examMode(ExamMode::Desactivate),
@@ -13,9 +9,7 @@ GlobalPreferences::GlobalPreferences() :
 }
 
 GlobalPreferences * GlobalPreferences::sharedGlobalPreferences() {
-#if defined(_WIN32) || defined(_WIN64)
   static GlobalPreferences s_globalPreferences;
-#endif
   return &s_globalPreferences;
 }
 


### PR DESCRIPTION
Global pref isn't init when the init of MathToolbox:
static GlobalPreferences s_globalPreferences doesn't init on windows platform, move to
static methode sharedGlobalPreferences()