### PR TITLE
[apps] Code: Python syntax highlight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 *.d
 
 # No lex / yacc generated files.
+escher/src/highlight_lexer.cpp
+escher/src/highlight_lexer.hpp
 poincare/src/expression_lexer.cpp
 poincare/src/expression_lexer.hpp
 poincare/src/expression_parser.cpp

--- a/apps/code/editor_controller.h
+++ b/apps/code/editor_controller.h
@@ -40,4 +40,3 @@ private:
 }
 
 #endif
-

--- a/apps/code/editor_view.cpp
+++ b/apps/code/editor_view.cpp
@@ -8,10 +8,16 @@
 EditorView::EditorView(Responder * parentResponder) :
   Responder(parentResponder),
   View(),
-  m_textArea(parentResponder, nullptr, 0, &pythonHighlighter),
+  m_highlighter(new PythonHighlighter()),
+  m_textArea(parentResponder, nullptr, 0, m_highlighter),
   m_gutterView(KDText::FontSize::Large)
 {
   m_textArea.setScrollViewDelegate(this);
+}
+
+EditorView::~EditorView() {
+  delete m_highlighter;
+  m_highlighter = nullptr;
 }
 
 void EditorView::scrollViewDidChangeOffset(ScrollViewDataSource * scrollViewDataSource) {

--- a/apps/code/editor_view.cpp
+++ b/apps/code/editor_view.cpp
@@ -1,13 +1,14 @@
 #include "editor_view.h"
 #include <poincare.h>
 #include <escher/app.h>
+#include <escher/python_highlighter.h>
 
 /* EditorView */
 
 EditorView::EditorView(Responder * parentResponder) :
   Responder(parentResponder),
   View(),
-  m_textArea(parentResponder),
+  m_textArea(parentResponder, nullptr, 0, &pythonHighlighter),
   m_gutterView(KDText::FontSize::Large)
 {
   m_textArea.setScrollViewDelegate(this);

--- a/apps/code/editor_view.h
+++ b/apps/code/editor_view.h
@@ -7,6 +7,7 @@
 class EditorView : public Responder, public View, public ScrollViewDelegate {
 public:
   EditorView(Responder * parentResponder);
+  ~EditorView();
   void setTextAreaDelegate(TextAreaDelegate * delegate) {
     m_textArea.setDelegate(delegate);
   }
@@ -38,6 +39,7 @@ private:
     KDCoordinate m_offset;
   };
 
+  Highlighter * m_highlighter;
   TextArea m_textArea;
   GutterView m_gutterView;
 };

--- a/escher/Makefile
+++ b/escher/Makefile
@@ -24,6 +24,7 @@ objs += $(addprefix escher/src/,\
   expression_table_cell_with_pointer.o\
   expression_view.o\
   highlight_cell.o\
+  highlight_lexer.o\
   gauge_view.o\
   image_view.o\
   invocation.o\
@@ -44,6 +45,7 @@ objs += $(addprefix escher/src/,\
   modal_view_controller.o\
   palette.o\
   pointer_text_view.o\
+  python_highlighter.o\
   responder.o\
   run_loop.o\
   scroll_view.o\
@@ -96,4 +98,12 @@ $(INLINER): escher/image/inliner.c
 
 INLINER_PRODUCTS = $(1:.png=.h) $(1:.png=.cpp) $(1:.png=.o)
 
-products += $(INLINER)
+lexer_files = $(addprefix escher/src/, highlight_lexer.cpp highlight_lexer.hpp)
+escher/src/highlight_lexer.hpp: escher/src/highlight_lexer.cpp
+escher/src/highlight_lexer.cpp: escher/src/highlight_lexer.l
+	@echo "FLEX    $(lexer_files)"
+	$(Q) flex -Phighlight_lexer_yy --header-file=escher/src/highlight_lexer.hpp -o escher/src/highlight_lexer.cpp $<
+
+escher/src/highlight_lexer.o: CXXFLAGS += -Wno-deprecated-register -Wno-unused-value -Wno-unused-function
+
+products += $(INLINER) $(lexer_files)

--- a/escher/include/escher.h
+++ b/escher/include/escher.h
@@ -26,6 +26,7 @@
 #include <escher/expression_view.h>
 #include <escher/gauge_view.h>
 #include <escher/highlight_cell.h>
+#include <escher/highlighter.h>
 #include <escher/image.h>
 #include <escher/image_view.h>
 #include <escher/input_view_controller.h>

--- a/escher/include/escher.h
+++ b/escher/include/escher.h
@@ -48,6 +48,7 @@
 #include <escher/modal_view_controller.h>
 #include <escher/palette.h>
 #include <escher/pointer_text_view.h>
+#include <escher/python_highlighter.h>
 #include <escher/responder.h>
 #include <escher/scroll_view.h>
 #include <escher/scroll_view_data_source.h>

--- a/escher/include/escher/highlighter.h
+++ b/escher/include/escher/highlighter.h
@@ -5,7 +5,8 @@
 
 class Highlighter {
 public:
-  virtual void highlight(char * buffer, char * attr_buffer, size_t bufferSize) = 0;
+  virtual bool highlight(char * buffer, char * attr_buffer, size_t bufferSize) = 0;
+  virtual bool cursorMoved(char * buffer, char * attr_buffer, size_t bufferSize, int location) = 0;
 };
 
 #endif

--- a/escher/include/escher/highlighter.h
+++ b/escher/include/escher/highlighter.h
@@ -1,0 +1,11 @@
+#ifndef ESCHER_HIGHLIGHTER_H
+#define ESCHER_HIGHLIGHTER_H
+
+#include <stddef.h>
+
+class Highlighter {
+public:
+  virtual void highlight(char * buffer, char * attr_buffer, size_t bufferSize) = 0;
+};
+
+#endif

--- a/escher/include/escher/highlighter.h
+++ b/escher/include/escher/highlighter.h
@@ -7,6 +7,7 @@ class Highlighter {
 public:
   virtual bool highlight(char * buffer, char * attr_buffer, size_t bufferSize) = 0;
   virtual bool cursorMoved(char * buffer, char * attr_buffer, size_t bufferSize, int location) = 0;
+  virtual ~Highlighter() {};
 };
 
 #endif

--- a/escher/include/escher/python_highlighter.h
+++ b/escher/include/escher/python_highlighter.h
@@ -1,11 +1,15 @@
 #ifndef ESCHER_PYTHON_HIGHLIGHTER_H
 #define ESCHER_PYTHON_HIGHLIGHTER_H
 
+#include <escher/highlighter.h>
+
 #include <stddef.h>
 
-class PythonHighlighter {
+class PythonHighlighter : public Highlighter {
 public:
   void highlight(char * buffer, char * attr_buffer, size_t bufferSize);
 };
+
+extern PythonHighlighter pythonHighlighter;
 
 #endif

--- a/escher/include/escher/python_highlighter.h
+++ b/escher/include/escher/python_highlighter.h
@@ -7,9 +7,11 @@
 
 class PythonHighlighter : public Highlighter {
 public:
-  void highlight(char * buffer, char * attr_buffer, size_t bufferSize);
+  PythonHighlighter();
+  bool highlight(char * buffer, char * attr_buffer, size_t bufferSize);
+  bool cursorMoved(char * buffer, char * attr_buffer, size_t bufferSize, int location);
+private:
+  bool m_onParenthesis;
 };
-
-extern PythonHighlighter pythonHighlighter;
 
 #endif

--- a/escher/include/escher/python_highlighter.h
+++ b/escher/include/escher/python_highlighter.h
@@ -1,0 +1,11 @@
+#ifndef ESCHER_PYTHON_HIGHLIGHTER_H
+#define ESCHER_PYTHON_HIGHLIGHTER_H
+
+#include <stddef.h>
+
+class PythonHighlighter {
+public:
+  void highlight(char * buffer, char * attr_buffer, size_t bufferSize);
+};
+
+#endif

--- a/escher/include/escher/text_area.h
+++ b/escher/include/escher/text_area.h
@@ -3,13 +3,13 @@
 
 #include <escher/text_input.h>
 #include <escher/text_area_delegate.h>
+#include <escher/python_highlighter.h>
 #include <assert.h>
 #include <string.h>
 
 class TextArea : public TextInput {
 public:
-  TextArea(Responder * parentResponder, char * textBuffer = nullptr, size_t textBufferSize = 0, TextAreaDelegate * delegate = nullptr, KDText::FontSize fontSize = KDText::FontSize::Large,
-    KDColor textColor = KDColorBlack, KDColor backgroundColor = KDColorWhite);
+  TextArea(Responder * parentResponder, char * textBuffer = nullptr, size_t textBufferSize = 0, PythonHighlighter highlighter = PythonHighlighter(), TextAreaDelegate * delegate = nullptr, KDText::FontSize fontSize = KDText::FontSize::Large);
   void setDelegate(TextAreaDelegate * delegate) { m_delegate = delegate; }
   bool handleEvent(Ion::Events::Event event) override;
   bool handleEventWithText(const char * text, bool indentation = false, bool forceCursorRightOfText = false) override;
@@ -22,23 +22,28 @@ private:
   }
   class Text {
   public:
-    Text(char * buffer, size_t bufferSize);
+    Text(char * buffer, size_t bufferSize, PythonHighlighter highlighter);
+    ~Text();
     void setText(char * buffer, size_t bufferSize);
+    void highlight();
     const char * text() const { return const_cast<const char *>(m_buffer); }
+    const char * attr() const { return const_cast<const char *>(m_attr_buffer); }
     class Line {
     public:
-      Line(const char * text);
+      Line(const char * text, const char * attr);
       const char * text() const { return m_text; }
+      const char * attr() const { return m_attr; }
       size_t length() const { return m_length; }
       bool contains(const char * c) const;
     private:
       const char * m_text;
+      const char * m_attr;
       size_t m_length;
     };
 
     class LineIterator {
     public:
-      LineIterator(const char * text) : m_line(text) {}
+      LineIterator(const char * text, const char * attr) : m_line(text, attr) {}
       Line operator*() { return m_line; }
       LineIterator& operator++();
       bool operator!=(const LineIterator& it) const { return m_line.text() != it.m_line.text(); }
@@ -56,14 +61,15 @@ private:
       int m_line;
     };
 
-    LineIterator begin() const { return LineIterator(m_buffer); };
-    LineIterator end() const { return LineIterator(nullptr); };
+    LineIterator begin() const { return LineIterator(m_buffer, m_attr_buffer); };
+    LineIterator end() const { return LineIterator(nullptr, nullptr); };
 
     Position span() const;
 
     Position positionAtIndex(size_t index) const;
     size_t indexAtPosition(Position p);
 
+    void setAttr(char a, size_t index);
     void insertChar(char c, size_t index);
     char removeChar(size_t index);
     size_t removeRemainingLine(size_t index, int direction);
@@ -79,13 +85,14 @@ private:
     }
   private:
     char * m_buffer;
+    char * m_attr_buffer;
     size_t m_bufferSize;
+    PythonHighlighter m_highlighter;
   };
 
   class ContentView : public TextInput::ContentView {
   public:
-    ContentView(char * textBuffer, size_t textBufferSize, KDText::FontSize size,
-      KDColor textColor, KDColor backgroundColor);
+    ContentView(char * textBuffer, size_t textBufferSize, KDText::FontSize size, PythonHighlighter highlighter);
     void drawRect(KDContext * ctx, KDRect rect) const override;
     KDSize minimalSizeForOptimalDisplay() const override;
     void setText(char * textBuffer, size_t textBufferSize);

--- a/escher/include/escher/text_area.h
+++ b/escher/include/escher/text_area.h
@@ -3,13 +3,13 @@
 
 #include <escher/text_input.h>
 #include <escher/text_area_delegate.h>
-#include <escher/python_highlighter.h>
+#include <escher/highlighter.h>
 #include <assert.h>
 #include <string.h>
 
 class TextArea : public TextInput {
 public:
-  TextArea(Responder * parentResponder, char * textBuffer = nullptr, size_t textBufferSize = 0, PythonHighlighter highlighter = PythonHighlighter(), TextAreaDelegate * delegate = nullptr, KDText::FontSize fontSize = KDText::FontSize::Large);
+  TextArea(Responder * parentResponder, char * textBuffer = nullptr, size_t textBufferSize = 0, Highlighter * highlighter = nullptr, TextAreaDelegate * delegate = nullptr, KDText::FontSize fontSize = KDText::FontSize::Large);
   void setDelegate(TextAreaDelegate * delegate) { m_delegate = delegate; }
   bool handleEvent(Ion::Events::Event event) override;
   bool handleEventWithText(const char * text, bool indentation = false, bool forceCursorRightOfText = false) override;
@@ -22,7 +22,7 @@ private:
   }
   class Text {
   public:
-    Text(char * buffer, size_t bufferSize, PythonHighlighter highlighter);
+    Text(char * buffer, size_t bufferSize, Highlighter * highlighter);
     ~Text();
     void setText(char * buffer, size_t bufferSize);
     void highlight();
@@ -87,12 +87,12 @@ private:
     char * m_buffer;
     char * m_attr_buffer;
     size_t m_bufferSize;
-    PythonHighlighter m_highlighter;
+    Highlighter * m_highlighter;
   };
 
   class ContentView : public TextInput::ContentView {
   public:
-    ContentView(char * textBuffer, size_t textBufferSize, KDText::FontSize size, PythonHighlighter highlighter);
+    ContentView(char * textBuffer, size_t textBufferSize, KDText::FontSize size, Highlighter * highlighter);
     void drawRect(KDContext * ctx, KDRect rect) const override;
     KDSize minimalSizeForOptimalDisplay() const override;
     void setText(char * textBuffer, size_t textBufferSize);

--- a/escher/include/escher/text_area.h
+++ b/escher/include/escher/text_area.h
@@ -14,6 +14,7 @@ public:
   bool handleEvent(Ion::Events::Event event) override;
   bool handleEventWithText(const char * text, bool indentation = false, bool forceCursorRightOfText = false) override;
   void setText(char * textBuffer, size_t textBufferSize);
+  bool setCursorLocation(int location);
 private:
   int indentationBeforeCursor() const;
   bool insertTextWithIndentation(const char * textBuffer, int location);
@@ -25,7 +26,7 @@ private:
     Text(char * buffer, size_t bufferSize, Highlighter * highlighter);
     ~Text();
     void setText(char * buffer, size_t bufferSize);
-    void highlight();
+    bool highlight(int location = -1);
     const char * text() const { return const_cast<const char *>(m_buffer); }
     const char * attr() const { return const_cast<const char *>(m_attr_buffer); }
     class Line {
@@ -97,7 +98,7 @@ private:
     KDSize minimalSizeForOptimalDisplay() const override;
     void setText(char * textBuffer, size_t textBufferSize);
     const char * text() const override;
-    const Text * getText() const { return &m_text; }
+    Text * getText() { return &m_text; }
     size_t editedTextLength() const override {
       return m_text.textLength();
     }
@@ -106,6 +107,7 @@ private:
     bool removeChar() override;
     bool removeEndOfLine() override;
     bool removeStartOfLine();
+    void setCursorLocation(int cursorLocation);
   private:
     KDRect characterFrameAtIndex(size_t index) const override;
     Text m_text;

--- a/escher/src/highlight_lexer.l
+++ b/escher/src/highlight_lexer.l
@@ -1,0 +1,39 @@
+%option noyywrap
+%option never-interactive
+
+%{
+#define YY_DECL int yylex(char *attr, int position)
+
+#define YY_INPUT
+#define ECHO
+
+#undef YY_BUF_SIZE
+#define YY_BUF_SIZE 256
+
+#define fprintf(...) ((void)0)
+#define exit(...) abort()
+%}
+
+KEYWORD    "False"|"None"|"True"|"and"|"as"|"assert"|"break"|"class"|"continue"|"def"|"del"|"elif"|"else"|"except"|"finally"|"for"|"from"|"global"|"if"|"import"|"in"|"is"|"lambda"|"nonlocal"|"not"|"or"|"pass"|"raise"|"return"|"try"|"while"|"with"|"yield"
+BUILTIN    "ArithmeticError"|"AssertionError"|"AttributeError"|"BaseException"|"BlockingIOError"|"BrokenPipeError"|"BufferError"|"BytesWarning"|"ChildProcessError"|"ConnectionAbortedError"|"ConnectionError"|"ConnectionRefusedError"|"ConnectionResetError"|"DeprecationWarning"|"EOFError"|"Ellipsis"|"EnvironmentError"|"Exception"|"FileExistsError"|"FileNotFoundError"|"FloatingPointError"|"FutureWarning"|"GeneratorExit"|"IOError"|"ImportError"|"ImportWarning"|"IndentationError"|"IndexError"|"InterruptedError"|"IsADirectoryError"|"KeyError"|"KeyboardInterrupt"|"LookupError"|"MemoryError"|"ModuleNotFoundError"|"NameError"|"NotADirectoryError"|"NotImplemented"|"NotImplementedError"|"OSError"|"OverflowError"|"PendingDeprecationWarning"|"PermissionError"|"ProcessLookupError"|"RecursionError"|"ReferenceError"|"ResourceWarning"|"RuntimeError"|"RuntimeWarning"|"StopAsyncIteration"|"StopIteration"|"SyntaxError"|"SyntaxWarning"|"SystemError"|"SystemExit"|"TabError"|"TimeoutError"|"TypeError"|"UnboundLocalError"|"UnicodeDecodeError"|"UnicodeEncodeError"|"UnicodeError"|"UnicodeTranslateError"|"UnicodeWarning"|"UserWarning"|"ValueError"|"Warning"|"ZeroDivisionError"|"abs"|"all"|"any"|"ascii"|"bin"|"bool"|"bytearray"|"bytes"|"callable"|"chr"|"classmethod"|"compile"|"complex"|"copyright"|"credits"|"delattr"|"dict"|"dir"|"divmod"|"enumerate"|"eval"|"exec"|"exit"|"filter"|"float"|"format"|"frozenset"|"getattr"|"globals"|"hasattr"|"hash"|"help"|"hex"|"id"|"input"|"int"|"isinstance"|"issubclass"|"iter"|"len"|"license"|"list"|"locals"|"map"|"max"|"memoryview"|"min"|"next"|"object"|"oct"|"open"|"ord"|"pow"|"print"|"property"|"quit"|"range"|"repr"|"reversed"|"round"|"set"|"setattr"|"slice"|"sorted"|"staticmethod"|"str"|"sum"|"super"|"tuple"|"type"|"vars"|"zip"
+IDENTIFIER [a-zA-Z_][a-zA-Z0-9_]*
+COMMENT    "#"[^\n]*
+SP         (?i:r|u|f|fr|rf|b|br|rb)?
+SQSTRING   '[^'\\\n]*(\\.[^'\\\n]*)*'?
+DQSTRING   \"[^"\\\n]*(\\.[^"\\\n]*)*\"?
+TSQSTRING  '''[^'\\]*((\\.|'[^']|''[^'])[^'\\]*)*(''')?
+TDQSTRING  \"\"\"[^"\\]*((\\.|\"[^"]|\"\"[^"])[^"\\]*)*(\"\"\")?
+
+%%
+
+def\ {IDENTIFIER}                   { memset(attr+position, 6, 4); memset(attr+position+4, 1, yyleng-4); position += yyleng; }
+class\ {IDENTIFIER}                 { memset(attr+position, 6, 6); memset(attr+position+6, 1, yyleng-6); position += yyleng; }
+{KEYWORD}                           { memset(attr+position, 6, yyleng); position += yyleng; }
+{BUILTIN}                           { memset(attr+position, 5, yyleng); position += yyleng; }
+{COMMENT}                           { memset(attr+position, 4, yyleng); position += yyleng; }
+({SP}{TDQSTRING})|({SP}{TDQSTRING}) { memset(attr+position, 2, yyleng); position += yyleng; }
+({SP}{DQSTRING})|({SP}{SQSTRING})   { memset(attr+position, 2, yyleng); position += yyleng; }
+{IDENTIFIER}                        { memset(attr+position, 0, yyleng); position += yyleng; }
+.|\n                                { attr[position] = 0; position += yyleng; }
+
+%%

--- a/escher/src/python_highlighter.cpp
+++ b/escher/src/python_highlighter.cpp
@@ -13,3 +13,5 @@ void PythonHighlighter::highlight(char * buffer, char * attr_buffer, size_t buff
     highlight_lexer_yy_delete_buffer(buf);
   }
 }
+
+PythonHighlighter pythonHighlighter = PythonHighlighter();

--- a/escher/src/python_highlighter.cpp
+++ b/escher/src/python_highlighter.cpp
@@ -1,0 +1,15 @@
+#include <escher/python_highlighter.h>
+
+#include <stddef.h>
+
+#include "highlight_lexer.hpp"
+
+extern int highlight_lexer_yylex(char *attr, int position);
+
+void PythonHighlighter::highlight(char * buffer, char * attr_buffer, size_t bufferSize) {
+  if(bufferSize > 0) {
+    YY_BUFFER_STATE buf = highlight_lexer_yy_scan_string(buffer);
+    highlight_lexer_yylex(attr_buffer, 0);
+    highlight_lexer_yy_delete_buffer(buf);
+  }
+}

--- a/escher/src/python_highlighter.cpp
+++ b/escher/src/python_highlighter.cpp
@@ -6,12 +6,76 @@
 
 extern int highlight_lexer_yylex(char *attr, int position);
 
-void PythonHighlighter::highlight(char * buffer, char * attr_buffer, size_t bufferSize) {
+const char DEFAULT_BG_MASK = (char) 0x0f;
+const char PARENTHESIS_BG_MASK = (char) ~0x7f;
+
+PythonHighlighter::PythonHighlighter():
+  m_onParenthesis(false) {
+}
+
+bool PythonHighlighter::highlight(char * buffer, char * attr_buffer, size_t bufferSize) {
   if(bufferSize > 0) {
     YY_BUFFER_STATE buf = highlight_lexer_yy_scan_string(buffer);
     highlight_lexer_yylex(attr_buffer, 0);
     highlight_lexer_yy_delete_buffer(buf);
   }
+  return true;
 }
 
-PythonHighlighter pythonHighlighter = PythonHighlighter();
+void clearAttributes(char * buffer, char * attr_buffer, size_t bufferSize) {
+  for(size_t i=0; i<bufferSize && buffer[i] != '\0'; i++) {
+    attr_buffer[i] &= DEFAULT_BG_MASK;
+  }
+}
+
+bool PythonHighlighter::cursorMoved(char * buffer, char * attr_buffer, size_t bufferSize, int location) {
+  if(bufferSize > 0 && location > 0 && (size_t)location < bufferSize) {
+    location--;
+    int count = 0;
+    if(buffer[location] == ')') {
+      m_onParenthesis = true;
+      clearAttributes(buffer, attr_buffer, bufferSize);
+      attr_buffer[location] |= PARENTHESIS_BG_MASK;
+      while(location > 0) {
+        location--;
+        attr_buffer[location] |= PARENTHESIS_BG_MASK;
+        if(buffer[location] == ')') {
+          count++;
+        } else if(buffer[location] == '(') {
+          if(count == 0) {
+            break;
+          } else {
+            count--;
+          }
+        }
+      }
+      return true;
+    } else if (buffer[location] == '(') {
+      m_onParenthesis = true;
+      clearAttributes(buffer, attr_buffer, bufferSize);
+      attr_buffer[location] |= PARENTHESIS_BG_MASK;
+      while((size_t)location < bufferSize - 1) {
+        location++;
+        attr_buffer[location] |= PARENTHESIS_BG_MASK;
+        if(buffer[location] == '(') {
+          count++;
+        } else if(buffer[location] == ')') {
+          if(count == 0) {
+            break;
+          } else {
+            count--;
+          }
+        }
+      }
+      return true;
+    } else if(m_onParenthesis) {
+      m_onParenthesis = false;
+      clearAttributes(buffer, attr_buffer, bufferSize);
+      return true;
+    } else {
+      m_onParenthesis = false;
+      return false;
+    }
+  }
+  return false;
+}

--- a/escher/src/text_area.cpp
+++ b/escher/src/text_area.cpp
@@ -10,13 +10,15 @@ static inline size_t min(size_t a, size_t b) {
   return (a>b ? b : a);
 }
 
-TextArea::Text::Text(char * buffer, size_t bufferSize, PythonHighlighter highlighter) :
+TextArea::Text::Text(char * buffer, size_t bufferSize, Highlighter * highlighter) :
   m_buffer(buffer),
   m_bufferSize(bufferSize),
   m_highlighter(highlighter)
 {
   m_attr_buffer = new char[bufferSize]();
-  m_highlighter.highlight(m_buffer, m_attr_buffer, m_bufferSize);
+  if(m_highlighter != nullptr) {
+    m_highlighter->highlight(m_buffer, m_attr_buffer, m_bufferSize);
+  }
 }
 
 TextArea::Text::~Text() {
@@ -31,7 +33,9 @@ void TextArea::Text::setText(char * buffer, size_t bufferSize) {
   m_bufferSize = bufferSize;
   delete[] m_attr_buffer;
   m_attr_buffer = new char[bufferSize]();
-  m_highlighter.highlight(m_buffer, m_attr_buffer, m_bufferSize);
+  if(m_highlighter != nullptr) {
+    m_highlighter->highlight(m_buffer, m_attr_buffer, m_bufferSize);
+  }
 }
 
 TextArea::Text::Line::Line(const char * text, const char * attr) :
@@ -111,7 +115,9 @@ void TextArea::Text::insertChar(char c, size_t index) {
       break;
     }
   }
-  m_highlighter.highlight(m_buffer, m_attr_buffer, m_bufferSize);
+  if(m_highlighter != nullptr) {
+    m_highlighter->highlight(m_buffer, m_attr_buffer, m_bufferSize);
+  }
 }
 
 char TextArea::Text::removeChar(size_t index) {
@@ -124,7 +130,9 @@ char TextArea::Text::removeChar(size_t index) {
       break;
     }
   }
-  m_highlighter.highlight(m_buffer, m_attr_buffer, m_bufferSize);
+  if(m_highlighter != nullptr) {
+    m_highlighter->highlight(m_buffer, m_attr_buffer, m_bufferSize);
+  }
   return deletedChar;
 }
 
@@ -153,7 +161,9 @@ size_t TextArea::Text::removeRemainingLine(size_t index, int direction) {
     }
   }
   assert(false);
-  m_highlighter.highlight(m_buffer, m_attr_buffer, m_bufferSize);
+  if(m_highlighter != nullptr) {
+    m_highlighter->highlight(m_buffer, m_attr_buffer, m_bufferSize);
+  }
   return 0;
 }
 
@@ -172,7 +182,7 @@ TextArea::Text::Position TextArea::Text::span() const {
 
 /* TextArea::ContentView */
 
-TextArea::ContentView::ContentView(char * textBuffer, size_t textBufferSize, KDText::FontSize fontSize, PythonHighlighter highlighter) :
+TextArea::ContentView::ContentView(char * textBuffer, size_t textBufferSize, KDText::FontSize fontSize, Highlighter * highlighter) :
   TextInput::ContentView(fontSize, KDColorBlack, KDColorWhite),
   m_text(textBuffer, textBufferSize, highlighter)
 {
@@ -316,7 +326,7 @@ void TextArea::TextArea::ContentView::moveCursorGeo(int deltaX, int deltaY) {
 /* TextArea */
 
 TextArea::TextArea(Responder * parentResponder, char * textBuffer,
-    size_t textBufferSize, PythonHighlighter highlighter, TextAreaDelegate * delegate,
+    size_t textBufferSize, Highlighter * highlighter, TextAreaDelegate * delegate,
     KDText::FontSize fontSize) :
   TextInput(parentResponder, &m_contentView),
   m_contentView(textBuffer, textBufferSize, fontSize, highlighter),

--- a/escher/src/text_area.cpp
+++ b/escher/src/text_area.cpp
@@ -10,15 +10,39 @@ static inline size_t min(size_t a, size_t b) {
   return (a>b ? b : a);
 }
 
+bool TextArea::setCursorLocation(int location) {
+  bool result = TextInput::setCursorLocation(location);
+  if(m_contentView.getText()->highlight(cursorLocation())) {
+    markRectAsDirty(bounds());
+  }
+  return result;
+}
+
+void TextArea::TextArea::ContentView::setCursorLocation(int location) {
+  TextInput::ContentView::setCursorLocation(location);
+  if(m_text.highlight(cursorLocation())) {
+    markRectAsDirty(bounds());
+  }
+}
+
+bool TextArea::Text::highlight(int location) {
+  if(m_highlighter != nullptr) {
+    if(location < 0) {
+      return m_highlighter->highlight(m_buffer, m_attr_buffer, m_bufferSize);
+    } else {
+      return m_highlighter->cursorMoved(m_buffer, m_attr_buffer, m_bufferSize, location);
+    }
+  }
+  return false;
+}
+
 TextArea::Text::Text(char * buffer, size_t bufferSize, Highlighter * highlighter) :
   m_buffer(buffer),
   m_bufferSize(bufferSize),
   m_highlighter(highlighter)
 {
   m_attr_buffer = new char[bufferSize]();
-  if(m_highlighter != nullptr) {
-    m_highlighter->highlight(m_buffer, m_attr_buffer, m_bufferSize);
-  }
+  highlight();
 }
 
 TextArea::Text::~Text() {
@@ -33,9 +57,7 @@ void TextArea::Text::setText(char * buffer, size_t bufferSize) {
   m_bufferSize = bufferSize;
   delete[] m_attr_buffer;
   m_attr_buffer = new char[bufferSize]();
-  if(m_highlighter != nullptr) {
-    m_highlighter->highlight(m_buffer, m_attr_buffer, m_bufferSize);
-  }
+  highlight();
 }
 
 TextArea::Text::Line::Line(const char * text, const char * attr) :
@@ -115,9 +137,7 @@ void TextArea::Text::insertChar(char c, size_t index) {
       break;
     }
   }
-  if(m_highlighter != nullptr) {
-    m_highlighter->highlight(m_buffer, m_attr_buffer, m_bufferSize);
-  }
+  highlight();
 }
 
 char TextArea::Text::removeChar(size_t index) {
@@ -130,9 +150,7 @@ char TextArea::Text::removeChar(size_t index) {
       break;
     }
   }
-  if(m_highlighter != nullptr) {
-    m_highlighter->highlight(m_buffer, m_attr_buffer, m_bufferSize);
-  }
+  highlight();
   return deletedChar;
 }
 
@@ -161,9 +179,7 @@ size_t TextArea::Text::removeRemainingLine(size_t index, int direction) {
     }
   }
   assert(false);
-  if(m_highlighter != nullptr) {
-    m_highlighter->highlight(m_buffer, m_attr_buffer, m_bufferSize);
-  }
+  highlight();
   return 0;
 }
 

--- a/escher/src/text_area.cpp
+++ b/escher/src/text_area.cpp
@@ -255,11 +255,13 @@ void TextArea::ContentView::drawRect(KDContext * ctx, KDRect rect) const {
     }
     y++;
   }
