### PR TITLE
[escher] ExpressionLayoutFieldDelegate should not take a text as parameter but a layout

### DIFF
--- a/apps/calculation/edit_expression_controller.h
+++ b/apps/calculation/edit_expression_controller.h
@@ -19,7 +19,6 @@ public:
   void didBecomeFirstResponder() override;
   void viewDidDisappear() override;
   bool handleEvent(Ion::Events::Event event) override;
-  const char * textBody();
   void insertTextBody(const char * text);
 
   /* TextFieldDelegate */
@@ -29,7 +28,7 @@ public:
 
   /* ExpressionLayoutFieldDelegate */
   bool expressionLayoutFieldDidReceiveEvent(::ExpressionLayoutField * expressionLayoutField, Ion::Events::Event event) override;
-  bool expressionLayoutFieldDidFinishEditing(::ExpressionLayoutField * expressionLayoutField, const char * text, Ion::Events::Event event) override;
+  bool expressionLayoutFieldDidFinishEditing(::ExpressionLayoutField * expressionLayoutField, Poincare::ExpressionLayout * layout, Ion::Events::Event event) override;
   bool expressionLayoutFieldDidAbortEditing(::ExpressionLayoutField * expressionLayoutField) override;
   void expressionLayoutFieldDidChangeSize(::ExpressionLayoutField * expressionLayoutField) override;
 
@@ -60,7 +59,7 @@ private:
   void unloadView(View * view) override;
   void reloadView();
   bool inputViewDidReceiveEvent(Ion::Events::Event event);
-  bool inputViewDidFinishEditing(const char * text, Ion::Events::Event event);
+  bool inputViewDidFinishEditing(const char * text, Poincare::ExpressionLayout * layout);
   bool inputViewDidAbortEditing(const char * text);
   Shared::TextFieldDelegateApp * textFieldDelegateApp() override;
   Shared::ExpressionFieldDelegateApp * expressionFieldDelegateApp() override;

--- a/apps/shared/expression_layout_field_delegate.cpp
+++ b/apps/shared/expression_layout_field_delegate.cpp
@@ -12,8 +12,8 @@ bool ExpressionLayoutFieldDelegate::expressionLayoutFieldDidReceiveEvent(Express
   return expressionFieldDelegateApp()->expressionLayoutFieldDidReceiveEvent(expressionLayoutField, event);
 }
 
