### PR TITLE
[apps] Fix exam mode

### DIFF
--- a/apps/sequence/graph/curve_view_range.cpp
+++ b/apps/sequence/graph/curve_view_range.cpp
@@ -75,11 +75,12 @@ void CurveViewRange::setTrigonometric() {
 }
 
 void CurveViewRange::setDefault() {
-  assert(m_delegate);
-  m_xMax = m_delegate->interestingXRange();
-  m_xMin = -k_displayLeftMarginRatio*m_xMax;
-  m_xGridUnit = computeGridUnit(Axis::X, m_xMin, m_xMax);
-  setYAuto(true);
+  if (m_delegate) {
+    m_xMax = m_delegate->interestingXRange();
+    m_xMin = -k_displayLeftMarginRatio*m_xMax;
+    m_xGridUnit = computeGridUnit(Axis::X, m_xMin, m_xMax);
+    setYAuto(true);
+  }
 }
 
 }

--- a/apps/shared/interactive_curve_view_range.cpp
+++ b/apps/shared/interactive_curve_view_range.cpp
@@ -167,10 +167,11 @@ void InteractiveCurveViewRange::setTrigonometric() {
 }
 
 void InteractiveCurveViewRange::setDefault() {
-  assert(m_delegate);
-  m_xMax = m_delegate->interestingXRange();
-  MemoizedCurveViewRange::setXMin(-m_xMax);
-  setYAuto(true);
+  if (m_delegate) {
+    m_xMax = m_delegate->interestingXRange();
+    MemoizedCurveViewRange::setXMin(-m_xMax);
+    setYAuto(true);
+  }
 }
 
 void InteractiveCurveViewRange::centerAxisAround(Axis axis, float position) {


### PR DESCRIPTION
05055c387f8b0535062bee4a0d5b93ddd86c8d2a seems to have broken the exam mode.

## Steps to reproduce
1. Open the native simulator
2. Try to enable Exam mode
3. The simulator crashes
```
epsilon.elf: apps/shared/interactive_curve_view_range.cpp:170: virtual void Shared::InteractiveCurveViewRange::setDefault(): Assertion `m_delegate' failed.
```

This is also present in the official Emscripten simulator at https://www.numworks.com/simulator/. On an actual device, the calculator simply reboots.