### PR TITLE
Revert "[poincare] Finer addition of parenthesis when serializing fra…

### DIFF
--- a/poincare/include/poincare/expression_layout.h
+++ b/poincare/include/poincare/expression_layout.h
@@ -102,8 +102,6 @@ public:
   bool addGreySquaresToAllMatrixAncestors();
   bool removeGreySquaresFromAllMatrixAncestors();
   bool hasText() const;
-  virtual bool needsParenthesesWithParent() const { return false; }
-  virtual bool childMightNeedParentheses() const { return false; }
   virtual bool isCollapsable(int * numberOfOpenParenthesis, bool goingLeft) const { return true; }
   /* isCollapsable is used when adding a sibling fraction: should the layout be
    * inserted in the numerator (or denominator)? For instance, 1+2|3-4 should

--- a/poincare/include/poincare/layout_engine.h
+++ b/poincare/include/poincare/layout_engine.h
@@ -32,6 +32,7 @@ public:
       const char * operatorName);
 
   /* ExpressionLayout to Text */
+  typedef bool (*ChildNeedsParenthesis)(const char * operatorName);
   static int writeInfixExpressionLayoutTextInBuffer(
       const ExpressionLayout * expressionLayout,
       char * buffer,
@@ -39,7 +40,9 @@ public:
       int numberOfDigits,
       const char * operatorName,
       int firstChildIndex = 0,
-      int lastChildIndex = -1);
+      int lastChildIndex = -1,
+      ChildNeedsParenthesis childNeedsParenthesis = [](const char * operatorName) {
+        return (operatorName[1] == 0 && (operatorName[0] == divideChar)); });
   static int writePrefixExpressionLayoutTextInBuffer(
       const ExpressionLayout * expressionLayout,
       char * buffer,
@@ -54,7 +57,7 @@ public:
 private:
   static constexpr char divideChar = '/';
   // These two functions return the index of the null-terminating char.
-  static int writeInfixExpressionOrExpressionLayoutTextInBuffer(const Expression * expression, const ExpressionLayout * expressionLayout, char * buffer, int bufferSize, int numberOfDigits, const char * operatorName, int firstChildIndex, int lastChildIndex);
+  static int writeInfixExpressionOrExpressionLayoutTextInBuffer(const Expression * expression, const ExpressionLayout * expressionLayout, char * buffer, int bufferSize, int numberOfDigits, const char * operatorName, int firstChildIndex, int lastChildIndex, ChildNeedsParenthesis childNeedsParenthesis);
   static int writePrefixExpressionOrExpressionLayoutTextInBuffer(const Expression * expression, const ExpressionLayout * expressionLayout, char * buffer, int bufferSize, int numberOfDigits, const char * operatorName, bool writeFirstChild = true);
 };
 

--- a/poincare/src/layout/fraction_layout.h
+++ b/poincare/src/layout/fraction_layout.h
@@ -34,7 +34,6 @@ public:
    * an omitted multiplication layout factor. We have the same problem with
    *  2^3 1/2 being serialized as 2^3**1/2, so must override the Right version
    * and not canBeOmittedMultiplicationLeftFactor. */
-  bool childMightNeedParentheses() const override { return true; }
 protected:
   void render(KDContext * ctx, KDPoint p, KDColor expressionColor, KDColor backgroundColor) override;
   KDSize computeSize() override;

--- a/poincare/src/layout/horizontal_layout.cpp
+++ b/poincare/src/layout/horizontal_layout.cpp
@@ -337,19 +337,6 @@ ExpressionLayoutCursor HorizontalLayout::equivalentCursor(ExpressionLayoutCursor
   return result;
 }
 