-bool ExpressionLayoutFieldDelegate::expressionLayoutFieldDidFinishEditing(ExpressionLayoutField * expressionLayoutField, const char * text, Ion::Events::Event event) {
-  return expressionFieldDelegateApp()->expressionLayoutFieldDidFinishEditing(expressionLayoutField, text, event);
+bool ExpressionLayoutFieldDelegate::expressionLayoutFieldDidFinishEditing(ExpressionLayoutField * expressionLayoutField, ExpressionLayout * layout, Ion::Events::Event event) {
+  return expressionFieldDelegateApp()->expressionLayoutFieldDidFinishEditing(expressionLayoutField, layout, event);
 }
 
 bool ExpressionLayoutFieldDelegate::expressionLayoutFieldDidAbortEditing(ExpressionLayoutField * expressionLayoutField) {

--- a/apps/shared/expression_layout_field_delegate.h
+++ b/apps/shared/expression_layout_field_delegate.h
@@ -10,7 +10,7 @@ class ExpressionLayoutFieldDelegate : public ::ExpressionLayoutFieldDelegate {
 public:
   bool expressionLayoutFieldShouldFinishEditing(ExpressionLayoutField * expressionLayoutField, Ion::Events::Event event) override;
   bool expressionLayoutFieldDidReceiveEvent(ExpressionLayoutField * expressionLayoutField, Ion::Events::Event event) override;
-  bool expressionLayoutFieldDidFinishEditing(ExpressionLayoutField * expressionLayoutField, const char * text, Ion::Events::Event event) override;
+  bool expressionLayoutFieldDidFinishEditing(ExpressionLayoutField * expressionLayoutField, Poincare::ExpressionLayout * layout, Ion::Events::Event event) override;
   bool expressionLayoutFieldDidAbortEditing(ExpressionLayoutField * expressionLayoutField) override;
   void expressionLayoutFieldDidChangeSize(ExpressionLayoutField * expressionLayoutField) override;
   Toolbox * toolboxForExpressionLayoutField(ExpressionLayoutField * expressionLayoutField) override;

--- a/escher/include/escher/expression_field.h
+++ b/escher/include/escher/expression_field.h
@@ -13,6 +13,11 @@ public:
 
   void setEditing(bool isEditing, bool reinitDraftBuffer = true);
   bool isEditing() const;
+  /* Warning: this function is VERY dangerous! Indeed: sometimes the
+   * m_expressionLayoutField might overflow the m_textBuffer once serialized
+   * and still have been accepted before because the model can hold a longer
+   * buffer. This is the case in the application 'Calculation' and we do not
+   * use text() there... TODO: change text() for fillTextInBuffer?*/
   const char * text();
   void setText(const char * text);
   void reload();

--- a/escher/include/escher/expression_layout_field.h
+++ b/escher/include/escher/expression_layout_field.h
@@ -22,7 +22,7 @@ public:
   bool hasText() const;
   int writeTextInBuffer(char * buffer, int bufferLength);
   bool handleEventWithText(const char * text, bool indentation = false, bool forceCursorRightOfText = false) override;
-  Poincare::ExpressionLayout * expressionLayout();
+  Poincare::ExpressionLayout * expressionLayout() const;
   char XNTChar();
   void setBackgroundColor(KDColor c) override;
 

--- a/escher/include/escher/expression_layout_field_delegate.h
+++ b/escher/include/escher/expression_layout_field_delegate.h
@@ -10,7 +10,7 @@ class ExpressionLayoutFieldDelegate {
 public:
   virtual bool expressionLayoutFieldShouldFinishEditing(ExpressionLayoutField * expressionLayoutField, Ion::Events::Event event) = 0;
   virtual bool expressionLayoutFieldDidReceiveEvent(ExpressionLayoutField * expressionLayoutField, Ion::Events::Event event) = 0;
-  virtual bool expressionLayoutFieldDidFinishEditing(ExpressionLayoutField * expressionLayoutField, const char * text, Ion::Events::Event event) { return false; }
+  virtual bool expressionLayoutFieldDidFinishEditing(ExpressionLayoutField * expressionLayoutField, Poincare::ExpressionLayout * layout, Ion::Events::Event event) { return false; }
   virtual bool expressionLayoutFieldDidAbortEditing(ExpressionLayoutField * expressionLayoutField) { return false; }
   virtual void expressionLayoutFieldDidChangeSize(ExpressionLayoutField * expressionLayoutField) {}
   virtual Toolbox * toolboxForExpressionLayoutField(ExpressionLayoutField * expressionLayoutField) = 0;

--- a/escher/include/escher/input_view_controller.h
+++ b/escher/include/escher/input_view_controller.h
@@ -7,6 +7,7 @@
 #include <escher/invocation.h>
 #include <escher/text_field.h>
 #include <escher/text_field_delegate.h>
+#include <poincare.h>
 
 /* TODO Implement a split view. Because we use a modal view, the main view is
  * redrawn underneath the modal view, which is visible and ugly. */
@@ -28,7 +29,7 @@ public:
   /* ExpressionLayoutFieldDelegate */
   bool expressionLayoutFieldShouldFinishEditing(ExpressionLayoutField * expressionLayoutField, Ion::Events::Event event) override;
   bool expressionLayoutFieldDidReceiveEvent(ExpressionLayoutField * expressionLayoutField, Ion::Events::Event event) override;
-  bool expressionLayoutFieldDidFinishEditing(ExpressionLayoutField * expressionLayoutField, const char * text, Ion::Events::Event event) override;
+  bool expressionLayoutFieldDidFinishEditing(ExpressionLayoutField * expressionLayoutField, Poincare::ExpressionLayout * layout, Ion::Events::Event event) override;
   bool expressionLayoutFieldDidAbortEditing(ExpressionLayoutField * expressionLayoutField) override;
   void expressionLayoutFieldDidChangeSize(ExpressionLayoutField * expressionLayoutField) override;
   Toolbox * toolboxForExpressionLayoutField(ExpressionLayoutField * expressionLayoutField) override;

--- a/escher/src/expression_layout_field.cpp
+++ b/escher/src/expression_layout_field.cpp
@@ -90,13 +90,13 @@ bool ExpressionLayoutField::privateHandleMoveEvent(Ion::Events::Event event, boo
     if (m_contentView.cursor()->pointedExpressionLayout()->removeGreySquaresFromAllMatrixAncestors()) {
       *shouldRecomputeLayout = true;
     }
-    result.setPointedExpressionLayout(m_contentView.expressionView()->expressionLayout());
+    result.setPointedExpressionLayout(expressionLayout());
     result.setPosition(Poincare::ExpressionLayoutCursor::Position::Left);
   } else if (event == Ion::Events::ShiftRight) {
     if (m_contentView.cursor()->pointedExpressionLayout()->removeGreySquaresFromAllMatrixAncestors()) {
       *shouldRecomputeLayout = true;
     }
-    result.setPointedExpressionLayout(m_contentView.expressionView()->expressionLayout());
+    result.setPointedExpressionLayout(expressionLayout());
     result.setPosition(Poincare::ExpressionLayoutCursor::Position::Right);
   }
   if (result.isDefined()) {
@@ -120,14 +120,14 @@ bool ExpressionLayoutField::privateHandleEvent(Ion::Events::Event event) {
   }
   if (isEditing() && expressionLayoutFieldShouldFinishEditing(event)) {
     setEditing(false);
-    if (m_delegate->expressionLayoutFieldDidFinishEditing(this, m_contentView.expressionView()->expressionLayout(), event)) {
+    if (m_delegate->expressionLayoutFieldDidFinishEditing(this, expressionLayout(), event)) {
       clearLayout();
     }
     return true;
   }
   if ((event == Ion::Events::OK || event == Ion::Events::EXE) && !isEditing()) {
     setEditing(true);
-    m_contentView.cursor()->setPointedExpressionLayout(m_contentView.expressionView()->expressionLayout());
+    m_contentView.cursor()->setPointedExpressionLayout(expressionLayout());
     m_contentView.cursor()->setPosition(Poincare::ExpressionLayoutCursor::Position::Right);
     return true;
   }
@@ -160,7 +160,7 @@ bool ExpressionLayoutField::privateHandleEvent(Ion::Events::Event event) {
 
 void ExpressionLayoutField::reload() {
   KDSize previousSize = minimalSizeForOptimalDisplay();
-  m_contentView.expressionView()->expressionLayout()->invalidAllSizesPositionsAndBaselines();
+  expressionLayout()->invalidAllSizesPositionsAndBaselines();
   KDSize newSize = minimalSizeForOptimalDisplay();
   if (m_delegate && previousSize.height() != newSize.height()) {
     m_delegate->expressionLayoutFieldDidChangeSize(this);
@@ -171,11 +171,11 @@ void ExpressionLayoutField::reload() {
 }
 
 bool ExpressionLayoutField::hasText() const {
-  return m_contentView.expressionView()->expressionLayout()->hasText();
+  return expressionLayout()->hasText();
 }
 
 int ExpressionLayoutField::writeTextInBuffer(char * buffer, int bufferLength) {
-  return m_contentView.expressionView()->expressionLayout()->writeTextInBuffer(buffer, bufferLength);
+  return expressionLayout()->writeTextInBuffer(buffer, bufferLength);
 }
 
 bool ExpressionLayoutField::handleEventWithText(const char * text, bool indentation, bool forceCursorRightOfText) {
@@ -242,7 +242,7 @@ bool ExpressionLayoutField::handleEventWithText(const char * text, bool indentat
   return true;
 }
 
-Poincare::ExpressionLayout * ExpressionLayoutField::expressionLayout() {
+Poincare::ExpressionLayout * ExpressionLayoutField::expressionLayout() const {
   return m_contentView.expressionView()->expressionLayout();
 }
 

--- a/escher/src/expression_layout_field.cpp
+++ b/escher/src/expression_layout_field.cpp
@@ -120,10 +120,7 @@ bool ExpressionLayoutField::privateHandleEvent(Ion::Events::Event event) {
   }
   if (isEditing() && expressionLayoutFieldShouldFinishEditing(event)) {
     setEditing(false);
-    int bufferSize = TextField::maxBufferSize();
-    char buffer[bufferSize];
-    m_contentView.expressionView()->expressionLayout()->writeTextInBuffer(buffer, bufferSize);
-    if (m_delegate->expressionLayoutFieldDidFinishEditing(this, buffer, event)) {
+    if (m_delegate->expressionLayoutFieldDidFinishEditing(this, m_contentView.expressionView()->expressionLayout(), event)) {
       clearLayout();
     }
     return true;

--- a/escher/src/input_view_controller.cpp
+++ b/escher/src/input_view_controller.cpp
@@ -78,7 +78,7 @@ bool InputViewController::expressionLayoutFieldDidReceiveEvent(ExpressionLayoutF
   return m_expressionLayoutFieldDelegate->expressionLayoutFieldDidReceiveEvent(expressionLayoutField, event);
 }
 
-bool InputViewController::expressionLayoutFieldDidFinishEditing(ExpressionLayoutField * expressionLayoutField, const char * text, Ion::Events::Event event) {
+bool InputViewController::expressionLayoutFieldDidFinishEditing(ExpressionLayoutField * expressionLayoutField, Poincare::ExpressionLayout * layout, Ion::Events::Event event) {
   return inputViewDidFinishEditing();
 }
 


### PR DESCRIPTION
Warning: in ExpressionField: the serialized layout is not guaranteed to
be small enough to fill in the text buffer