### PR TITLE
Very small feature : In Home application, Home or Back button select Calculation

### DIFF
--- a/apps/home/controller.cpp
+++ b/apps/home/controller.cpp
@@ -51,6 +51,11 @@ bool Controller::handleEvent(Ion::Events::Event event) {
     m_container->switchTo(m_container->appSnapshotAtIndex(m_selectionDataSource->selectedRow()*k_numberOfColumns+m_selectionDataSource->selectedColumn()+1));
     return true;
   }
+
+  if (event == Ion::Events::Home || event == Ion::Events::Back) {
+    return m_view.selectableTableView()->selectCellAtLocation(0,0);
+  } 
+
   return false;
 }
 


### PR DESCRIPTION
Some very minor change, almost futile, to the Home application.

Like in many handheld devices, when in the Home application, if you push the Home (or Back) button, you will select the first page/application. 