### PR TITLE
Fix flash access

### DIFF
--- a/ion/src/device/usb/dfu_interface.cpp
+++ b/ion/src/device/usb/dfu_interface.cpp
@@ -258,8 +258,10 @@ void DFUInterface::writeOnMemory() {
     /* We should check here that the destination is not the option bytes: it
      * won't happen for us. */
 
-    // Unlock the Flash and check that no memory operation is ongoing
+    // Unlock the Flash
     unlockFlashMemory();
+
+    // Activate Flash programming
     while (FLASH.SR()->getBSY()) {
     }
     FLASH.CR()->setPG(true);
@@ -270,9 +272,12 @@ void DFUInterface::writeOnMemory() {
       *destination++ = *source++;
     }
 
-    // Lock the Flash after all operations are done
+    // De-activate Flash programming
     while (FLASH.SR()->getBSY()) {
     }
+    FLASH.CR()->setPG(false);
+
+    // Lock the Flash
     lockFlashMemoryAndPurgeCaches();
   } else if (m_writeAddress >= k_sramStartAddress && m_writeAddress <= k_sramEndAddress) {
     // Write on SRAM

--- a/ion/src/device/usb/dfu_interface.cpp
+++ b/ion/src/device/usb/dfu_interface.cpp
@@ -221,23 +221,27 @@ void DFUInterface::eraseMemoryIfNeeded() {
 
   // Unlock the Flash and check that no memory operation is ongoing
   unlockFlashMemory();
-  while (FLASH.SR()->getBSY()) {
-  }
 
   if (m_erasePage == k_flashMemorySectorsCount) {
     // Mass erase
+    while (FLASH.SR()->getBSY()) {
+    }
     FLASH.CR()->setMER(true);
   } else {
     // Sector erase
+    while (FLASH.SR()->getBSY()) {
+    }
     FLASH.CR()->setSER(true);
+    while (FLASH.SR()->getBSY()) {
+    }
     FLASH.CR()->setSNB(m_erasePage);
   }
   // Trigger the erase operation
+  while (FLASH.SR()->getBSY()) {
+  }
   FLASH.CR()->setSTRT(true);
 
   // Lock the Flash after all operations are done
-  while (FLASH.SR()->getBSY()) {
-  }
   lockFlashMemoryAndPurgeCaches();
 
   /* Put an out of range value in m_erasePage to indicate that no erase is
@@ -293,12 +297,12 @@ void DFUInterface::unlockFlashMemory() {
   /* After a reset, program and erase operations are forbidden on the flash.
    * They can be unlocked by writting the appropriate keys in the FLASH_KEY
    * register. */
-  while (FLASH.SR()->getBSY()) {
-  }
   if (FLASH.CR()->getLOCK()) {
     FLASH.KEYR()->set(0x45670123);
     FLASH.KEYR()->set(0xCDEF89AB);
     // Set the parallelism size
+    while (FLASH.SR()->getBSY()) {
+    }
     FLASH.CR()->setPSIZE(FLASH::CR::PSIZE::X32);
   }
 }


### PR DESCRIPTION
The PG bit in FLASH.CR stayed true, which allowed unwanted flash write operations outside of DFU commands.