### PR TITLE
[emscripten] Use an event queue

### DIFF
--- a/build/toolchain.emscripten.mak
+++ b/build/toolchain.emscripten.mak
@@ -30,6 +30,7 @@ _mp_execute_bytecode \
 _fun_bc_call \
 _mp_call_function_0 \
 _IonEventsEmscriptenPushEvent \
+_IonEventsEmscriptenPushKey \
 __ZN3Ion6Events13isShiftActiveEv \
 __ZN3Ion6Events13isAlphaActiveEv \
 __ZN3Ion6Events5EventC2ENS_8Keyboard3KeyEbb \
@@ -49,4 +50,4 @@ EMFLAGS += --profiling-funcs -s ASSERTIONS=1
 endif
 
 SFLAGS += $(EMFLAGS)
-LDFLAGS += $(EMFLAGS) -Oz -s EXPORTED_FUNCTIONS='["_main", "_IonEventsEmscriptenPushEvent"]'
+LDFLAGS += $(EMFLAGS) -Oz -s EXPORTED_FUNCTIONS='["_main", "_IonEventsEmscriptenPushKey", "_IonEventsEmscriptenPushEvent"]'

--- a/ion/include/ion/events.h
+++ b/ion/include/ion/events.h
@@ -14,6 +14,7 @@ public:
   static constexpr Event ShiftAlphaKey(Keyboard::Key k) { return Event(3*PageSize+(int)k); }
   static constexpr Event Special(int i) { return Event(4*PageSize+i); }
 
+  constexpr Event() : m_id(4*PageSize){} // Return Ion::Event::None by default
   constexpr Event(int i) : m_id(i){} // TODO: Assert here that i>=0 && i<255
 #if DEBUG
   uint8_t id() const { return m_id; }

--- a/ion/src/emscripten/events_keyboard.h
+++ b/ion/src/emscripten/events_keyboard.h
@@ -4,7 +4,8 @@
 #include <ion/events.h>
 
 extern "C" {
-void IonEventsEmscriptenPushEvent(int e);
+void IonEventsEmscriptenPushKey(int keyNumber);
+void IonEventsEmscriptenPushEvent(int eventNumber);
 }
 
 namespace Ion {

--- a/ion/src/emscripten/simulator.html
+++ b/ion/src/emscripten/simulator.html
@@ -203,7 +203,7 @@ var buttons = document.querySelectorAll(".calculator .keyboard a");
 for (var i=0; i< buttons.length; i++) {
   var button = buttons[i];
   button.addEventListener("click", function(e) {
-    Module._IonEventsEmscriptenPushEvent(this.getAttribute("data-key"));
+    Module._IonEventsEmscriptenPushKey(this.getAttribute("data-key"));
     e.preventDefault();
   });
 }


### PR DESCRIPTION
* Much, much lower CPU usage by using `emscripten_sleep` in a tight loop
* Ability to push multiple events at once
* Ability to push a key or an event (modifiers discarded in the second case)
* Only redraw when processing the last event