### PR TITLE
Emterpretify

### DIFF
--- a/build/targets.emscripten.mak
+++ b/build/targets.emscripten.mak
@@ -3,7 +3,7 @@ epsilon.js: LDFLAGS += -s 'EMTERPRETIFY_FILE="epsilon.etb"'
 epsilon.packed.js: LDFLAGS += --memory-init-file 0
 epsilon.packed.js: $(app_objs) $(app_image_objs)
 
-numworks_simulator.zip: epsilon.packed.js
+simulator.zip: epsilon.packed.js
 	@rm -rf $(basename $@)
 	@mkdir $(basename $@)
 	@cp epsilon.packed.js $(basename $@)/epsilon.js
@@ -13,4 +13,4 @@ numworks_simulator.zip: epsilon.packed.js
 	@zip -r -9 $@ $(basename $@) > /dev/null
 	@rm -rf $(basename $@)
 
-products += $(addprefix epsilon.,js js.mem etb) epsilon.packed.js numworks_simulator.zip
+products += $(addprefix epsilon,.js .js.mem .etb) epsilon.packed.js simulator.zip

--- a/build/targets.emscripten.mak
+++ b/build/targets.emscripten.mak
@@ -1,5 +1,3 @@
-epsilon.js: LDFLAGS += -s 'EMTERPRETIFY_FILE="epsilon.etb"'
-
 epsilon.packed.js: LDFLAGS += --memory-init-file 0
 epsilon.packed.js: $(app_objs) $(app_image_objs)
 
@@ -13,4 +11,4 @@ simulator.zip: epsilon.packed.js
 	@zip -r -9 $@ $(basename $@) > /dev/null
 	@rm -rf $(basename $@)
 
-products += $(addprefix epsilon,.js .js.mem .etb) epsilon.packed.js simulator.zip
+products += $(addprefix epsilon,.js .js.mem) epsilon.packed.js simulator.zip

--- a/build/toolchain.emscripten.mak
+++ b/build/toolchain.emscripten.mak
@@ -2,5 +2,39 @@ CC = emcc
 CXX = emcc
 LD = emcc
 
-SFLAGS += -s EMTERPRETIFY=1 -s EMTERPRETIFY_ASYNC=1
-LDFLAGS +=  -Oz -s EMTERPRETIFY=1 -s EMTERPRETIFY_ASYNC=1 -s EXPORTED_FUNCTIONS="['_main', '_IonEventsEmscriptenPushEvent']"
+EMSCRIPTEN_ASYNC_SYMBOLS = \
+_main \
+__ZN3Ion6Events8getEventEPi \
+__ZN4Code17ConsoleController9inputTextEPKc \
+__ZThn32_N4Code17ConsoleController9inputTextEPKc \
+_mp_hal_input \
+_mp_builtin_input \
+_fun_builtin_var_call \
+_mp_call_function_n_kw \
+__ZN11MicroPython20ExecutionEnvironment7runCodeEPKc \
+__ZN4Code17ConsoleController21runAndPrintForCommandEPKc \
+__ZN4Code17ConsoleController25textFieldDidFinishEditingEP9TextFieldPKcN3Ion6Events5EventE \
+__ZThn28_N4Code17ConsoleController25textFieldDidFinishEditingEP9TextFieldPKcN3Ion6Events5EventE \
+__ZN9TextField18privateHandleEventEN3Ion6Events5EventE \
+__ZN9TextField11handleEventEN3Ion6Events5EventE \
+__ZN3App12processEventEN3Ion6Events5EventE \
+__ZN9Container13dispatchEventEN3Ion6Events5EventE \
+__ZN13AppsContainer13dispatchEventEN3Ion6Events5EventE \
+__ZN7RunLoop4stepEv \
+__ZN7RunLoop8runWhileEPFbPvES0_ \
+__ZN7RunLoop3runEv \
+__ZN9Container3runEv \
+__ZN13AppsContainer3runEv \
+__Z7ion_appv \
+_mp_execute_bytecode \
+_fun_bc_call \
+_mp_call_function_0 \
+_IonEventsEmscriptenPushEvent \
+__ZN3Ion6Events13isShiftActiveEv \
+__ZN3Ion6Events13isAlphaActiveEv \
+__ZN3Ion6Events5EventC2ENS_8Keyboard3KeyEbb
+
+EMFLAGS = -s EMTERPRETIFY=1 -s EMTERPRETIFY_ASYNC=1 -s EMTERPRETIFY_WHITELIST='[$(foreach sym,$(EMSCRIPTEN_ASYNC_SYMBOLS),"$(sym)",)]'
+
+SFLAGS += $(EMFLAGS)
+LDFLAGS += $(EMFLAGS) -Oz -s EXPORTED_FUNCTIONS='["_main", "_IonEventsEmscriptenPushEvent"]'

--- a/build/toolchain.emscripten.mak
+++ b/build/toolchain.emscripten.mak
@@ -32,9 +32,21 @@ _mp_call_function_0 \
 _IonEventsEmscriptenPushEvent \
 __ZN3Ion6Events13isShiftActiveEv \
 __ZN3Ion6Events13isAlphaActiveEv \
-__ZN3Ion6Events5EventC2ENS_8Keyboard3KeyEbb
+__ZN3Ion6Events5EventC2ENS_8Keyboard3KeyEbb \
+_mp_parse_compile_execute \
+_do_load_from_lexer \
+_do_load \
+_mp_builtin___import__ \
+_mp_import_name \
+__ZN4Code25ScriptParameterController11handleEventEN3Ion6Events5EventE \
+__ZN4Code14MenuController28openConsoleWithScriptAtIndexEi \
+__ZN4Code17ConsoleController23autoImportScriptAtIndexEib
 
 EMFLAGS = -s EMTERPRETIFY=1 -s EMTERPRETIFY_ASYNC=1 -s EMTERPRETIFY_WHITELIST='[$(foreach sym,$(EMSCRIPTEN_ASYNC_SYMBOLS),"$(sym)",)]'
+
+ifeq ($(DEBUG),1)
+EMFLAGS += --profiling-funcs -s ASSERTIONS=1
+endif
 
 SFLAGS += $(EMFLAGS)
 LDFLAGS += $(EMFLAGS) -Oz -s EXPORTED_FUNCTIONS='["_main", "_IonEventsEmscriptenPushEvent"]'


### PR DESCRIPTION
Use a whitelist to reduce the impact of Emterpreter, and get rid of EMTERPRETIFY_FILE