### PR TITLE
[statistics] Recompute the histogram range parameters if the store has changed

### DIFF
--- a/apps/statistics/histogram_controller.cpp
+++ b/apps/statistics/histogram_controller.cpp
@@ -84,6 +84,7 @@ void HistogramController::didBecomeFirstResponder() {
   if (*m_storeVersion != storeChecksum) {
     *m_storeVersion = storeChecksum;
     initBarParameters();
+    initRangeParameters();
   }
   uint32_t barChecksum = m_store->barChecksum();
   if (*m_barVersion != barChecksum) {


### PR DESCRIPTION
Even if the bar parameters has not changed, the maximal size might differ.