### PR TITLE
Math Toolbox Title Localization Fix

### DIFF
--- a/apps/apps_container.cpp
+++ b/apps/apps_container.cpp
@@ -58,9 +58,9 @@ Poincare::Context * AppsContainer::globalContext() {
 }
 
 MathToolbox * AppsContainer::mathToolbox() {
-  if(GlobalPreferences::sharedGlobalPreferences()->languageChanged || m_mathToolbox == NULL){
+  if(GlobalPreferences::sharedGlobalPreferences()->languageChanged || m_mathToolbox == nullptr){
     GlobalPreferences::sharedGlobalPreferences()->languageChanged = false;
-    if(m_mathToolbox != NULL){
+    if(m_mathToolbox != nullptr){
       delete(m_mathToolbox);
     }
     m_mathToolbox = new MathToolbox();

--- a/apps/apps_container.cpp
+++ b/apps/apps_container.cpp
@@ -58,7 +58,14 @@ Poincare::Context * AppsContainer::globalContext() {
 }
 
 MathToolbox * AppsContainer::mathToolbox() {
-  return &m_mathToolbox;
+  if(GlobalPreferences::sharedGlobalPreferences()->languageChanged || m_mathToolbox == NULL){
+    GlobalPreferences::sharedGlobalPreferences()->languageChanged = false;
+    if(m_mathToolbox != NULL){
+      delete(m_mathToolbox);
+    }
+    m_mathToolbox = new MathToolbox();
+  }
+  return m_mathToolbox;
 }
 
 VariableBoxController * AppsContainer::variableBoxController() {

--- a/apps/apps_container.h
+++ b/apps/apps_container.h
@@ -65,7 +65,7 @@ private:
   PicViewApp m_picViewApp;
 #endif
   Poincare::GlobalContext m_globalContext;
-  MathToolbox* m_mathToolbox = NULL;
+  MathToolbox* m_mathToolbox;
   VariableBoxController m_variableBoxController;
   ExamPopUpController m_examPopUpController;
   OnBoarding::UpdateController m_updateController;

--- a/apps/apps_container.h
+++ b/apps/apps_container.h
@@ -65,7 +65,7 @@ private:
   PicViewApp m_picViewApp;
 #endif
   Poincare::GlobalContext m_globalContext;
-  MathToolbox m_mathToolbox;
+  MathToolbox* m_mathToolbox = NULL;
   VariableBoxController m_variableBoxController;
   ExamPopUpController m_examPopUpController;
   OnBoarding::UpdateController m_updateController;

--- a/apps/global_preferences.cpp
+++ b/apps/global_preferences.cpp
@@ -20,6 +20,7 @@ I18n::Language GlobalPreferences::language() const {
 void GlobalPreferences::setLanguage(I18n::Language language) {
   if (language != m_language) {
     m_language = language;
+    languageChanged = true;
   }
 }
 

--- a/apps/global_preferences.h
+++ b/apps/global_preferences.h
@@ -20,6 +20,7 @@ public:
   int brightnessLevel() const;
   void setBrightnessLevel(int brightnessLevel);
   constexpr static int NumberOfBrightnessStates = 5;
+  bool languageChanged;
 private:
   I18n::Language m_language;
   ExamMode m_examMode;

--- a/apps/toolbox.de.i18n
+++ b/apps/toolbox.de.i18n
@@ -1,4 +1,4 @@
-Toolbox = "Toolbox"
+Toolbox = "Werkzeugkasten"
 AbsoluteValue = "Betragsfunktion"
 NthRoot = "n-te Wurzel"
 BasedLogarithm = "Logarithmus zur Basis a"

--- a/apps/toolbox.es.i18n
+++ b/apps/toolbox.es.i18n
@@ -1,4 +1,4 @@
-Toolbox = "Toolbox"
+Toolbox = "Caja de instrumento"
 AbsoluteValue = "Valor absoluto"
 NthRoot = "Raiz enesima"
 BasedLogarithm = "Logaritmo en base a"

--- a/apps/toolbox.fr.i18n
+++ b/apps/toolbox.fr.i18n
@@ -1,4 +1,4 @@
-Toolbox = "Toolbox"
+Toolbox = "Boite a utils"
 AbsoluteValue = "Valeur absolue"
 NthRoot = "Racine n-ieme"
 BasedLogarithm = "Logarithme base a"

--- a/apps/toolbox.fr.i18n
+++ b/apps/toolbox.fr.i18n
@@ -1,4 +1,4 @@
-Toolbox = "Boite a utils"
+Toolbox = "Boite a outils"
 AbsoluteValue = "Valeur absolue"
 NthRoot = "Racine n-ieme"
 BasedLogarithm = "Logarithme base a"

--- a/apps/toolbox.pt.i18n
+++ b/apps/toolbox.pt.i18n
@@ -1,4 +1,4 @@
-Toolbox = "Toolbox"
+Toolbox = "Caixa de ferramentas"
 AbsoluteValue = "Valor absoluto"
 NthRoot = "Radiciacao"
 BasedLogarithm = "Logaritmo na base a"


### PR DESCRIPTION
This is a fix for #343

I changed the translation files for the toolbox to say the name in the appropriate language. Unfortunately, this only worked in the Python toolbox. It had to do with the fact that the global MathToolbox would not get reinitialized when the language was changed.

**Fix Details:**
The toolbox i18n files have been updated. Now, every time the language is changed, a flag in GlobalPreferences is activated. When the MathToolbox is requested, it is initialized if it has to be (when a language changes or when it is created for the first time). It also frees up the memory used by the old toolbox.