+
+  // TODO Clearing the bottom of the editor should be done better
   ctx->fillRect(KDRect(
-    topLeft.column(),
+    m_frame.x() + topLeft.column() * charSize.width() - charSize.width(),
     y * charSize.height(),
-    (bottomRight.column() - topLeft.column()) * charSize.width(),
-    (bottomRight.line() - y) * charSize.height()
+    m_frame.width() + 2*charSize.width(),
+    m_frame.height() - y * charSize.height()
   ), m_backgroundColor);
 }
 

--- a/escher/src/text_input.cpp
+++ b/escher/src/text_input.cpp
@@ -47,12 +47,7 @@ void TextInput::ContentView::layoutSubviews() {
 }
 
 void TextInput::ContentView::reloadRectFromCursorPosition(size_t index, bool lineBreak) {
-  KDRect charRect = characterFrameAtIndex(index);
-  KDRect dirtyRect = KDRect(charRect.x(), charRect.y(), bounds().width() - charRect.x(), charRect.height());
-  if (lineBreak) {
-      dirtyRect = dirtyRect.unionedWith(KDRect(0, charRect.bottom()+1, bounds().width(), bounds().height()-charRect.bottom()-1));
-  }
-  markRectAsDirty(dirtyRect);
+  markRectAsDirty(bounds());
 }
 
 /* TextInput */

