### PR TITLE
[escher] Fix transparent view: absolute origin can be undefined

### DIFF
--- a/escher/src/transparent_view.cpp
+++ b/escher/src/transparent_view.cpp
@@ -2,7 +2,7 @@
 
 void TransparentView::markRectAsDirty(KDRect rect) {
   if (m_superview) {
-    m_superview->markRectAsDirty(KDRect(m_superview->pointFromPointInView(this, rect.origin()), rect.size()));
+    m_superview->markRectAsDirty(KDRect(rect.translatedBy(m_frame.origin())));
   }
   View::markRectAsDirty(rect);
 }


### PR DESCRIPTION
(because superviews have not been filled yet). Rather use m_frame.