### PR TITLE
[apps] Add numpad shortcuts to math_toolbox

### DIFF
--- a/apps/math_toolbox.cpp
+++ b/apps/math_toolbox.cpp
@@ -105,6 +105,23 @@ MathToolbox::MathToolbox() : Toolbox(nullptr, I18n::translate(rootModel()->label
 {
 }
 
+bool MathToolbox::handleEvent(Ion::Events::Event event) {
+  if (Toolbox::handleEvent(event)) {
+    return true;
+  }
+  if (event.hasText() && strlen(event.text()) == 1) {
+    char key = event.text()[0];
+    if (key >= '0' && key <= '9') {
+      int index = key == '0' ? 9 : key - '0' - 1;
+      if (index >= 0 && index < m_messageTreeModel->numberOfChildren()) {
+        scrollToAndSelectChild(index);
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 TextField * MathToolbox::sender() {
   return (TextField *)Toolbox::sender();
 }
@@ -136,4 +153,11 @@ MessageTableCellWithChevron* MathToolbox::nodeCellAtIndex(int index) {
 
 int MathToolbox::maxNumberOfDisplayedRows() {
  return k_maxNumberOfDisplayedRows;
+}
+
+void MathToolbox::scrollToAndSelectChild(int i) {
+  assert(i >=0 && i<m_messageTreeModel->numberOfChildren());
+  m_selectableTableView.deselectTable();
+  m_selectableTableView.scrollToCell(0, i);
+  m_selectableTableView.selectCellAtLocation(0, i);
 }

--- a/apps/math_toolbox.h
+++ b/apps/math_toolbox.h
@@ -8,6 +8,7 @@
 class MathToolbox : public Toolbox {
 public:
   MathToolbox();
+  bool handleEvent(Ion::Events::Event event) override;
 protected:
   TextField * sender() override;
   bool selectLeaf(ToolboxMessageTree * selectedMessageTree) override;
@@ -17,6 +18,7 @@ protected:
   int maxNumberOfDisplayedRows() override;
   constexpr static int k_maxNumberOfDisplayedRows = 6; // = 240/40
 private:
+  void scrollToAndSelectChild(int i);
   MessageTableCellWithMessage m_leafCells[k_maxNumberOfDisplayedRows];
   MessageTableCellWithChevron m_nodeCells[k_maxNumberOfDisplayedRows];
 };


### PR DESCRIPTION
This commit adds numpad shortcuts to the Math toolbox, as proposed in https://github.com/numworks/epsilon/pull/39#issuecomment-326604315. This makes it easier for experienced users to navigate the menu. Currently, items 1-10 are accessible through the numpad.

To prevent potential conflicts with the navigation logic in other menus, I've chosen to do this in the Math toolbox only for now. Some of the code is taken from the Python toolbox.

## GIF
![numpad-shortcuts](https://user-images.githubusercontent.com/2189609/38168736-a81a4eac-350a-11e8-8c58-1eace2acecc2.gif)
