### PR TITLE
Enable the urandom module in mpconfigport.h, not in uPy

### DIFF
--- a/python/port/mpconfigport.h
+++ b/python/port/mpconfigport.h
@@ -55,6 +55,8 @@
 #define MICROPY_CPYTHON_COMPAT      (0)
 #define MICROPY_LONGINT_IMPL        (MICROPY_LONGINT_IMPL_MPZ)
 #define MICROPY_FLOAT_IMPL          (MICROPY_FLOAT_IMPL_DOUBLE)
+#define MICROPY_PY_URANDOM          (1)
+#define MICROPY_PY_URANDOM_EXTRA_FUNCS (1)
 
 #define MICROPY_VM_HOOK_LOOP micropython_port_should_interrupt();
 


### PR DESCRIPTION
Otherwise it breaks when upgrading uPy. Faulty commit 4011290.