### PR TITLE
[apps] CurveViewRange uses default xRange value when no delegate is set.

### DIFF
--- a/apps/graph/graph/graph_controller.cpp
+++ b/apps/graph/graph/graph_controller.cpp
@@ -49,7 +49,7 @@ float GraphController::interestingXRange() {
       characteristicRange = fRange > characteristicRange ? fRange : characteristicRange;
     }
   }
-  return (characteristicRange > 0.0f ? 1.6f*characteristicRange : 10.0f);
+  return (characteristicRange > 0.0f ? 1.6f*characteristicRange : InteractiveCurveViewRangeDelegate::DefaultXRange);
 }
 
 void GraphController::selectFunctionWithCursor(int functionIndex) {

--- a/apps/sequence/graph/curve_view_range.cpp
+++ b/apps/sequence/graph/curve_view_range.cpp
@@ -75,8 +75,11 @@ void CurveViewRange::setTrigonometric() {
 }
 
 void CurveViewRange::setDefault() {
-  assert(m_delegate);
-  m_xMax = m_delegate->interestingXRange();
+  if (m_delegate) {
+    m_xMax = m_delegate->interestingXRange();
+  } else {
+    m_xMax = InteractiveCurveViewRangeDelegate::DefaultXRange;
+  }
   m_xMin = -k_displayLeftMarginRatio*m_xMax;
   m_xGridUnit = computeGridUnit(Axis::X, m_xMin, m_xMax);
   setYAuto(true);

--- a/apps/shared/interactive_curve_view_range.cpp
+++ b/apps/shared/interactive_curve_view_range.cpp
@@ -167,8 +167,11 @@ void InteractiveCurveViewRange::setTrigonometric() {
 }
 
 void InteractiveCurveViewRange::setDefault() {
-  assert(m_delegate);
-  m_xMax = m_delegate->interestingXRange();
+  if (m_delegate) {
+    m_xMax = m_delegate->interestingXRange();
+  } else {
+    m_xMax = InteractiveCurveViewRangeDelegate::DefaultXRange;
+  }
   MemoizedCurveViewRange::setXMin(-m_xMax);
   setYAuto(true);
 }

--- a/apps/shared/interactive_curve_view_range_delegate.h
+++ b/apps/shared/interactive_curve_view_range_delegate.h
@@ -7,6 +7,7 @@ class InteractiveCurveViewRange;
 
 class InteractiveCurveViewRangeDelegate {
 public:
+  static constexpr float DefaultXRange = 10.0f;
   bool didChangeRange(InteractiveCurveViewRange * interactiveCurveViewRange);
   virtual float interestingXRange();
 protected:


### PR DESCRIPTION
Before, there was an "assert" on m_delegate, which was then de-referenced
to get a range value. When entering the Examination mode, the Graph and
Sequence apps were in the Snapshot format, which means that the delegates
were not present and the calculator crashed.

Change-Id: I7800faa60c4a108d668a5fb3a314c5e873846e4d