### PR TITLE
[ion] Blackbox keyboard scan

### DIFF
--- a/ion/src/shared/dummy/keyboard.cpp
+++ b/ion/src/shared/dummy/keyboard.cpp
@@ -4,7 +4,7 @@ namespace Ion {
 namespace Keyboard {
 
 State scan() {
-  return 0xFFFFFFFFFFFFFF;
+  return 0x00000000000000;
 }
 
 }


### PR DESCRIPTION
The scan of keyboard in Blackbox should indicate that no key is pressed in order to avoid interrupting all simplification