### PR TITLE
[poincare] PrintFloat: fix error due to float/double precision

### DIFF
--- a/poincare/src/print_float.cpp
+++ b/poincare/src/print_float.cpp
@@ -142,7 +142,7 @@ int PrintFloat::convertFloatToTextPrivate(T f, char * buffer, int numberOfSignif
 
   // Correct the number of digits in mantissa after rounding
   int mantissaExponentInBase10 = exponentInBase10 > 0 || displayMode == Mode::Scientific ? availableCharsForMantissaWithoutSign - 1 : availableCharsForMantissaWithoutSign + exponentInBase10;
-  if (std::floor(std::fabs((T)mantissa) * std::pow((T)10, - mantissaExponentInBase10)) > 0) {
+  if (IEEE754<T>::exponentBase10(mantissa) >= mantissaExponentInBase10) {
     mantissa = mantissa/10;
   }
 

--- a/poincare/test/convert_expression_to_text.cpp
+++ b/poincare/test/convert_expression_to_text.cpp
@@ -97,6 +97,7 @@ QUIZ_CASE(assert_float_prints_to) {
   assert_float_prints_to(12345.678910121314, "12345.678910121", DecimalDisplay, 14);
   assert_float_prints_to(9.999999999999999999999E12, "1E13", DecimalDisplay, 9);
   assert_float_prints_to(-0.000000099999999, "-0.0000001", DecimalDisplay, 9);
+  assert_float_prints_to(999.99999999999977, "1000", DecimalDisplay, 5);
 }
 
 QUIZ_CASE(poincare_rational_to_text) {


### PR DESCRIPTION
floor(abs(100000))*pow(10,-5)= 0.9999999 instead of 1