--- a/kandinsky/include/kandinsky/context.h
+++ b/kandinsky/include/kandinsky/context.h
@@ -16,6 +16,7 @@ public:
 
   // Text
   KDPoint drawString(const char * text, KDPoint p, KDText::FontSize size = KDText::FontSize::Large, KDColor textColor = KDColorBlack, KDColor backgroundColor = KDColorWhite, int maxLength = -1);
+  KDPoint drawString(const char * text, KDPoint p, const char * attr, KDText::FontSize size = KDText::FontSize::Large, int maxLength = -1);
   KDPoint blendString(const char * text, KDPoint p, KDText::FontSize size, KDColor textColor = KDColorBlack);
 
   // Line. Not anti-aliased.
@@ -33,7 +34,7 @@ protected:
   virtual void pullRect(KDRect rect, KDColor * pixels) = 0;
 private:
   KDRect absoluteFillRect(KDRect rect);
-  KDPoint writeString(const char * text, KDPoint p, KDText::FontSize size, KDColor textColor, KDColor backgroundColor, int maxLength, bool transparentBackground);
+  KDPoint writeString(const char * text, const char * attr, KDPoint p, KDText::FontSize size, KDColor textColor, KDColor backgroundColor, int maxLength, bool transparentBackground);
   void writeChar(char character, KDPoint p, KDText::FontSize size, KDColor textColor, KDColor backgroundColor, bool transparentBackground);
   KDPoint m_origin;
   KDRect m_clippingRect;

