### PR TITLE
[apps/sequence] Reset first rank when changing sequence type to Explicit

### DIFF
--- a/apps/sequence/list/type_parameter_controller.cpp
+++ b/apps/sequence/list/type_parameter_controller.cpp
@@ -64,9 +64,13 @@ bool TypeParameterController::handleEvent(Ion::Events::Event event) {
       Sequence::Type sequenceType = (Sequence::Type)selectedRow();
       if (m_sequence->type() != sequenceType) {
         m_listController->selectPreviousNewSequenceCell();
-        m_sequence->setType((Sequence::Type)selectedRow());
+        m_sequence->setType(sequenceType);
         // Invalidate sequence context cache when changing sequence type
         static_cast<App *>(app())->localContext()->resetCache();
+        // Reset the first index if the new type is "Explicit"
+        if (sequenceType == Sequence::Type::Explicit) {
+          m_sequence->setInitialRank(0);
+        }
       }
       StackViewController * stack = stackController();
       assert(stack->depth()>2);


### PR DESCRIPTION
Before, the sequence would keep the initial rank that might have been defined for a simple or double recurrence sequence.

Change-Id: I3f356ebf95f1f81ab4601f0654166f146a505c27