### PR TITLE
It's now possible to type a single quote (enhance #276)

### DIFF
--- a/ion/src/shared/events.cpp
+++ b/ion/src/shared/events.cpp
@@ -67,7 +67,7 @@ static constexpr EventData s_dataForEvent[4*Event::PageSize] = {
 // Shift+Alpha
   U(), U(), U(), U(), U(), U(),
   U(), U(), U(), U(), U(), U(),
-  U(), U(), U(), U(), U(), U(),
+  U(), U(), U(), U(), T("'"), U(),
   T("A"), T("B"), T("C"), T("D"), T("E"), T("F"),
   T("G"), T("H"), T("I"), T("J"), T("K"), T("L"),
   T("M"), T("N"), T("O"), T("P"), T("Q"), U(),


### PR DESCRIPTION
To add single quote, it's possible to change from double quote to single quote for "shift-alpha on toolbox key" event.

But I don't known if we need to add single-quote to the list of UNDEFINED_SYMBOL of epsilon\poincare\src\expression_lexer.l

[a-eg-z;:"_=<>?] { return UNDEFINED_SYMBOL; }
-->
[a-eg-z;:"'_=<>?] { return UNDEFINED_SYMBOL; }