--- a/kandinsky/src/context_text.cpp
+++ b/kandinsky/src/context_text.cpp
@@ -3,18 +3,41 @@
 #include "small_font.h"
 #include "large_font.h"
 
+const KDColor palette[] = {
+  KDColor::RGB24(0x000000),
+  KDColor::RGB24(0x0000FF),
+  KDColor::RGB24(0x00AA00),
+  KDColor::RGB24(0x00AAAA),
+  KDColor::RGB24(0xDD0000),
+  KDColor::RGB24(0x900090),
+  KDColor::RGB24(0xFF7700),
+  KDColor::RGB24(0xAAAAAA),
+  KDColor::RGB24(0x555555),
+  KDColor::RGB24(0x5555FF),
+  KDColor::RGB24(0x55FF55),
+  KDColor::RGB24(0x55FFFF),
+  KDColor::RGB24(0xFF5555),
+  KDColor::RGB24(0xFF55FF),
+  KDColor::RGB24(0xFFFF55),
+  KDColor::RGB24(0xFFFFFF),
+  };
+
 KDColor smallCharacterBuffer[BITMAP_SmallFont_CHARACTER_WIDTH*BITMAP_SmallFont_CHARACTER_HEIGHT];
 KDColor largeCharacterBuffer[BITMAP_LargeFont_CHARACTER_WIDTH*BITMAP_LargeFont_CHARACTER_HEIGHT];
 
 KDPoint KDContext::drawString(const char * text, KDPoint p, KDText::FontSize size, KDColor textColor, KDColor backgroundColor, int maxLength) {
-  return writeString(text, p, size, textColor, backgroundColor, maxLength, false);
+  return writeString(text, nullptr, p, size, textColor, backgroundColor, maxLength, false);
+}
+
+KDPoint KDContext::drawString(const char * text, KDPoint p, const char * attr, KDText::FontSize size, int maxLength) {
+  return writeString(text, attr, p, size, KDColorBlack, KDColorWhite, maxLength, false);
 }
 
 KDPoint KDContext::blendString(const char * text, KDPoint p, KDText::FontSize size, KDColor textColor) {
-  return writeString(text, p, size, textColor, KDColorWhite, -1, true);
+  return writeString(text, nullptr, p, size, textColor, KDColorWhite, -1, true);
 }
 
