### PR TITLE
[kandinsky] use pkg-config instead of freetype-config

### DIFF
--- a/kandinsky/Makefile
+++ b/kandinsky/Makefile
@@ -30,8 +30,8 @@ generated_headers += $(addprefix kandinsky/src/, small_font.h large_font.h)
 small_font_files = $(addprefix kandinsky/src/, small_font.h small_font.c)
 large_font_files = $(addprefix kandinsky/src/, large_font.h large_font.c)
 
-RASTERIZER_CFLAGS := -std=c99 `freetype-config --cflags`
-RASTERIZER_LDFLAGS := `freetype-config --libs`
+RASTERIZER_CFLAGS := -std=c99 `pkg-config freetype2 --cflags`
+RASTERIZER_LDFLAGS := `pkg-config freetype2 --libs`
 
 ifdef LIBPNG_PATH
   small_font_files += kandinsky/src/small_font.png


### PR DESCRIPTION
Since freetype2 version 2.9.1 freetype-config has been deprecated and is not installed by default anymore: https://sourceforge.net/projects/freetype/files/freetype2/2.9.1/

Fixes #502.