-bool HorizontalLayout::needsParenthesesWithParent() const {
-  if (!parent()->childMightNeedParentheses()) {
-    return false;
-  }
-  int numberOfOpenParenthesis = 0;
-  for (int i = 0; i < numberOfChildren(); i++) {
-    if (!child(i)->isCollapsable(&numberOfOpenParenthesis, true)) {
-      return true;
-    }
-  }
-  return false;
-}
-
 KDSize HorizontalLayout::computeSize() {
   KDCoordinate totalWidth = 0;
   int i = 0;

--- a/poincare/src/layout/horizontal_layout.h
+++ b/poincare/src/layout/horizontal_layout.h
@@ -44,7 +44,6 @@ public:
   // Other
   bool isHorizontal() const override { return true; }
   bool isEmpty() const override { return m_numberOfChildren == 1 && child(0)->isEmpty(); }
-  bool needsParenthesesWithParent() const override;
   bool isCollapsable(int * numberOfOpenParenthesis, bool goingLeft) const override { return m_numberOfChildren != 0; }
 protected:
   void render(KDContext * ctx, KDPoint p, KDColor expressionColor, KDColor backgroundColor) override {}

--- a/poincare/src/layout/vertical_offset_layout.cpp
+++ b/poincare/src/layout/vertical_offset_layout.cpp
@@ -185,11 +185,8 @@ int VerticalOffsetLayout::writeTextInBuffer(char * buffer, int bufferSize, int n
     return numberOfChar;
   }
   assert(m_type == Type::Superscript);
-  // If the layout is a superscript, write "^indice", with parentheses if needed
-  int numberOfChar = LayoutEngine::writeOneCharInBuffer(buffer, bufferSize, '^');
-  if (numberOfChar >= bufferSize-1) { return bufferSize-1; }
-  numberOfChar += LayoutEngine::writeInfixExpressionLayoutTextInBuffer(this, buffer+numberOfChar, bufferSize-numberOfChar, numberOfSignificantDigits, "^");
-  if (numberOfChar >= bufferSize-1) { return bufferSize-1; }
+  // If the layout is a superscript, write "^(indice)"
+  int numberOfChar = LayoutEngine::writePrefixExpressionLayoutTextInBuffer(this, buffer, bufferSize, numberOfSignificantDigits, "^");
 
   // Add a multiplication if omitted.
   int indexInParent = -1;

--- a/poincare/src/layout/vertical_offset_layout.h
+++ b/poincare/src/layout/vertical_offset_layout.h
@@ -32,7 +32,6 @@ public:
   // Other
   bool mustHaveLeftSibling() const override { return true; }
   bool isVerticalOffset() const override { return true; }
-  bool childMightNeedParentheses() const override { return m_type == Type::Superscript; }
 protected:
   ExpressionLayout * indiceLayout() { return editableChild(0);}
   ExpressionLayout * baseLayout();

--- a/poincare/src/layout_engine.cpp
+++ b/poincare/src/layout_engine.cpp
@@ -81,22 +81,22 @@ ExpressionLayout * LayoutEngine::createLogLayout(ExpressionLayout * argument, Ex
 }
 
 int LayoutEngine::writeInfixExpressionTextInBuffer(const Expression * expression, char * buffer, int bufferSize, int numberOfDigits, const char * operatorName) {
-  return writeInfixExpressionOrExpressionLayoutTextInBuffer(expression, nullptr, buffer, bufferSize, numberOfDigits, operatorName, 0, -1);
+  return writeInfixExpressionOrExpressionLayoutTextInBuffer(expression, nullptr, buffer, bufferSize, numberOfDigits, operatorName, 0, -1, [](const char * operatorName) { return true; });
 }
 
 int LayoutEngine::writePrefixExpressionTextInBuffer(const Expression * expression, char * buffer, int bufferSize, int numberOfDigits, const char * operatorName) {
   return writePrefixExpressionOrExpressionLayoutTextInBuffer(expression, nullptr, buffer, bufferSize, numberOfDigits, operatorName);
 }
 
-int LayoutEngine::writeInfixExpressionLayoutTextInBuffer(const ExpressionLayout * expressionLayout, char * buffer, int bufferSize, int numberOfDigits, const char * operatorName, int firstChildIndex, int lastChildIndex) {
-  return writeInfixExpressionOrExpressionLayoutTextInBuffer(nullptr, expressionLayout, buffer, bufferSize, numberOfDigits, operatorName, firstChildIndex, lastChildIndex);
+int LayoutEngine::writeInfixExpressionLayoutTextInBuffer(const ExpressionLayout * expressionLayout, char * buffer, int bufferSize, int numberOfDigits, const char * operatorName, int firstChildIndex, int lastChildIndex, ChildNeedsParenthesis childNeedsParenthesis) {
+  return writeInfixExpressionOrExpressionLayoutTextInBuffer(nullptr, expressionLayout, buffer, bufferSize, numberOfDigits, operatorName, firstChildIndex, lastChildIndex, childNeedsParenthesis);
 }
 
 int LayoutEngine::writePrefixExpressionLayoutTextInBuffer(const ExpressionLayout * expressionLayout, char * buffer, int bufferSize, int numberOfDigits, const char * operatorName, bool writeFirstChild) {
   return writePrefixExpressionOrExpressionLayoutTextInBuffer(nullptr, expressionLayout, buffer, bufferSize, numberOfDigits, operatorName, writeFirstChild);
 }
 
-int LayoutEngine::writeInfixExpressionOrExpressionLayoutTextInBuffer(const Expression * expression, const ExpressionLayout * expressionLayout, char * buffer, int bufferSize, int numberOfDigits, const char * operatorName, int firstChildIndex, int lastChildIndex) {
+int LayoutEngine::writeInfixExpressionOrExpressionLayoutTextInBuffer(const Expression * expression, const ExpressionLayout * expressionLayout, char * buffer, int bufferSize, int numberOfDigits, const char * operatorName, int firstChildIndex, int lastChildIndex, ChildNeedsParenthesis childNeedsParenthesis) {
   assert(expression != nullptr || expressionLayout != nullptr);
   if (bufferSize == 0) {
     return -1;
@@ -109,44 +109,37 @@ int LayoutEngine::writeInfixExpressionOrExpressionLayoutTextInBuffer(const Expre
     return bufferSize-1;
   }
 
-  bool currentChildNeedsParentheses =
-    (expression != nullptr
-      && expression->operand(firstChildIndex)->needParenthesisWithParent(expression))
-    || (expression == nullptr
-        && expressionLayout->child(firstChildIndex)->needsParenthesesWithParent());
-
-  // Write first operand
-  if (currentChildNeedsParentheses){
+  if ((expression != nullptr && expression->operand(firstChildIndex)->needParenthesisWithParent(expression))
+      || (expression == nullptr && childNeedsParenthesis(operatorName)))
+  {
     buffer[numberOfChar++] = '(';
-    if (numberOfChar >= bufferSize-1) { return bufferSize-1; }
+    if (numberOfChar >= bufferSize-1) {
+      return bufferSize-1;
+    }
   }
+
   numberOfChar += (expression != nullptr) ? expression->operand(firstChildIndex)->writeTextInBuffer(buffer+numberOfChar, bufferSize-numberOfChar, numberOfDigits) : expressionLayout->child(firstChildIndex)->writeTextInBuffer(buffer+numberOfChar, bufferSize-numberOfChar, numberOfDigits);
-  if (currentChildNeedsParentheses){
+  if ((expression != nullptr && expression->operand(firstChildIndex)->needParenthesisWithParent(expression))
+      || (expression == nullptr && childNeedsParenthesis(operatorName)))
+  {
     buffer[numberOfChar++] = ')';
     if (numberOfChar >= bufferSize-1) { return bufferSize-1; }
   }
-
   int lastIndex = lastChildIndex < 0 ? numberOfOperands - 1 : lastChildIndex;
   for (int i = firstChildIndex + 1; i < lastIndex+1; i++) {
     if (numberOfChar >= bufferSize-1) { return bufferSize-1; }
-
-    // Write operator
     numberOfChar += strlcpy(buffer+numberOfChar, operatorName, bufferSize-numberOfChar);
     if (numberOfChar >= bufferSize-1) { return bufferSize-1; }
-
-    // Write next operand
-    currentChildNeedsParentheses =
-    (expression != nullptr
-      && expression->operand(i)->needParenthesisWithParent(expression))
-    || (expression == nullptr
-        && expressionLayout->child(i)->needsParenthesesWithParent());
-
-    if (currentChildNeedsParentheses) {
+    if ((expression != nullptr && expression->operand(i)->needParenthesisWithParent(expression))
+      || (expression == nullptr && childNeedsParenthesis(operatorName)))
+    {
       buffer[numberOfChar++] = '(';
       if (numberOfChar >= bufferSize-1) { return bufferSize-1; }
     }
     numberOfChar += (expression != nullptr) ? expression->operand(i)->writeTextInBuffer(buffer+numberOfChar, bufferSize-numberOfChar, numberOfDigits) : expressionLayout->child(i)->writeTextInBuffer(buffer+numberOfChar, bufferSize-numberOfChar, numberOfDigits);
-    if (currentChildNeedsParentheses) {
+    if ((expression != nullptr && expression->operand(i)->needParenthesisWithParent(expression))
+      || (expression == nullptr && childNeedsParenthesis(operatorName)))
+    {
       buffer[numberOfChar++] = ')';
       if (numberOfChar >= bufferSize-1) { return bufferSize-1; }
     }


### PR DESCRIPTION
…ction"

This reverts commit a84686d2626d94eee09f82451eb018f56a4d3fc8.

The reverted commit created serialization errors. For instance,
the layout 1/(2^(3) 3) , without the parenthesis, would serialize to
1/(2^3) * 3.