-KDPoint KDContext::writeString(const char * text, KDPoint p, KDText::FontSize size, KDColor textColor, KDColor backgroundColor, int maxLength, bool transparentBackground) {
+KDPoint KDContext::writeString(const char * text, const char * attr, KDPoint p, KDText::FontSize size, KDColor textColor, KDColor backgroundColor, int maxLength, bool transparentBackground) {
   KDPoint position = p;
   int characterWidth = size == KDText::FontSize::Large ? BITMAP_LargeFont_CHARACTER_WIDTH : BITMAP_SmallFont_CHARACTER_WIDTH;
   int characterHeight = size == KDText::FontSize::Large ? BITMAP_LargeFont_CHARACTER_HEIGHT: BITMAP_SmallFont_CHARACTER_HEIGHT;
@@ -22,7 +45,12 @@ KDPoint KDContext::writeString(const char * text, KDPoint p, KDText::FontSize si
 
   const char * end = text+maxLength;
   while(*text != 0 && text != end) {
-    writeChar(*text, position, size, textColor, backgroundColor, transparentBackground);
+    if(attr == nullptr) {
+      writeChar(*text, position, size, textColor, backgroundColor, transparentBackground);
+    } else {
+      writeChar(*text, position, size, palette[*attr & 0x0f], palette[(~*attr >> 4) & 0x0f], false);
+      attr++;
+    }
     if (*text == '\n') {
       position = KDPoint(0, position.y()+characterHeight);
     } else if (*text == '\t') {


### PR DESCRIPTION
This adds syntax highlight to the python code editor.

I had to disable the "dirty rect" optimisation in TextInput, in order to have the full text updated when typing a triple quote comment, but I somewhat enhaced the TextArea rendering, by clearing only what is needed, line by line. This way, the scrolling almost flicker free.

The color scheme and highlighting logic is based on what is done in [IDLE](https://docs.python.org/3/library/idle.html)

A sample of the result:

![telechargement 2](https://user-images.githubusercontent.com/1298609/39677860-747f329e-5182-11e8-90aa-c581c6f0dc41.png)
