### PR TITLE
Add option USE_LIBGCC to link agains libgcc instead of liba softfloat implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
 matrix:
   include:
     - env: PLATFORM=device EXT=elf
+    - env: PLATFORM=device EXT=elf USE_LIBGCC=1
     - env: PLATFORM=simulator EXT=elf
     - env: PLATFORM=simulator EXT=elf TOOLCHAIN=host-clang
     - env: PLATFORM=blackbox EXT=bin QUIZ_USE_CONSOLE=1

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ ifndef EXE
   $(error platform.mak should define EXE, the extension for executables)
 endif
 
+USE_LIBGCC ?= 0
+
 HOSTCC = gcc
 HOSTCXX = g++
 
@@ -65,7 +67,11 @@ ifeq ($(USE_LIBA),0)
 include liba/Makefile.bridge
 else
 SFLAGS += -ffreestanding -nostdinc -nostdlib
+ifneq ($(USE_LIBGCC),0)
+include liba/Makefile.libgcc
+else
 include liba/Makefile
+endif
 include libaxx/Makefile
 endif
 include ion/Makefile

--- a/build/toolchain.arm-gcc.mak
+++ b/build/toolchain.arm-gcc.mak
@@ -1,6 +1,6 @@
 CC = arm-none-eabi-gcc
 CXX = arm-none-eabi-g++
-LD = arm-none-eabi-ld.bfd
+LD = arm-none-eabi-gcc
 GDB = arm-none-eabi-gdb
 OBJCOPY = arm-none-eabi-objcopy
 SIZE = arm-none-eabi-size
@@ -8,6 +8,7 @@ ifeq ($(DEBUG),1)
 OPTIM_SFLAGS += -ggdb3
 else
 OPTIM_SFLAGS += -fdata-sections -ffunction-sections
-LDFLAGS = --gc-sections
+LDFLAGS = -Wl,--gc-sections
 endif
 SFLAGS = -mthumb -march=armv7e-m -mfloat-abi=hard -mcpu=cortex-m4 -mfpu=fpv4-sp-d16
+LDFLAGS += ${SFLAGS}

--- a/ion/src/device/boot/Makefile
+++ b/ion/src/device/boot/Makefile
@@ -1,7 +1,7 @@
 objs += $(addprefix ion/src/device/boot/, isr.o rt0.o)
 LDFLAGS += -T ion/src/device/boot/flash.ld
 
-LDFLAGS += -M -Map output.map
+LDFLAGS += -Wl,-M -Wl,-Map=output.map
 products += output.map
 
 .PHONY: %_memory_map

--- a/liba/Makefile.libgcc
+++ b/liba/Makefile.libgcc
@@ -1,0 +1,139 @@
+SFLAGS += -Iliba/include
+
+liba/src/external/sqlite/mem5.o: CFLAGS += -w
+
+objs += $(addprefix liba/src/, \
+  armv7m/setjmp.o \
+  armv7m/longjmp.o \
+  assert.o \
+  bzero.o \
+  ctype.o \
+  errno.o \
+  fpclassify.o \
+  fpclassifyf.o \
+  ieee754.o \
+  malloc.o \
+  memcmp.o \
+  memcpy.o \
+  memmove.o \
+  memset.o \
+  nearbyint.o \
+  nearbyintf.o \
+  strcmp.o \
+  strchr.o \
+  strlcpy.o \
+  strlen.o \
+  external/sqlite/mem5.o \
+)
+
+objs += $(addprefix liba/src/external/openbsd/, \
+  b_exp__D.o \
+  b_log__D.o \
+  b_tgamma.o \
+  e_acosf.o \
+  e_acoshf.o \
+  e_asinf.o \
+  e_atanhf.o \
+  e_atan2.o \
+  e_atan2f.o \
+  e_coshf.o \
+  e_expf.o \
+  e_fmod.o \
+  e_fmodf.o \
+  e_lgammaf_r.o \
+  e_log10f.o \
+  e_log2.o \
+  e_logf.o \
+  e_powf.o \
+  e_rem_pio2f.o \
+  e_scalb.o \
+  e_sinhf.o \
+  e_sqrtf.o \
+  k_cosf.o \
+  k_rem_pio2f.o \
+  k_sinf.o \
+  k_tanf.o \
+  s_asinhf.o\
+  s_atanf.o \
+  s_ceilf.o \
+  s_copysignf.o \
+  s_cosf.o \
+  s_erf.o \
+  s_expm1f.o\
+  s_fabsf.o \
+  s_floorf.o \
+  s_frexpf.o \
+  s_frexp.o \
+  s_log1pf.o \
+  s_logb.o \
+  s_modf.o \
+  s_modff.o \
+  s_rint.o \
+  s_roundf.o \
+  s_scalbnf.o \
+  s_signgam.o \
+  s_sinf.o \
+  s_tanf.o \
+  s_tanhf.o \
+  s_trunc.o \
+  s_truncf.o \
+  w_lgammaf.o \
+)
+
+objs += $(addprefix liba/src/external/openbsd/, \
+  e_acos.o \
+  e_acosh.o \
+  e_asin.o \
+  e_atanh.o \
+  e_cosh.o \
+  e_exp.o \
+  e_lgamma_r.o \
+  e_log.o \
+  e_log10.o \
+  e_pow.o \
+  e_rem_pio2.o \
+  e_sinh.o \
+  e_sqrt.o \
+  k_cos.o \
+  k_rem_pio2.o \
+  k_sin.o \
+  k_tan.o \
+  s_asinh.o \
+  s_atan.o \
+  s_ceil.o \
+  s_copysign.o \
+  s_cos.o \
+  s_expm1.o \
+  s_fabs.o \
+  s_floor.o \
+  s_log1p.o \
+  s_round.o \
+  s_scalbn.o \
+  s_sin.o \
+  s_tan.o \
+  s_tanh.o \
+  w_lgamma.o \
+)
+
+liba/src/external/openbsd/%.o: SFLAGS := -Iliba/src/external/openbsd/include $(SFLAGS)
+liba/src/external/openbsd/%.o: CFLAGS += -w
+
+tests += $(addprefix liba/test/, \
+  aeabi.c \
+  double.c \
+  ieee754.c \
+  long.c \
+  math.c \
+  setjmp.c \
+  stddef.c \
+  stdint.c \
+  strlcpy.c \
+)
+
+# The use of aeabi-rt could be made conditional to an AEABI target.
+# In practice we're always using liba on such a target.
+objs += $(addprefix liba/src/aeabi-rt/, \
+  atexit.o \
+)
+
+LDFLAGS+=-lgcc


### PR DESCRIPTION
This leads to smaller binary size:
 - 631 328 bytes when using liba
 - 628 608 bytes when using libgcc

And also to improved performance, at least in the mandelbrot python script. When using mandelbrot(10), it takes about:
 - 54 seconds with liba
 - 42 seconds with libgcc

There is normally no license problem to link against libgcc : https://www.gnu.org/licenses/gcc-exception-3.1-faq.en.html 