### PR TITLE
[poincare] Fix layout collapsing

### DIFF
--- a/poincare/src/layout/expression_layout.cpp
+++ b/poincare/src/layout/expression_layout.cpp
@@ -492,7 +492,10 @@ void ExpressionLayout::collapseOnDirection(HorizontalDirection direction, int ab
     }
     int siblingIndex = direction == HorizontalDirection::Right ? indexInParent+1 : indexInParent-1;
     sibling = editableParent()->editableChild(siblingIndex);
-    if (forceCollapse || sibling->isCollapsable(&numberOfOpenParenthesis, direction == HorizontalDirection::Left)) {
+    /* Even if forceCollapse is true, isCollapsable should be called to update
+     * the number of open parentheses. */
+    bool shouldCollapse = sibling->isCollapsable(&numberOfOpenParenthesis, direction == HorizontalDirection::Left);
+    if (shouldCollapse || forceCollapse) {
       /* If the collapse direction is Left and the next sibling to be collapsed
        * must have a left sibling, force the collapsing of this needed left
        * sibling. */


### PR DESCRIPTION
When collapsing sibling layouts, isCollapsable should be called even if
forceCollapse is true, in order to update the number of open
parentheses.
This fixes the bug: (1+(21)^2), then Event::Divide