### PR TITLE
Use saner default debug flags

### DIFF
--- a/build/defaults.mak
+++ b/build/defaults.mak
@@ -7,7 +7,7 @@ CXXFLAGS = -std=c++11 -fno-exceptions -fno-rtti -fno-threadsafe-statics
 
 # Flags - Optimizations
 ifeq ($(DEBUG),1)
-SFLAGS = -O0 -g
+SFLAGS = -Og -g
 else
 SFLAGS = -Os
 endif


### PR DESCRIPTION
Using `-O0` with the device target results in an ELF binary so bloated it won't fit in flash. Use saner `-Og` instead for debug builds.