### PR TITLE
[calculation] Fix heap overflow

### DIFF
--- a/apps/calculation/calculation.h
+++ b/apps/calculation/calculation.h
@@ -24,15 +24,16 @@ public:
   /* c.reset() is the equivalent of c = Calculation() without copy assingment. */
   void reset();
   void setContent(const char * c, Poincare::Context * context, Poincare::Expression * ansExpression);
+  KDCoordinate height(Poincare::Context * context);
   const char * inputText();
   const char * exactOutputText();
   const char * approximateOutputText();
   Poincare::Expression * input();
-  Poincare::ExpressionLayout * inputLayout();
+  Poincare::ExpressionLayout * createInputLayout();
   Poincare::Expression * approximateOutput(Poincare::Context * context);
   Poincare::Expression * exactOutput(Poincare::Context * context);
-  Poincare::ExpressionLayout * exactOutputLayout(Poincare::Context * context);
-  Poincare::ExpressionLayout * approximateOutputLayout(Poincare::Context * context);
+  Poincare::ExpressionLayout * createExactOutputLayout(Poincare::Context * context);
+  Poincare::ExpressionLayout * createApproximateOutputLayout(Poincare::Context * context);
   bool isEmpty();
   void tidy();
   bool shouldOnlyDisplayApproximateOutput(Poincare::Context * context);
@@ -46,11 +47,9 @@ private:
   char m_exactOutputText[k_printedExpressionSize];
   char m_approximateOutputText[k_printedExpressionSize];
   Poincare::Expression * m_input;
-  Poincare::ExpressionLayout * m_inputLayout;
   Poincare::Expression * m_exactOutput;
-  Poincare::ExpressionLayout * m_exactOutputLayout;
   Poincare::Expression * m_approximateOutput;
-  Poincare::ExpressionLayout * m_approximateOutputLayout;
+  KDCoordinate m_height;
   EqualSign m_equalSign;
 };
 

--- a/apps/calculation/history_controller.cpp
+++ b/apps/calculation/history_controller.cpp
@@ -158,17 +158,8 @@ KDCoordinate HistoryController::rowHeight(int j) {
     return 0;
   }
   Calculation * calculation = m_calculationStore->calculationAtIndex(j);
-  KDCoordinate inputHeight = calculation->inputLayout()->size().height();
   App * calculationApp = (App *)app();
-  Poincare::ExpressionLayout * approximateLayout = calculation->approximateOutputLayout(calculationApp->localContext());
-  KDCoordinate approximateOutputHeight = approximateLayout->size().height();
-  if (calculation->shouldOnlyDisplayApproximateOutput(calculationApp->localContext())) {
-    return inputHeight + approximateOutputHeight + 3*HistoryViewCell::k_digitVerticalMargin;
-  }
-  Poincare::ExpressionLayout * exactLayout = calculation->exactOutputLayout(calculationApp->localContext());
-  KDCoordinate exactOutputHeight = exactLayout->size().height();
-  KDCoordinate outputHeight = max(exactLayout->baseline(), approximateLayout->baseline()) + max(exactOutputHeight-exactLayout->baseline(), approximateOutputHeight-approximateLayout->baseline());
-  return inputHeight + outputHeight + 3*HistoryViewCell::k_digitVerticalMargin;
+  return calculation->height(calculationApp->localContext()) + 3*HistoryViewCell::k_digitVerticalMargin;
 }
 
 KDCoordinate HistoryController::cumulatedHeightFromIndex(int j) {

--- a/apps/calculation/history_view_cell.h
+++ b/apps/calculation/history_view_cell.h
@@ -15,6 +15,7 @@ public:
     Output
   };
   HistoryViewCell(Responder * parentResponder);
+  ~HistoryViewCell();
   void reloadCell() override;
   void reloadScroll();
   void setEven(bool even) override;
@@ -35,6 +36,9 @@ public:
   OutputExpressionsView * outputView();
 private:
   constexpr static KDCoordinate k_resultWidth = 80;
+  Poincare::ExpressionLayout * m_inputLayout;
+  Poincare::ExpressionLayout * m_exactOutputLayout;
+  Poincare::ExpressionLayout * m_approximateOutputLayout;
   ScrollableExpressionView m_inputView;
   ScrollableOutputExpressionsView m_scrollableOutputView;
   SubviewType m_selectedSubviewType;


### PR DESCRIPTION
Do not memoize the expression layouts but the expressions final heights to avoid overflowing the heap. The expression layouts are kept in the cell which are fewer then the number of calculations.