### PR TITLE
[poincare] Fix VerticalOffsetLayout serialization

### DIFF
--- a/poincare/src/layout/vertical_offset_layout.cpp
+++ b/poincare/src/layout/vertical_offset_layout.cpp
@@ -185,10 +185,8 @@ int VerticalOffsetLayout::writeTextInBuffer(char * buffer, int bufferSize, int n
     return numberOfChar;
   }
   assert(m_type == Type::Superscript);
-  // If the layout is a superscript, write "^indice", with parentheses if needed
-  int numberOfChar = LayoutEngine::writeOneCharInBuffer(buffer, bufferSize, '^');
-  if (numberOfChar >= bufferSize-1) { return bufferSize-1; }
-  numberOfChar += LayoutEngine::writeInfixExpressionLayoutTextInBuffer(this, buffer+numberOfChar, bufferSize-numberOfChar, numberOfSignificantDigits, "^");
+  // If the layout is a superscript, write "^indice", with parentheses
+  int numberOfChar = LayoutEngine::writePrefixExpressionLayoutTextInBuffer(this, buffer, bufferSize, numberOfSignificantDigits, "^");
   if (numberOfChar >= bufferSize-1) { return bufferSize-1; }
 
   // Add a multiplication if omitted.


### PR DESCRIPTION
The layout representing 2^(6^(1)6), without the parentheses, became
2^(6^(1))*6