### PR TITLE
[poincare] Rational Power: always reduce p^(-1) if p rational

### DIFF
--- a/poincare/src/power.cpp
+++ b/poincare/src/power.cpp
@@ -821,6 +821,9 @@ bool Power::isNthRootOfUnity() const {
 }
 
 bool Power::RationalExponentShouldNotBeReduced(const Rational * b, const Rational * r) {
+  if (r->isMinusOne()) {
+    return false;
+  }
   /* We check that the simplification does not involve too complex power of
    * integers (ie 3^999, 120232323232^50) that would take too much time to
    * compute:


### PR DESCRIPTION
Otherwise, it causes bug when trying to reduce to same denominator.
For example:
  In Calculation app, type:
    `'6' OK,
    'Y-ans/(ans*ans*ans*ans*ans)', OK
    OK
    OK
    OK`
 --> crash