### PR TITLE
Python syntax highlighting

### DIFF
--- a/apps/code/Makefile
+++ b/apps/code/Makefile
@@ -11,6 +11,7 @@ app_objs += $(addprefix apps/code/,\
   editor_view.o\
   helpers.o\
   menu_controller.o\
+  python_highlighter.o\
   python_toolbox.o\
   sandbox_controller.o\
   script.o\

--- a/apps/code/editor_view.cpp
+++ b/apps/code/editor_view.cpp
@@ -1,4 +1,5 @@
 #include "editor_view.h"
+#include "python_highlighter.h"
 #include <poincare.h>
 #include <escher/app.h>
 
@@ -11,6 +12,7 @@ EditorView::EditorView(Responder * parentResponder) :
   m_gutterView(KDText::FontSize::Large)
 {
   m_textArea.setScrollViewDelegate(this);
+  m_textArea.setRenderer(Code::PythonHighlighter);
 }
 
 void EditorView::scrollViewDidChangeOffset(ScrollViewDataSource * scrollViewDataSource) {

--- a/apps/code/python_highlighter.cpp
+++ b/apps/code/python_highlighter.cpp
@@ -1,0 +1,112 @@
+#include "python_highlighter.h"
+
+extern "C" {
+#include "py/nlr.h"
+#include "py/lexer.h"
+}
+#include <python/port/port.h>
+
+#include <string.h>
+
+#include <stdio.h>
+
+namespace Code {
+
+constexpr KDColor CommentColor = KDColor::RGB24(0x999988);
+constexpr KDColor NumberColor =  KDColor::RGB24(0x009999);
+constexpr KDColor KeywordColor = KDColor::RGB24(0xFF000C);
+// constexpr KDColor BuiltinColor = KDColor::RGB24(0x0086B3);
+constexpr KDColor OperatorColor = KDColor::RGB24(0xd73a49);
+
+static KDColor TokenColor(mp_token_kind_t tokenKind) {
+  if (tokenKind == MP_TOKEN_INTEGER || tokenKind == MP_TOKEN_FLOAT_OR_IMAG) {
+    return NumberColor;
+  }
+  if (tokenKind >= MP_TOKEN_KW_FALSE && tokenKind <= MP_TOKEN_KW_YIELD) {
+    return KeywordColor;
+  }
+  if (tokenKind >= MP_TOKEN_OP_PLUS && tokenKind <= MP_TOKEN_OP_NOT_EQUAL) {
+    return OperatorColor;
+  }
+  return KDColorBlack;
+}
+
+static int TokenLength(mp_lexer_t * lex) {
+  if (lex->vstr.len > 0) {
+    return lex->vstr.len;
+  }
+  switch (lex->tok_kind) {
+    case MP_TOKEN_OP_DBL_STAR:
+    case MP_TOKEN_OP_DBL_SLASH:
+    case MP_TOKEN_OP_DBL_LESS:
+    case MP_TOKEN_OP_DBL_MORE:
+    case MP_TOKEN_OP_DBL_EQUAL:
+      return 2;
+    case MP_TOKEN_DEL_DBL_MORE_EQUAL:
+    case MP_TOKEN_DEL_DBL_LESS_EQUAL:
+    case MP_TOKEN_DEL_DBL_STAR_EQUAL:
+      return 3;
+    default:
+      return 1;
+  }
+}
+
+void PythonHighlighter(const TextAreaRenderingContext * context, const char * text, size_t length, int fromColumn, int toColumn) {
+
+  char m_pythonHeap[4096];
+
+  MicroPython::init(m_pythonHeap, m_pythonHeap + 4096);
+
+  nlr_buf_t nlr;
+  if (nlr_push(&nlr) == 0) {
+
+    mp_lexer_t * lex = mp_lexer_new_from_str_len(0, text, length, 0);
+
+    int drawFrom = 0;
+    int drawLength = 0;
+    KDColor drawColor = KDColorBlack;
+
+    while (lex->tok_kind != MP_TOKEN_END && drawFrom <= toColumn) {
+
+      // Draw text from drawFrom to drawLength using drawColor
+      if (drawFrom + drawLength >= fromColumn) {
+        context->drawLineChunk(
+          text + drawFrom, // text
+          drawLength, // length
+          drawFrom,
+          drawColor,
+          KDColorWhite
+        );
+      }
+
+      drawFrom = drawFrom + drawLength;
+
+      // Let's prepare the next draw call.
+      // We have a token in front of us. Two possibilities:
+      int tokenPosition = lex->tok_kind == MP_TOKEN_NEWLINE ? length : lex->tok_column - 1;
+      if (drawFrom == tokenPosition) {
+        // Either the token is immediatly in front of us, so we'll draw it next
+        drawLength = TokenLength(lex);
+        drawColor = TokenColor(lex->tok_kind);
+        // So let's pop a new token
+        mp_lexer_to_next(lex);
+        //printf("Did pop token of kind %d\n", lex->tok_kind);
+      } else {
+        // Or we're not at the token yet, so let's draw what's before first
+        assert(drawFrom < tokenPosition);
+        drawLength = tokenPosition - drawFrom;
+        drawColor = CommentColor;
+      }
+    }
+
+    mp_lexer_free(lex);
+    nlr_pop();
+  }
+
+  MicroPython::deinit();
+
+
+}
+
+}
+

--- a/apps/code/python_highlighter.h
+++ b/apps/code/python_highlighter.h
@@ -1,0 +1,12 @@
+#ifndef CODE_PYTHON_HIGHLIGHTER_H
+#define CODE_PYTHON_HIGHLIGHTER_H
+
+#include <escher/text_area_renderer.h>
+
+namespace Code {
+
+void PythonHighlighter(const TextAreaRenderingContext * context, const char * text, size_t length, int fromColumn, int toColumn);
+
+}
+
+#endif

--- a/escher/include/escher/text_area.h
+++ b/escher/include/escher/text_area.h
@@ -99,10 +99,27 @@ private:
     bool removeChar() override;
     bool removeEndOfLine() override;
     bool removeStartOfLine();
+    class LineDrawingContext {
+    public:
+      LineDrawingContext(KDContext * ctx, const ContentView * contentView, int lineNumber) :
+        m_ctx(ctx), m_contentView(contentView), m_lineNumber(lineNumber) {}
+      void drawString(const char * text, size_t length, int column) const {
+        drawString(text, length, column, m_contentView->m_textColor, m_contentView->m_backgroundColor);
+      }
+      void drawString(const char * text, size_t length, int column, KDColor textColor, KDColor backgroundColor) const;
+    private:
+      KDContext * m_ctx;
+      const ContentView * m_contentView;
+      int m_lineNumber;
+    };
+    typedef void (*LineRenderer)(const LineDrawingContext lineContext, Text::Line line, int leftColumn, int rightColumn);
+    static void DefaultLineRenderer(TextArea::ContentView::LineDrawingContext lineContext, TextArea::Text::Line line, int leftColumn, int rightColumn);
   private:
     KDRect characterFrameAtIndex(size_t index) const override;
     Text m_text;
+    LineRenderer m_textRenderer;
   };
+
   const ContentView * nonEditableContentView() const override { return &m_contentView; }
   ContentView m_contentView;
   TextAreaDelegate * m_delegate;

--- a/escher/include/escher/text_area.h
+++ b/escher/include/escher/text_area.h
@@ -3,6 +3,7 @@
 
 #include <escher/text_input.h>
 #include <escher/text_area_delegate.h>
+#include <escher/text_area_renderer.h>
 #include <assert.h>
 #include <string.h>
 
@@ -11,6 +12,7 @@ public:
   TextArea(Responder * parentResponder, char * textBuffer = nullptr, size_t textBufferSize = 0, TextAreaDelegate * delegate = nullptr, KDText::FontSize fontSize = KDText::FontSize::Large,
     KDColor textColor = KDColorBlack, KDColor backgroundColor = KDColorWhite);
   void setDelegate(TextAreaDelegate * delegate) { m_delegate = delegate; }
+  void setRenderer(TextAreaRenderer renderer) { m_contentView.setRenderer(renderer); }
   bool handleEvent(Ion::Events::Event event) override;
   bool handleEventWithText(const char * text, bool indentation = false, bool forceCursorRightOfText = false) override;
   void setText(char * textBuffer, size_t textBufferSize);
@@ -86,6 +88,7 @@ private:
   public:
     ContentView(char * textBuffer, size_t textBufferSize, KDText::FontSize size,
       KDColor textColor, KDColor backgroundColor);
+    void setRenderer(TextAreaRenderer renderer) { m_renderer = renderer; }
     void drawRect(KDContext * ctx, KDRect rect) const override;
     KDSize minimalSizeForOptimalDisplay() const override;
     void setText(char * textBuffer, size_t textBufferSize);
@@ -99,25 +102,24 @@ private:
     bool removeChar() override;
     bool removeEndOfLine() override;
     bool removeStartOfLine();
-    class LineDrawingContext {
+    class LineDrawingContext : public TextAreaRenderingContext {
     public:
       LineDrawingContext(KDContext * ctx, const ContentView * contentView, int lineNumber) :
         m_ctx(ctx), m_contentView(contentView), m_lineNumber(lineNumber) {}
-      void drawString(const char * text, size_t length, int column) const {
-        drawString(text, length, column, m_contentView->m_textColor, m_contentView->m_backgroundColor);
+      void drawLineChunk(const char * text, size_t length, int column) const {
+        drawLineChunk(text, length, column, m_contentView->m_textColor, m_contentView->m_backgroundColor);
       }
-      void drawString(const char * text, size_t length, int column, KDColor textColor, KDColor backgroundColor) const;
+      void drawLineChunk(const char * text, size_t length, int column, KDColor textColor, KDColor backgroundColor) const override;
     private:
       KDContext * m_ctx;
       const ContentView * m_contentView;
       int m_lineNumber;
     };
-    typedef void (*LineRenderer)(const LineDrawingContext lineContext, Text::Line line, int leftColumn, int rightColumn);
-    static void DefaultLineRenderer(TextArea::ContentView::LineDrawingContext lineContext, TextArea::Text::Line line, int leftColumn, int rightColumn);
+    static void DefaultTextAreaRenderer(const TextAreaRenderingContext * context, const char * text, size_t length, int fromColumn, int toColumn);
   private:
     KDRect characterFrameAtIndex(size_t index) const override;
     Text m_text;
-    LineRenderer m_textRenderer;
+    TextAreaRenderer m_renderer;
   };
 
   const ContentView * nonEditableContentView() const override { return &m_contentView; }

--- a/escher/include/escher/text_area_renderer.h
+++ b/escher/include/escher/text_area_renderer.h
@@ -1,0 +1,14 @@
+#ifndef ESCHER_TEXT_AREA_RENDERER_H
+#define ESCHER_TEXT_AREA_RENDERER_H
+
+#include <stddef.h>
+#include <kandinsky.h>
+
+class TextAreaRenderingContext {
+public:
+  virtual void drawLineChunk(const char * text, size_t length, int column, KDColor textColor, KDColor backgroundColor) const = 0;
+};
+
+typedef void (*TextAreaRenderer)(const TextAreaRenderingContext * context, const char * text, size_t length, int fromColumn, int toColumn);
+
+#endif


### PR DESCRIPTION
Following a very interesting PR by @zardam #435 , here's an updated version.

* TextArea is not tied to Python anymore
* The Python heap is dynamically allocated (it risked overflowing the stack)
* If not enough memory is available, it falls back to black and white drawing
* Uses the MicroPython's lexer, thanks to a [very nice PoC](https://github.com/numworks/epsilon/compare/master...zardam:test_upy_lexer) by @zaradam
* Reuses and extends TextArea's dirty tracking
* Does syntax-highlighting on a per-line basis (avoids re-rendering the whole screen)
* The color theme that matches the one on https://workshop.numworks.com

Shortcomings:

* Doesn't do anything special for builtins because those aren't recognized by uPy's lexer.
* Doesn't treat function definition differently (because we're using a lexer and not a parser).