### PR TITLE
[poincare] Fix fix CharLayout

### DIFF
--- a/poincare/src/layout/char_layout.cpp
+++ b/poincare/src/layout/char_layout.cpp
@@ -59,13 +59,6 @@ bool CharLayout::isCollapsable(int * numberOfOpenParenthesis, bool goingLeft) co
   return true;
 }
 
-bool CharLayout::canBeOmittedMultiplicationLeftFactor() const {
-  return m_char != Ion::Charset::Sto;
-}
-bool CharLayout::canBeOmittedMultiplicationRightFactor() const {
-  return m_char != Ion::Charset::Sto;
-}
-
 void CharLayout::render(KDContext * ctx, KDPoint p, KDColor expressionColor, KDColor backgroundColor) {
   char string[2] = {m_char, 0};
   ctx->drawString(string, p, m_fontSize, expressionColor, backgroundColor);

--- a/poincare/src/layout/char_layout.h
+++ b/poincare/src/layout/char_layout.h
@@ -28,8 +28,6 @@ public:
 
   // Other
   bool isCollapsable(int * numberOfOpenParenthesis, bool goingLeft) const override;
-  bool canBeOmittedMultiplicationLeftFactor() const override;
-  bool canBeOmittedMultiplicationRightFactor() const override;
 protected:
   void render(KDContext * ctx, KDPoint p, KDColor expressionColor, KDColor backgroundColor) override;
   KDPoint positionOfChild(ExpressionLayout * child) override {


### PR DESCRIPTION
Avoid adding multiplication sign between Sto and another expression without breaking other writeTextInBuffer ('1+x+x^2+x^3')