### PR TITLE
[poincare] ExpressionArray is now a class, not a method.

### DIFF
--- a/poincare/include/poincare.h
+++ b/poincare/include/poincare.h
@@ -23,6 +23,7 @@
 #include <poincare/division_quotient.h>
 #include <poincare/division_remainder.h>
 #include <poincare/expression.h>
+#include <poincare/expression_array.h>
 #include <poincare/expression_layout.h>
 #include <poincare/factorial.h>
 #include <poincare/floor.h>

--- a/poincare/include/poincare/dynamic_hierarchy.h
+++ b/poincare/include/poincare/dynamic_hierarchy.h
@@ -2,6 +2,7 @@
 #define POINCARE_DYNAMIC_HIERARCHY_H
 
 #include <poincare/expression.h>
+#include <poincare/expression_array.h>
 #include <poincare/rational.h>
 
 namespace Poincare {
@@ -11,7 +12,7 @@ public:
   DynamicHierarchy();
   DynamicHierarchy(const Expression * const * operands, int numberOfOperands, bool cloneOperands = true);
   DynamicHierarchy(const Expression * operand1, const Expression * operand2, bool cloneOperands = true) :
-   DynamicHierarchy(ExpressionArray(operand1, operand2), 2, cloneOperands) {}
+    DynamicHierarchy(ExpressionArray(operand1, operand2).array(), 2, cloneOperands) {}
   ~DynamicHierarchy();
   DynamicHierarchy(const DynamicHierarchy & other) = delete;
   DynamicHierarchy(DynamicHierarchy && other) = delete;

--- a/poincare/include/poincare/expression.h
+++ b/poincare/include/poincare/expression.h
@@ -219,7 +219,6 @@ public:
 protected:
   /* Constructor */
   Expression() : m_parent(nullptr) {}
-  static const Expression * const * ExpressionArray(const Expression * e1, const Expression * e2);
   /* Hierarchy */
   void detachOperandAtIndex(int i);
   /* Evaluation Engine */

--- a/poincare/include/poincare/expression_array.h
+++ b/poincare/include/poincare/expression_array.h
@@ -1,0 +1,20 @@
+#ifndef POINCARE_EXPRESSION_ARRAY_H
+#define POINCARE_EXPRESSION_ARRAY_H
+
+#include <poincare/expression.h>
+
+namespace Poincare {
+
+class ExpressionArray {
+public:
+  ExpressionArray(const Expression * eL1 = nullptr, const Expression * eL2 = nullptr) :
+    m_data{eL1, eL2}
+  {}
+  const Expression * const * array() { return const_cast<const Expression * const *>(m_data); }
+private:
+  const Expression * m_data[2];
+};
+
+}
+
+#endif

--- a/poincare/src/bounded_static_hierarchy.cpp
+++ b/poincare/src/bounded_static_hierarchy.cpp
@@ -1,4 +1,5 @@
 #include <poincare/bounded_static_hierarchy.h>
+#include <poincare/expression_array.h>
 extern "C" {
 #include <assert.h>
 }
@@ -21,7 +22,7 @@ BoundedStaticHierarchy<T>::BoundedStaticHierarchy(const Expression * const * ope
 
 template<>
 BoundedStaticHierarchy<2>::BoundedStaticHierarchy(const Expression * e1, const Expression * e2, bool cloneOperands) :
-  BoundedStaticHierarchy(ExpressionArray(e1, e2), 2, cloneOperands)
+  BoundedStaticHierarchy(ExpressionArray(e1, e2).array(), 2, cloneOperands)
 {
 }
 

--- a/poincare/src/expression.cpp
+++ b/poincare/src/expression.cpp
@@ -40,13 +40,6 @@ Expression * Expression::parse(char const * string) {
   return expression;
 }
 
-const Expression * const * Expression::ExpressionArray(const Expression * e1, const Expression * e2) {
-  static const Expression * result[2] = {nullptr, nullptr};
-  result[0] = e1;
-  result[1] = e2;
-  return result;
-}
-
 /* Circuit breaker */
 
 static Expression::CircuitBreaker sCircuitBreaker = nullptr;

--- a/poincare/src/static_hierarchy.cpp
+++ b/poincare/src/static_hierarchy.cpp
@@ -1,4 +1,5 @@
 #include <poincare/static_hierarchy.h>
+#include <poincare/expression_array.h>
 extern "C" {
 #include <assert.h>
 }
@@ -27,7 +28,7 @@ StaticHierarchy<1>::StaticHierarchy(const Expression * e, bool cloneOperands) :
 
 template<>
 StaticHierarchy<2>::StaticHierarchy(const Expression * e1, const Expression * e2, bool cloneOperands) :
-  StaticHierarchy(ExpressionArray(e1, e2), cloneOperands)
+  StaticHierarchy(ExpressionArray(e1, e2).array(), cloneOperands)
 {
 }
 


### PR DESCRIPTION
Before, it was a method of Expression and returned a static array.
However, we have no guarantee that the function will not be called again
while the array is being used, thus erasing the previous array.

Change-Id: Ic640cee7edeb3b2805febde6287414a1497a5b4c