### PR TITLE
[ion] Re-calibrate the delay methods (msleep and usleep) 

### DIFF
--- a/ion/src/device/device.cpp
+++ b/ion/src/device/device.cpp
@@ -20,12 +20,12 @@ extern "C" {
 // Public Ion methods
 
 void Ion::msleep(long ms) {
-  for (volatile long i=0; i<5400*ms; i++) {
+  for (volatile long i=0; i<8852*ms; i++) {
       __asm volatile("nop");
   }
 }
 void Ion::usleep(long us) {
-  for (volatile long i=0; i<5*us; i++) {
+  for (volatile long i=0; i<9*us; i++) {
     __asm volatile("nop");
   }
 }

--- a/ion/src/device/device.cpp
+++ b/ion/src/device/device.cpp
@@ -19,6 +19,10 @@ extern "C" {
 
 // Public Ion methods
 
+/* TODO: The delay methods 'msleep' and 'usleep' are currently dependent on the
+ * optimizations chosen by the compiler. To prevent that and to gain in
+ * precision, we could use the controller cycle counter (Systick). */
+
 void Ion::msleep(long ms) {
   for (volatile long i=0; i<8852*ms; i++) {
       __asm volatile("nop");


### PR DESCRIPTION
The recent enabling of instruction and data cache increase the device performance which forces to recalibrate the delay methods