### PR TITLE
Python syntax highlighting

### DIFF
--- a/apps/code/Makefile
+++ b/apps/code/Makefile
@@ -12,6 +12,7 @@ app_objs += $(addprefix apps/code/,\
   helpers.o\
   menu_controller.o\
   python_toolbox.o\
+  python_text_area.o\
   sandbox_controller.o\
   script.o\
   script_node_cell.o\

--- a/apps/code/editor_controller.cpp
+++ b/apps/code/editor_controller.cpp
@@ -53,6 +53,7 @@ void EditorController::didBecomeFirstResponder() {
 }
 
 void EditorController::viewWillAppear() {
+  m_editorView.loadSyntaxHighlighter();
   m_editorView.setCursorLocation(strlen(m_editorView.text()));
 }
 
@@ -60,6 +61,7 @@ void EditorController::viewDidDisappear() {
   m_menuController->scriptContentEditionDidFinish();
   delete[] m_areaBuffer;
   m_areaBuffer = nullptr;
+  m_editorView.unloadSyntaxHighlighter();
 }
 
 bool EditorController::textAreaDidReceiveEvent(TextArea * textArea, Ion::Events::Event event) {

--- a/apps/code/editor_view.cpp
+++ b/apps/code/editor_view.cpp
@@ -2,13 +2,17 @@
 #include <poincare.h>
 #include <escher/app.h>
 
+namespace Code {
+
 /* EditorView */
+
+constexpr KDText::FontSize editorFontSize = KDText::FontSize::Large;
 
 EditorView::EditorView(Responder * parentResponder) :
   Responder(parentResponder),
   View(),
-  m_textArea(parentResponder),
-  m_gutterView(KDText::FontSize::Large)
+  m_textArea(parentResponder, editorFontSize),
+  m_gutterView(editorFontSize)
 {
   m_textArea.setScrollViewDelegate(this);
 }
@@ -91,4 +95,6 @@ void EditorView::GutterView::setOffset(KDCoordinate offset) {
 KDSize EditorView::GutterView::minimalSizeForOptimalDisplay() const {
   int numberOfChars = 2; // TODO: Could be computed
   return KDSize(2 * k_margin + numberOfChars * KDText::charSize(m_fontSize).width(), 0);
+}
+
 }

--- a/apps/code/editor_view.h
+++ b/apps/code/editor_view.h
@@ -2,7 +2,7 @@
 #define CODE_EDITOR_VIEW_H
 
 #include <escher/view.h>
-#include <escher/text_area.h>
+#include <escher/solid_text_area.h>
 
 class EditorView : public Responder, public View, public ScrollViewDelegate {
 public:
@@ -38,7 +38,7 @@ private:
     KDCoordinate m_offset;
   };
 
-  TextArea m_textArea;
+  SolidTextArea m_textArea;
   GutterView m_gutterView;
 };
 

--- a/apps/code/editor_view.h
+++ b/apps/code/editor_view.h
@@ -2,7 +2,9 @@
 #define CODE_EDITOR_VIEW_H
 
 #include <escher/view.h>
-#include <escher/solid_text_area.h>
+#include "python_text_area.h"
+
+namespace Code {
 
 class EditorView : public Responder, public View, public ScrollViewDelegate {
 public:
@@ -38,8 +40,10 @@ private:
     KDCoordinate m_offset;
   };
 
-  SolidTextArea m_textArea;
+  PythonTextArea m_textArea;
   GutterView m_gutterView;
 };
+
+}
 
 #endif

--- a/apps/code/editor_view.h
+++ b/apps/code/editor_view.h
@@ -12,15 +12,15 @@ public:
   void setTextAreaDelegate(TextAreaDelegate * delegate) {
     m_textArea.setDelegate(delegate);
   }
-  const char * text() const {
-    return m_textArea.text();
-  }
+  const char * text() const { return m_textArea.text(); }
   void setText(char * textBuffer, size_t textBufferSize) {
     m_textArea.setText(textBuffer, textBufferSize);
   }
   bool setCursorLocation(int location) {
     return m_textArea.setCursorLocation(location);
   }
+  void loadSyntaxHighlighter() { m_textArea.loadSyntaxHighlighter(); };
+  void unloadSyntaxHighlighter() { m_textArea.unloadSyntaxHighlighter(); };
   void scrollViewDidChangeOffset(ScrollViewDataSource * scrollViewDataSource) override;
   void didBecomeFirstResponder() override;
 private:

--- a/apps/code/python_text_area.cpp
+++ b/apps/code/python_text_area.cpp
@@ -92,8 +92,8 @@ void PythonTextArea::ContentView::drawLine(KDContext * ctx, int line, const char
       fromColumn,
       text + fromColumn,
       min(length - fromColumn, toColumn - fromColumn),
-      KDColorBlack,
-      KDColorWhite
+      StringColor,
+      BackgroundColor
     );
     return;
   }
@@ -129,7 +129,7 @@ void PythonTextArea::ContentView::drawLine(KDContext * ctx, int line, const char
         text + tokenFrom, // text
         tokenLength, // length
         tokenColor,
-        KDColorWhite
+        BackgroundColor
       );
 
       mp_lexer_to_next(lex);
@@ -144,7 +144,7 @@ void PythonTextArea::ContentView::drawLine(KDContext * ctx, int line, const char
           text + tokenFrom, // text
           length - tokenFrom, // length
           CommentColor,
-          KDColorWhite
+          BackgroundColor
         );
     }
 

--- a/apps/code/python_text_area.cpp
+++ b/apps/code/python_text_area.cpp
@@ -1,53 +1,150 @@
 #include "python_text_area.h"
 
+extern "C" {
+#include "py/nlr.h"
+#include "py/lexer.h"
+}
+#include <python/port/port.h>
+
+
 namespace Code {
 
-/* PythonTextArea */
+constexpr KDColor CommentColor = KDColor::RGB24(0x999988);
+constexpr KDColor NumberColor =  KDColor::RGB24(0x009999);
+constexpr KDColor KeywordColor = KDColor::RGB24(0xFF000C);
+// constexpr KDColor BuiltinColor = KDColor::RGB24(0x0086B3);
+constexpr KDColor OperatorColor = KDColor::RGB24(0xd73a49);
+constexpr KDColor StringColor = KDColor::RGB24(0x032f62);
+constexpr KDColor BackgroundColor = KDColorWhite;
 
-void PythonTextArea::ContentView::drawRect(KDContext * ctx, KDRect rect) const {
+static inline KDColor TokenColor(mp_token_kind_t tokenKind) {
+  if (tokenKind == MP_TOKEN_STRING) {
+    return StringColor;
+  }
+  if (tokenKind == MP_TOKEN_INTEGER || tokenKind == MP_TOKEN_FLOAT_OR_IMAG) {
+    return NumberColor;
+  }
+  if (tokenKind >= MP_TOKEN_KW_FALSE && tokenKind <= MP_TOKEN_KW_YIELD) {
+    return KeywordColor;
+  }
+  if (tokenKind >= MP_TOKEN_OP_PLUS && tokenKind <= MP_TOKEN_OP_NOT_EQUAL) {
+    return OperatorColor;
+  }
+  return KDColorBlack;
 }
 
-/* PythonTextArea::ContentView */
-
-PythonTextArea::ContentView::ContentView(KDText::FontSize fontSize) :
-  TextArea::ContentView(fontSize)
-{
-}
-
-void PythonTextArea::ContentView::drawRect(KDContext * ctx, KDRect rect) const {
-  ctx->fillRect(rect, m_backgroundColor);
-
-  KDSize charSize = KDText::charSize(m_fontSize);
-
-  // We want to draw even partially visible characters. So we need to round
-  // down for the top left corner and up for the bottom right one.
-  Text::Position topLeft(
-    rect.x()/charSize.width(),
-    rect.y()/charSize.height()
-  );
-  Text::Position bottomRight(
-    rect.right()/charSize.width() + 1,
-    rect.bottom()/charSize.height() + 1
-  );
-
-  int y = 0;
-  size_t x = topLeft.column();
-
-  for (Text::Line line : m_text) {
-    if (y >= topLeft.line() && y <= bottomRight.line() && topLeft.column() < (int)line.length()) {
-      //drawString(line.text(), 0, y*charHeight); // Naive version
-      ctx->drawString(
-        line.text() + topLeft.column(),
-        KDPoint(x*charSize.width(), y*charSize.height()),
-        m_fontSize,
-        m_textColor,
-        m_backgroundColor,
-        min(line.length() - topLeft.column(), bottomRight.column() - topLeft.column())
-      );
-    }
-    y++;
+static inline int TokenLength(mp_lexer_t * lex) {
+  if (lex->tok_kind == MP_TOKEN_STRING) {
+    return lex->vstr.len + 2;
+  }
+  if (lex->vstr.len > 0) {
+    return lex->vstr.len;
+  }
+  switch (lex->tok_kind) {
+    case MP_TOKEN_OP_DBL_STAR:
+    case MP_TOKEN_OP_DBL_SLASH:
+    case MP_TOKEN_OP_DBL_LESS:
+    case MP_TOKEN_OP_DBL_MORE:
+    case MP_TOKEN_OP_LESS_EQUAL:
+    case MP_TOKEN_OP_MORE_EQUAL:
+    case MP_TOKEN_OP_DBL_EQUAL:
+      return 2;
+    case MP_TOKEN_DEL_DBL_MORE_EQUAL:
+    case MP_TOKEN_DEL_DBL_LESS_EQUAL:
+    case MP_TOKEN_DEL_DBL_STAR_EQUAL:
+      return 3;
+    default:
+      return 1;
   }
 }
 
+void PythonTextArea::ContentView::clearRect(KDContext * ctx, KDRect rect) const {
+  ctx->fillRect(rect, BackgroundColor);
+}
+
+#define LOG_DRAWING 0
+#if LOG_DRAWING
+#include <stdio.h>
+#define LOG_DRAW(...) printf(__VA_ARGS__)
+#else
+#define LOG_DRAW(...)
+#endif
+
+void PythonTextArea::ContentView::drawLine(KDContext * ctx, int line, const char * text, size_t length, int fromColumn, int toColumn) const {
+  LOG_DRAW("Drawing \"%.*s\"\n", length, text);
+
+  char m_pythonHeap[4096];
+
+  MicroPython::init(m_pythonHeap, m_pythonHeap + 4096);
+
+  nlr_buf_t nlr;
+  if (nlr_push(&nlr) == 0) {
+    /* We're using the MicroPython lexer to do syntax highlighting on a per-line
+     * basis. This can work, however the MicroPython lexer won't accept a line
+     * starting with a whitespace. So we're discarding leading whitespaces
+     * beforehand. */
+    int whitespaceOffset = 0;
+    while (text[whitespaceOffset] == ' ' && whitespaceOffset < length) {
+      whitespaceOffset++;
+    }
+
+    mp_lexer_t * lex = mp_lexer_new_from_str_len(0, text + whitespaceOffset, length - whitespaceOffset, 0);
+    LOG_DRAW("Pop token %d\n", lex->tok_kind);
+
+    int tokenFrom = 0;
+    int tokenLength = 0;
+    KDColor tokenColor = KDColorBlack;
+
+    while (lex->tok_kind != MP_TOKEN_NEWLINE && lex->tok_kind != MP_TOKEN_END) {
+      tokenFrom = whitespaceOffset + lex->tok_column - 1;
+      tokenLength = TokenLength(lex);
+      tokenColor = TokenColor(lex->tok_kind);
+
+      LOG_DRAW("Draw \"%.*s\" for token %d\n", tokenLength, text + tokenFrom, lex->tok_kind);
+      drawStringAt(ctx, line,
+        tokenFrom,
+        text + tokenFrom, // text
+        tokenLength, // length
+        tokenColor,
+        KDColorWhite
+      );
+
+      mp_lexer_to_next(lex);
+      LOG_DRAW("Pop token %d\n", lex->tok_kind);
+    }
+
+    tokenFrom = tokenFrom + tokenLength;
+    if (tokenFrom != length) {
+      LOG_DRAW("Draw comment \"%.*s\" from %d\n", length - tokenFrom, text + tokenFrom, tokenFrom);
+      drawStringAt(ctx, line,
+          tokenFrom,
+          text + tokenFrom, // text
+          length - tokenFrom, // length
+          CommentColor,
+          KDColorWhite
+        );
+    }
+
+    mp_lexer_free(lex);
+    nlr_pop();
+  }
+
+  MicroPython::deinit();
+}
+
+KDRect PythonTextArea::ContentView::dirtyRectFromCursorPosition(size_t index, bool lineBreak) const {
+  /* Mark the whole line as dirty.
+   * TextArea has a very conservative approach and only dirties the surroundings
+   * of the current character. That works for plain text, but when doing syntax
+   * highlighting, you may want to redraw the surroundings as well. For example,
+   * if editing "def foo" into "df foo", you'll want to redraw "df". */
+  KDRect baseDirtyRect = TextArea::ContentView::dirtyRectFromCursorPosition(index, lineBreak);
+  return KDRect(
+    bounds().x(),
+    baseDirtyRect.y(),
+    bounds().width(),
+    baseDirtyRect.height()
+  );
+}
 
 }

--- a/apps/code/python_text_area.cpp
+++ b/apps/code/python_text_area.cpp
@@ -1,0 +1,53 @@
+#include "python_text_area.h"
+
+namespace Code {
+
+/* PythonTextArea */
+
+void PythonTextArea::ContentView::drawRect(KDContext * ctx, KDRect rect) const {
+}
+
+/* PythonTextArea::ContentView */
+
+PythonTextArea::ContentView::ContentView(KDText::FontSize fontSize) :
+  TextArea::ContentView(fontSize)
+{
+}
+
+void PythonTextArea::ContentView::drawRect(KDContext * ctx, KDRect rect) const {
+  ctx->fillRect(rect, m_backgroundColor);
+
+  KDSize charSize = KDText::charSize(m_fontSize);
+
+  // We want to draw even partially visible characters. So we need to round
+  // down for the top left corner and up for the bottom right one.
+  Text::Position topLeft(
+    rect.x()/charSize.width(),
+    rect.y()/charSize.height()
+  );
+  Text::Position bottomRight(
+    rect.right()/charSize.width() + 1,
+    rect.bottom()/charSize.height() + 1
+  );
+
+  int y = 0;
+  size_t x = topLeft.column();
+
+  for (Text::Line line : m_text) {
+    if (y >= topLeft.line() && y <= bottomRight.line() && topLeft.column() < (int)line.length()) {
+      //drawString(line.text(), 0, y*charHeight); // Naive version
+      ctx->drawString(
+        line.text() + topLeft.column(),
+        KDPoint(x*charSize.width(), y*charSize.height()),
+        m_fontSize,
+        m_textColor,
+        m_backgroundColor,
+        min(line.length() - topLeft.column(), bottomRight.column() - topLeft.column())
+      );
+    }
+    y++;
+  }
+}
+
+
+}

--- a/apps/code/python_text_area.h
+++ b/apps/code/python_text_area.h
@@ -15,14 +15,19 @@ public:
 protected:
   class ContentView : public TextArea::ContentView {
   public:
-    ContentView(KDText::FontSize fontSize) : TextArea::ContentView(fontSize) {}
+    ContentView(KDText::FontSize fontSize);
+    ~ContentView();
     void clearRect(KDContext * ctx, KDRect rect) const override;
     void drawLine(KDContext * ctx, int line, const char * text, size_t length, int fromColumn, int toColumn) const override;
     KDRect dirtyRectFromCursorPosition(size_t index, bool lineBreak) const override;
+  private:
+    static constexpr size_t k_pythonHeapSize = 4096;
+    char * m_pythonHeap;
   };
 private:
   const ContentView * nonEditableContentView() const override { return &m_contentView; }
   ContentView m_contentView;
+  char * m_pythonHeap;
 };
 
 }

--- a/apps/code/python_text_area.h
+++ b/apps/code/python_text_area.h
@@ -15,8 +15,10 @@ public:
 protected:
   class ContentView : public TextArea::ContentView {
   public:
-    ContentView(KDText::FontSize fontSize);
-    void drawRect(KDContext * ctx, KDRect rect) const override;
+    ContentView(KDText::FontSize fontSize) : TextArea::ContentView(fontSize) {}
+    void clearRect(KDContext * ctx, KDRect rect) const override;
+    void drawLine(KDContext * ctx, int line, const char * text, size_t length, int fromColumn, int toColumn) const override;
+    KDRect dirtyRectFromCursorPosition(size_t index, bool lineBreak) const override;
   };
 private:
   const ContentView * nonEditableContentView() const override { return &m_contentView; }

--- a/apps/code/python_text_area.h
+++ b/apps/code/python_text_area.h
@@ -1,0 +1,28 @@
+#ifndef CODE_PYTHON_TEXT_AREA_H
+#define CODE_PYTHON_TEXT_AREA_H
+
+#include <escher/text_area.h>
+
+namespace Code {
+
+class PythonTextArea : public TextArea {
+public:
+  PythonTextArea(Responder * parentResponder, KDText::FontSize fontSize) :
+    TextArea(parentResponder, &m_contentView, fontSize),
+    m_contentView(fontSize)
+  {
+  }
+protected:
+  class ContentView : public TextArea::ContentView {
+  public:
+    ContentView(KDText::FontSize fontSize);
+    void drawRect(KDContext * ctx, KDRect rect) const override;
+  };
+private:
+  const ContentView * nonEditableContentView() const override { return &m_contentView; }
+  ContentView m_contentView;
+};
+
+}
+
+#endif

--- a/apps/code/python_text_area.h
+++ b/apps/code/python_text_area.h
@@ -12,11 +12,18 @@ public:
     m_contentView(fontSize)
   {
   }
+  void loadSyntaxHighlighter() { m_contentView.loadSyntaxHighlighter(); }
+  void unloadSyntaxHighlighter() { m_contentView.unloadSyntaxHighlighter(); }
 protected:
   class ContentView : public TextArea::ContentView {
   public:
-    ContentView(KDText::FontSize fontSize);
-    ~ContentView();
+    ContentView(KDText::FontSize fontSize) :
+      TextArea::ContentView(fontSize),
+      m_pythonHeap(nullptr)
+    {
+    }
+    void loadSyntaxHighlighter();
+    void unloadSyntaxHighlighter();
     void clearRect(KDContext * ctx, KDRect rect) const override;
     void drawLine(KDContext * ctx, int line, const char * text, size_t length, int fromColumn, int toColumn) const override;
     KDRect dirtyRectFromCursorPosition(size_t index, bool lineBreak) const override;
@@ -27,7 +34,6 @@ protected:
 private:
   const ContentView * nonEditableContentView() const override { return &m_contentView; }
   ContentView m_contentView;
-  char * m_pythonHeap;
 };
 
 }

--- a/escher/Makefile
+++ b/escher/Makefile
@@ -58,6 +58,7 @@ objs += $(addprefix escher/src/,\
   simple_list_view_data_source.o\
   simple_table_view_data_source.o\
   solid_color_view.o\
+  solid_text_area.o\
   stack_view.o\
   stack_view_controller.o\
   switch_view.o\

--- a/escher/include/escher/solid_text_area.h
+++ b/escher/include/escher/solid_text_area.h
@@ -1,0 +1,30 @@
+#ifndef ESCHER_SOLID_TEXT_AREA_H
+#define ESCHER_SOLID_TEXT_AREA_H
+
+#include <escher/text_area.h>
+
+/* SimpleTextArea is a text area that draws text in a single solid color over a
+ * solid background. */
+
+class SolidTextArea : public TextArea {
+public:
+  SolidTextArea(Responder * parentResponder, KDText::FontSize fontSize = KDText::FontSize::Large,
+    KDColor textColor = KDColorBlack, KDColor backgroundColor = KDColorWhite) :
+    TextArea(parentResponder, &m_contentView, fontSize),
+    m_contentView(fontSize, textColor, backgroundColor) {}
+protected:
+  class ContentView : public TextArea::ContentView {
+  public:
+    ContentView(KDText::FontSize size, KDColor textColor, KDColor backgroundColor);
+    void drawRect(KDContext * ctx, KDRect rect) const override;
+  private:
+    KDColor m_textColor;
+    KDColor m_backgroundColor;
+  };
+
+private:
+  const ContentView * nonEditableContentView() const override { return &m_contentView; }
+  ContentView m_contentView;
+};
+
+#endif

--- a/escher/include/escher/solid_text_area.h
+++ b/escher/include/escher/solid_text_area.h
@@ -3,7 +3,7 @@
 
 #include <escher/text_area.h>
 
-/* SimpleTextArea is a text area that draws text in a single solid color over a
+/* SolidTextArea is a text area that draws text in a single solid color over a
  * solid background. */
 
 class SolidTextArea : public TextArea {
@@ -15,8 +15,8 @@ public:
 protected:
   class ContentView : public TextArea::ContentView {
   public:
-    ContentView(KDText::FontSize size, KDColor textColor, KDColor backgroundColor) :
-      TextArea::ContentView(size),
+    ContentView(KDText::FontSize fontSize, KDColor textColor, KDColor backgroundColor) :
+      TextArea::ContentView(fontSize),
       m_textColor(textColor),
       m_backgroundColor(backgroundColor)
     {

--- a/escher/include/escher/solid_text_area.h
+++ b/escher/include/escher/solid_text_area.h
@@ -15,7 +15,12 @@ public:
 protected:
   class ContentView : public TextArea::ContentView {
   public:
-    ContentView(KDText::FontSize size, KDColor textColor, KDColor backgroundColor);
+    ContentView(KDText::FontSize size, KDColor textColor, KDColor backgroundColor) :
+      TextArea::ContentView(size),
+      m_textColor(textColor),
+      m_backgroundColor(backgroundColor)
+    {
+    }
     void drawRect(KDContext * ctx, KDRect rect) const override;
   private:
     KDColor m_textColor;

--- a/escher/include/escher/solid_text_area.h
+++ b/escher/include/escher/solid_text_area.h
@@ -21,7 +21,8 @@ protected:
       m_backgroundColor(backgroundColor)
     {
     }
-    void drawRect(KDContext * ctx, KDRect rect) const override;
+    void clearRect(KDContext * ctx, KDRect rect) const override;
+    void drawLine(KDContext * ctx, int line, const char * text, size_t length, int fromColumn, int toColumn) const override;
   private:
     KDColor m_textColor;
     KDColor m_backgroundColor;

--- a/escher/include/escher/text_area.h
+++ b/escher/include/escher/text_area.h
@@ -23,8 +23,15 @@ protected:
 
   class Text {
   public:
-    Text(char * buffer, size_t bufferSize);
-    void setText(char * buffer, size_t bufferSize);
+    Text(char * buffer, size_t bufferSize) :
+      m_buffer(buffer),
+      m_bufferSize(bufferSize)
+    {
+    }
+    void setText(char * buffer, size_t bufferSize) {
+      m_buffer = buffer;
+      m_bufferSize = bufferSize;
+    }
     const char * text() const { return const_cast<const char *>(m_buffer); }
 
     class Line {
@@ -86,11 +93,15 @@ protected:
 
   class ContentView : public TextInput::ContentView {
   public:
-    ContentView(KDText::FontSize fontSize);
+    ContentView(KDText::FontSize fontSize) :
+      TextInput::ContentView(fontSize),
+      m_text(nullptr, 0)
+    {
+    }
     KDSize minimalSizeForOptimalDisplay() const override;
     void setText(char * textBuffer, size_t textBufferSize);
-    const char * text() const override;
-    size_t editedTextLength() const override;
+    const char * text() const override { return m_text.text(); }
+    size_t editedTextLength() const override { return m_text.textLength(); }
     const Text * getText() const { return &m_text; }
     bool insertTextAtLocation(const char * text, int location) override;
     void moveCursorGeo(int deltaX, int deltaY);
@@ -106,14 +117,5 @@ protected:
 private:
   TextAreaDelegate * m_delegate;
 };
-/*
-class TextAreaConcrete : public TextArea {
-public:
-  TextAreaConcrete(Responder * parentResponder) : TextArea(parentResponder), m_contentView( {}
-private:
-  const ContentView * nonEditableContentView() const override { return &m_contentView; }
-  ContentView m_contentView;
-};
-*/
 
 #endif

--- a/escher/include/escher/text_area.h
+++ b/escher/include/escher/text_area.h
@@ -8,23 +8,25 @@
 
 class TextArea : public TextInput {
 public:
-  TextArea(Responder * parentResponder, char * textBuffer = nullptr, size_t textBufferSize = 0, TextAreaDelegate * delegate = nullptr, KDText::FontSize fontSize = KDText::FontSize::Large,
-    KDColor textColor = KDColorBlack, KDColor backgroundColor = KDColorWhite);
+  TextArea(Responder * parentResponder, View * contentView, KDText::FontSize fontSize = KDText::FontSize::Large);
   void setDelegate(TextAreaDelegate * delegate) { m_delegate = delegate; }
   bool handleEvent(Ion::Events::Event event) override;
   bool handleEventWithText(const char * text, bool indentation = false, bool forceCursorRightOfText = false) override;
   void setText(char * textBuffer, size_t textBufferSize);
-private:
+
+protected:
   int indentationBeforeCursor() const;
   bool insertTextWithIndentation(const char * textBuffer, int location);
   TextInputDelegate * delegate() override {
     return m_delegate;
   }
+
   class Text {
   public:
     Text(char * buffer, size_t bufferSize);
     void setText(char * buffer, size_t bufferSize);
     const char * text() const { return const_cast<const char *>(m_buffer); }
+
     class Line {
     public:
       Line(const char * text);
@@ -84,28 +86,34 @@ private:
 
   class ContentView : public TextInput::ContentView {
   public:
-    ContentView(char * textBuffer, size_t textBufferSize, KDText::FontSize size,
-      KDColor textColor, KDColor backgroundColor);
-    void drawRect(KDContext * ctx, KDRect rect) const override;
+    ContentView(KDText::FontSize fontSize);
     KDSize minimalSizeForOptimalDisplay() const override;
     void setText(char * textBuffer, size_t textBufferSize);
     const char * text() const override;
+    size_t editedTextLength() const override;
     const Text * getText() const { return &m_text; }
-    size_t editedTextLength() const override {
-      return m_text.textLength();
-    }
     bool insertTextAtLocation(const char * text, int location) override;
     void moveCursorGeo(int deltaX, int deltaY);
     bool removeChar() override;
     bool removeEndOfLine() override;
     bool removeStartOfLine();
-  private:
+  protected:
     KDRect characterFrameAtIndex(size_t index) const override;
     Text m_text;
   };
-  const ContentView * nonEditableContentView() const override { return &m_contentView; }
-  ContentView m_contentView;
+
+  ContentView * contentView() { return static_cast<ContentView *>(TextInput::contentView()); }
+private:
   TextAreaDelegate * m_delegate;
 };
+/*
+class TextAreaConcrete : public TextArea {
+public:
+  TextAreaConcrete(Responder * parentResponder) : TextArea(parentResponder), m_contentView( {}
+private:
+  const ContentView * nonEditableContentView() const override { return &m_contentView; }
+  ContentView m_contentView;
+};
+*/
 
 #endif

--- a/escher/include/escher/text_area.h
+++ b/escher/include/escher/text_area.h
@@ -98,6 +98,10 @@ protected:
       m_text(nullptr, 0)
     {
     }
+    void drawRect(KDContext * ctx, KDRect rect) const override;
+    void drawStringAt(KDContext * ctx, int line, int column, const char * text, size_t length, KDColor textColor, KDColor backgroundColor) const;
+    virtual void drawLine(KDContext * ctx, int line, const char * text, size_t length, int fromColumn, int toColumn) const = 0;
+    virtual void clearRect(KDContext * ctx, KDRect rect) const = 0;
     KDSize minimalSizeForOptimalDisplay() const override;
     void setText(char * textBuffer, size_t textBufferSize);
     const char * text() const override { return m_text.text(); }

--- a/escher/include/escher/text_field.h
+++ b/escher/include/escher/text_field.h
@@ -10,6 +10,8 @@ public:
   TextField(Responder * parentResponder, char * textBuffer, char * draftTextBuffer, size_t textBufferSize,
     TextFieldDelegate * delegate = nullptr, bool hasTwoBuffers = true, KDText::FontSize size = KDText::FontSize::Large,
     float horizontalAlignment = 0.0f, float verticalAlignment = 0.5f, KDColor textColor = KDColorBlack, KDColor backgroundColor = KDColorWhite);
+  void setBackgroundColor(KDColor backgroundColor) override;
+  void setTextColor(KDColor textColor);
   void setDelegate(TextFieldDelegate * delegate) { m_delegate = delegate; }
   void setDraftTextBuffer(char * draftTextBuffer);
   bool isEditing() const;
@@ -29,6 +31,9 @@ protected:
   class ContentView : public TextInput::ContentView {
   public:
     ContentView(char * textBuffer, char * draftTextBuffer, size_t textBufferSize, KDText::FontSize size, float horizontalAlignment = 0.0f, float verticalAlignment = 0.5f, KDColor textColor = KDColorBlack, KDColor = KDColorWhite);
+    void setBackgroundColor(KDColor backgroundColor);
+    KDColor backgroundColor() const { return m_backgroundColor; }
+    void setTextColor(KDColor textColor);
     void setDraftTextBuffer(char * draftTextBuffer);
     void drawRect(KDContext * ctx, KDRect rect) const override;
     bool isEditing() const { return m_isEditing; }
@@ -64,6 +69,8 @@ protected:
     size_t m_textBufferSize;
     float m_horizontalAlignment;
     float m_verticalAlignment;
+    KDColor m_textColor;
+    KDColor m_backgroundColor;
   };
   const ContentView * nonEditableContentView() const override { return &m_contentView; }
   ContentView m_contentView;

--- a/escher/include/escher/text_input.h
+++ b/escher/include/escher/text_input.h
@@ -29,6 +29,7 @@ protected:
     KDRect cursorRect();
   protected:
     virtual void layoutSubviews() override;
+    virtual KDRect dirtyRectFromCursorPosition(size_t index, bool lineBreak) const;
     void reloadRectFromCursorPosition(size_t index, bool lineBreak = false);
     virtual KDRect characterFrameAtIndex(size_t index) const = 0;
     TextCursorView m_cursorView;

--- a/escher/include/escher/text_input.h
+++ b/escher/include/escher/text_input.h
@@ -12,8 +12,6 @@ public:
   TextInput(Responder * parentResponder, View * contentView);
   Toolbox * toolbox() override;
   const char * text() const { return nonEditableContentView()->text(); }
-  void setBackgroundColor(KDColor backgroundColor) override;
-  void setTextColor(KDColor textColor);
   bool removeChar();
   size_t cursorLocation() const { return nonEditableContentView()->cursorLocation(); }
   bool setCursorLocation(int location);
@@ -21,10 +19,7 @@ public:
 protected:
   class ContentView : public View {
   public:
-    ContentView(KDText::FontSize size, KDColor textColor, KDColor backgroundColor);
-    void setBackgroundColor(KDColor backgroundColor);
-    KDColor backgroundColor() const { return m_backgroundColor; }
-    void setTextColor(KDColor textColor);
+    ContentView(KDText::FontSize size);
     size_t cursorLocation() const { return m_cursorIndex; }
     void setCursorLocation(int cursorLocation);
     virtual const char * text() const = 0;
@@ -38,8 +33,6 @@ protected:
     virtual KDRect characterFrameAtIndex(size_t index) const = 0;
     TextCursorView m_cursorView;
     KDText::FontSize m_fontSize;
-    KDColor m_textColor;
-    KDColor m_backgroundColor;
     size_t m_cursorIndex;
   private:
     int numberOfSubviews() const override;

--- a/escher/src/solid_text_area.cpp
+++ b/escher/src/solid_text_area.cpp
@@ -1,12 +1,5 @@
 #include <escher/solid_text_area.h>
 
-SolidTextArea::ContentView::ContentView(KDText::FontSize size, KDColor textColor, KDColor backgroundColor) :
-  TextArea::ContentView(size),
-  m_textColor(textColor),
-  m_backgroundColor(backgroundColor)
-{
-}
-
 void SolidTextArea::ContentView::drawRect(KDContext * ctx, KDRect rect) const {
   ctx->fillRect(rect, m_backgroundColor);
 

--- a/escher/src/solid_text_area.cpp
+++ b/escher/src/solid_text_area.cpp
@@ -1,0 +1,43 @@
+#include <escher/solid_text_area.h>
+
+SolidTextArea::ContentView::ContentView(KDText::FontSize size, KDColor textColor, KDColor backgroundColor) :
+  TextArea::ContentView(size),
+  m_textColor(textColor),
+  m_backgroundColor(backgroundColor)
+{
+}
+
+void SolidTextArea::ContentView::drawRect(KDContext * ctx, KDRect rect) const {
+  ctx->fillRect(rect, m_backgroundColor);
+
+  KDSize charSize = KDText::charSize(m_fontSize);
+
+  // We want to draw even partially visible characters. So we need to round
+  // down for the top left corner and up for the bottom right one.
+  Text::Position topLeft(
+    rect.x()/charSize.width(),
+    rect.y()/charSize.height()
+  );
+  Text::Position bottomRight(
+    rect.right()/charSize.width() + 1,
+    rect.bottom()/charSize.height() + 1
+  );
+
+  int y = 0;
+  size_t x = topLeft.column();
+
+  for (Text::Line line : m_text) {
+    if (y >= topLeft.line() && y <= bottomRight.line() && topLeft.column() < (int)line.length()) {
+      //drawString(line.text(), 0, y*charHeight); // Naive version
+      ctx->drawString(
+        line.text() + topLeft.column(),
+        KDPoint(x*charSize.width(), y*charSize.height()),
+        m_fontSize,
+        m_textColor,
+        m_backgroundColor,
+        min(line.length() - topLeft.column(), bottomRight.column() - topLeft.column())
+      );
+    }
+    y++;
+  }
+}

--- a/escher/src/solid_text_area.cpp
+++ b/escher/src/solid_text_area.cpp
@@ -1,36 +1,17 @@
 #include <escher/solid_text_area.h>
 
-void SolidTextArea::ContentView::drawRect(KDContext * ctx, KDRect rect) const {
+void SolidTextArea::ContentView::clearRect(KDContext * ctx, KDRect rect) const {
   ctx->fillRect(rect, m_backgroundColor);
+}
 
-  KDSize charSize = KDText::charSize(m_fontSize);
-
-  // We want to draw even partially visible characters. So we need to round
-  // down for the top left corner and up for the bottom right one.
-  Text::Position topLeft(
-    rect.x()/charSize.width(),
-    rect.y()/charSize.height()
+void SolidTextArea::ContentView::drawLine(KDContext * ctx, int line, const char * text, size_t length, int fromColumn, int toColumn) const {
+  drawStringAt(
+    ctx,
+    line,
+    fromColumn,
+    text + fromColumn,
+    min(length - fromColumn, toColumn - fromColumn),
+    m_textColor,
+    m_backgroundColor
   );
-  Text::Position bottomRight(
-    rect.right()/charSize.width() + 1,
-    rect.bottom()/charSize.height() + 1
-  );
-
-  int y = 0;
-  size_t x = topLeft.column();
-
-  for (Text::Line line : m_text) {
-    if (y >= topLeft.line() && y <= bottomRight.line() && topLeft.column() < (int)line.length()) {
-      //drawString(line.text(), 0, y*charHeight); // Naive version
-      ctx->drawString(
-        line.text() + topLeft.column(),
-        KDPoint(x*charSize.width(), y*charSize.height()),
-        m_fontSize,
-        m_textColor,
-        m_backgroundColor,
-        min(line.length() - topLeft.column(), bottomRight.column() - topLeft.column())
-      );
-    }
-    y++;
-  }
 }

--- a/escher/src/text_area.cpp
+++ b/escher/src/text_area.cpp
@@ -269,6 +269,45 @@ TextArea::Text::Position TextArea::Text::span() const {
 
 /* TextArea::ContentView */
 
+void TextArea::ContentView::drawRect(KDContext * ctx, KDRect rect) const {
+  // TODO: We're clearing areas we'll draw text over. It's not needed.
+  clearRect(ctx, rect);
+
+  KDSize charSize = KDText::charSize(m_fontSize);
+
+  // We want to draw even partially visible characters. So we need to round
+  // down for the top left corner and up for the bottom right one.
+  Text::Position topLeft(
+    rect.x()/charSize.width(),
+    rect.y()/charSize.height()
+  );
+  Text::Position bottomRight(
+    rect.right()/charSize.width() + 1,
+    rect.bottom()/charSize.height() + 1
+  );
+
+  int y = 0;
+
+  for (Text::Line line : m_text) {
+    if (y >= topLeft.line() && y <= bottomRight.line() && topLeft.column() < (int)line.length()) {
+      drawLine(ctx, y, line.text(), line.length(), topLeft.column(), bottomRight.column());
+    }
+    y++;
+  }
+}
+
+void TextArea::ContentView::drawStringAt(KDContext * ctx, int line, int column, const char * text, size_t length, KDColor textColor, KDColor backgroundColor) const {
+  KDSize charSize = KDText::charSize(m_fontSize);
+  ctx->drawString(
+    text,
+    KDPoint(column*charSize.width(), line*charSize.height()),
+    m_fontSize,
+    textColor,
+    backgroundColor,
+    length
+  );
+}
+
 KDSize TextArea::ContentView::minimalSizeForOptimalDisplay() const {
   KDSize charSize = KDText::charSize(m_fontSize);
   Text::Position span = m_text.span();

--- a/escher/src/text_area.cpp
+++ b/escher/src/text_area.cpp
@@ -10,242 +10,6 @@ static inline size_t min(size_t a, size_t b) {
   return (a>b ? b : a);
 }
 
-TextArea::Text::Text(char * buffer, size_t bufferSize) :
-  m_buffer(buffer),
-  m_bufferSize(bufferSize)
-{
-}
-
-void TextArea::Text::setText(char * buffer, size_t bufferSize) {
-  m_buffer = buffer;
-  m_bufferSize = bufferSize;
-}
-
-TextArea::Text::Line::Line(const char * text) :
-  m_text(text),
-  m_length(0)
-{
-  if (m_text != nullptr) {
-    while (*text != 0 && *text != '\n') {
-      text++;
-    }
-    m_length = text-m_text;
-  }
-}
-
-bool TextArea::Text::Line::contains(const char * c) const {
-  return (c >= m_text) && (c < m_text + m_length);
-}
-
-TextArea::Text::LineIterator & TextArea::Text::LineIterator::operator++() {
-  const char * last = m_line.text() + m_line.length();
-  m_line = Line(*last == 0 ? nullptr : last+1);
-  return *this;
-}
-
-size_t TextArea::Text::indexAtPosition(Position p) {
-  assert(m_buffer != nullptr);
-  if (p.line() < 0) {
-    return 0;
-  }
-  int y = 0;
-  const char * endOfLastLine = nullptr;
-  for (Line l : *this) {
-    if (p.line() == y) {
-      size_t x = p.column() < 0 ? 0 : p.column();
-      x = min(x, l.length());
-      return l.text() - m_buffer + x;
-    }
-    endOfLastLine = l.text() + l.length();
-    y++;
-  }
-  assert(endOfLastLine != nullptr && endOfLastLine >= m_buffer);
-  return endOfLastLine - m_buffer;
-}
-
-TextArea::Text::Position TextArea::Text::positionAtIndex(size_t index) const {
-  assert(m_buffer != nullptr);
-  assert(index < m_bufferSize);
-  const char * target = m_buffer + index;
-  size_t y = 0;
-  for (Line l : *this) {
-    if (l.text() <= target && l.text() + l.length() >= target) {
-      size_t x = target - l.text();
-      return Position(x, y);
-    }
-    y++;
-  }
-  assert(false);
-  return Position(0, 0);
-}
-
-void TextArea::Text::insertChar(char c, size_t index) {
-  assert(m_buffer != nullptr);
-  assert(index < m_bufferSize-1);
-  char previous = c;
-  for (size_t i=index; i<m_bufferSize; i++) {
-    char inserted = previous;
-    previous = m_buffer[i];
-    m_buffer[i] = inserted;
-    if (inserted == 0) {
-      break;
-    }
-  }
-}
-
-char TextArea::Text::removeChar(size_t index) {
-  assert(m_buffer != nullptr);
-  assert(index < m_bufferSize-1);
-  char deletedChar = m_buffer[index];
-  for (size_t i=index; i<m_bufferSize; i++) {
-    m_buffer[i] = m_buffer[i+1];
-    if (m_buffer[i] == 0) {
-      break;
-    }
-  }
-  return deletedChar;
-}
-
-size_t TextArea::Text::removeRemainingLine(size_t index, int direction) {
-  assert(m_buffer != nullptr);
-  assert(index < m_bufferSize);
-  int jump = index;
-  while (m_buffer[jump] != '\n' && m_buffer[jump] != 0 && jump >= 0) {
-    jump += direction;
-  }
-  size_t delta = direction > 0 ? jump - index : index - jump;
-  if (delta == 0) {
-    return 0;
-  }
-  /* We stop at m_bufferSize-1 because:
-   * - if direction > 0: jump >= k+1 so we will reach the 0 before m_bufferSize-1
-   * - if direction < 0: k+1 will reach m_bufferSize. */
-  for (size_t k = index; k < m_bufferSize-1; k++) {
-    if (direction > 0) {
-      m_buffer[k] = m_buffer[jump++];
-    } else {
-      m_buffer[++jump] = m_buffer[k+1];
-    }
-    if (m_buffer[k] == 0 || m_buffer[k+1] == 0) {
-      return delta;
-    }
-  }
-  assert(false);
-  return 0;
-}
-
-TextArea::Text::Position TextArea::Text::span() const {
-  assert(m_buffer != nullptr);
-  size_t width = 0;
-  size_t height = 0;
-  for (Line l : *this) {
-    if (l.length() > width) {
-      width = l.length();
-    }
-    height++;
-  }
-  return Position(width, height);
-}
-
-/* TextArea::ContentView */
-
-TextArea::ContentView::ContentView(KDText::FontSize fontSize) :
-  TextInput::ContentView(fontSize),
-  m_text(nullptr, 0)
-{
-}
-
-KDSize TextArea::ContentView::minimalSizeForOptimalDisplay() const {
-  KDSize charSize = KDText::charSize(m_fontSize);
-  Text::Position span = m_text.span();
-  return KDSize(
-    /* We take into account the space required to draw a cursor at the end of
-     * line by adding charSize.width() to the width. */
-    charSize.width() * (span.column()+1),
-    charSize.height() * span.line()
-  );
-}
-
-void TextArea::TextArea::ContentView::setText(char * textBuffer, size_t textBufferSize) {
-  m_text.setText(textBuffer, textBufferSize);
-  m_cursorIndex = 0;
-}
-
-const char * TextArea::TextArea::ContentView::text() const {
-  return m_text.text();
-}
-
-bool TextArea::TextArea::ContentView::insertTextAtLocation(const char * text, int location) {
-  int textSize = strlen(text);
-  if (m_text.textLength() + textSize >= m_text.bufferSize() || textSize == 0) {
-    return false;
-  }
-  bool lineBreak = false;
-  int currentLocation = location;
-  while (*text != 0) {
-    lineBreak |= *text == '\n';
-    m_text.insertChar(*text++, currentLocation++);
-  }
-  reloadRectFromCursorPosition(currentLocation-1, lineBreak);
-  return true;
-}
-
-bool TextArea::TextArea::ContentView::removeChar() {
-  if (cursorLocation() <= 0) {
-    return false;
-  }
-  bool lineBreak = false;
-  assert(m_cursorIndex > 0);
-  lineBreak = m_text.removeChar(--m_cursorIndex) == '\n';
-  layoutSubviews(); // Reposition the cursor
-  reloadRectFromCursorPosition(cursorLocation(), lineBreak);
-  return true;
-}
-
-size_t TextArea::ContentView::editedTextLength() const {
-  return m_text.textLength();
-}
-
-bool TextArea::ContentView::removeEndOfLine() {
-  size_t removedLine = m_text.removeRemainingLine(cursorLocation(), 1);
-  if (removedLine > 0) {
-    layoutSubviews();
-    reloadRectFromCursorPosition(cursorLocation(), false);
-    return true;
-  }
-  return false;
-}
-
-bool TextArea::ContentView::removeStartOfLine() {
-  if (cursorLocation() <= 0) {
-    return false;
-  }
-  size_t removedLine = m_text.removeRemainingLine(cursorLocation()-1, -1);
-  if (removedLine > 0) {
-    assert(m_cursorIndex >= removedLine);
-    setCursorLocation(cursorLocation()-removedLine);
-    reloadRectFromCursorPosition(cursorLocation(), false);
-    return true;
-  }
-  return false;
-}
-
-KDRect TextArea::ContentView::characterFrameAtIndex(size_t index) const {
-  KDSize charSize = KDText::charSize(m_fontSize);
-  Text::Position p = m_text.positionAtIndex(index);
-  return KDRect(
-    p.column() * charSize.width(),
-    p.line() * charSize.height(),
-    charSize.width(),
-    charSize.height()
-  );
-}
-
-void TextArea::ContentView::moveCursorGeo(int deltaX, int deltaY) {
-  Text::Position p = m_text.positionAtIndex(m_cursorIndex);
-  setCursorLocation(m_text.indexAtPosition(Text::Position(p.column() + deltaX, p.line() + deltaY)));
-}
-
 /* TextArea */
 
 TextArea::TextArea(Responder * parentResponder, View * contentView, KDText::FontSize fontSize) :
@@ -367,4 +131,223 @@ int TextArea::indentationBeforeCursor() const {
     charIndex--;
   }
   return indentationSize;
+}
+
+/* TextArea::Text */
+
+size_t TextArea::Text::indexAtPosition(Position p) {
+  assert(m_buffer != nullptr);
+  if (p.line() < 0) {
+    return 0;
+  }
+  int y = 0;
+  const char * endOfLastLine = nullptr;
+  for (Line l : *this) {
+    if (p.line() == y) {
+      size_t x = p.column() < 0 ? 0 : p.column();
+      x = min(x, l.length());
+      return l.text() - m_buffer + x;
+    }
+    endOfLastLine = l.text() + l.length();
+    y++;
+  }
+  assert(endOfLastLine != nullptr && endOfLastLine >= m_buffer);
+  return endOfLastLine - m_buffer;
+}
+
+TextArea::Text::Position TextArea::Text::positionAtIndex(size_t index) const {
+  assert(m_buffer != nullptr);
+  assert(index < m_bufferSize);
+  const char * target = m_buffer + index;
+  size_t y = 0;
+  for (Line l : *this) {
+    if (l.text() <= target && l.text() + l.length() >= target) {
+      size_t x = target - l.text();
+      return Position(x, y);
+    }
+    y++;
+  }
+  assert(false);
+  return Position(0, 0);
+}
+
+void TextArea::Text::insertChar(char c, size_t index) {
+  assert(m_buffer != nullptr);
+  assert(index < m_bufferSize-1);
+  char previous = c;
+  for (size_t i=index; i<m_bufferSize; i++) {
+    char inserted = previous;
+    previous = m_buffer[i];
+    m_buffer[i] = inserted;
+    if (inserted == 0) {
+      break;
+    }
+  }
+}
+
+char TextArea::Text::removeChar(size_t index) {
+  assert(m_buffer != nullptr);
+  assert(index < m_bufferSize-1);
+  char deletedChar = m_buffer[index];
+  for (size_t i=index; i<m_bufferSize; i++) {
+    m_buffer[i] = m_buffer[i+1];
+    if (m_buffer[i] == 0) {
+      break;
+    }
+  }
+  return deletedChar;
+}
+
+size_t TextArea::Text::removeRemainingLine(size_t index, int direction) {
+  assert(m_buffer != nullptr);
+  assert(index < m_bufferSize);
+  int jump = index;
+  while (m_buffer[jump] != '\n' && m_buffer[jump] != 0 && jump >= 0) {
+    jump += direction;
+  }
+  size_t delta = direction > 0 ? jump - index : index - jump;
+  if (delta == 0) {
+    return 0;
+  }
+  /* We stop at m_bufferSize-1 because:
+   * - if direction > 0: jump >= k+1 so we will reach the 0 before m_bufferSize-1
+   * - if direction < 0: k+1 will reach m_bufferSize. */
+  for (size_t k = index; k < m_bufferSize-1; k++) {
+    if (direction > 0) {
+      m_buffer[k] = m_buffer[jump++];
+    } else {
+      m_buffer[++jump] = m_buffer[k+1];
+    }
+    if (m_buffer[k] == 0 || m_buffer[k+1] == 0) {
+      return delta;
+    }
+  }
+  assert(false);
+  return 0;
+}
+
+/* TextArea::Text::Line */
+
+TextArea::Text::Line::Line(const char * text) :
+  m_text(text),
+  m_length(0)
+{
+  if (m_text != nullptr) {
+    while (*text != 0 && *text != '\n') {
+      text++;
+    }
+    m_length = text-m_text;
+  }
+}
+
+bool TextArea::Text::Line::contains(const char * c) const {
+  return (c >= m_text) && (c < m_text + m_length);
+}
+
+/* TextArea::Text::LineIterator */
+
+TextArea::Text::LineIterator & TextArea::Text::LineIterator::operator++() {
+  const char * last = m_line.text() + m_line.length();
+  m_line = Line(*last == 0 ? nullptr : last+1);
+  return *this;
+}
+
+/* TextArea::Text::Position */
+
+TextArea::Text::Position TextArea::Text::span() const {
+  assert(m_buffer != nullptr);
+  size_t width = 0;
+  size_t height = 0;
+  for (Line l : *this) {
+    if (l.length() > width) {
+      width = l.length();
+    }
+    height++;
+  }
+  return Position(width, height);
+}
+
+/* TextArea::ContentView */
+
+KDSize TextArea::ContentView::minimalSizeForOptimalDisplay() const {
+  KDSize charSize = KDText::charSize(m_fontSize);
+  Text::Position span = m_text.span();
+  return KDSize(
+    /* We take into account the space required to draw a cursor at the end of
+     * line by adding charSize.width() to the width. */
+    charSize.width() * (span.column()+1),
+    charSize.height() * span.line()
+  );
+}
+
+void TextArea::TextArea::ContentView::setText(char * textBuffer, size_t textBufferSize) {
+  m_text.setText(textBuffer, textBufferSize);
+  m_cursorIndex = 0;
+}
+
+bool TextArea::TextArea::ContentView::insertTextAtLocation(const char * text, int location) {
+  int textSize = strlen(text);
+  if (m_text.textLength() + textSize >= m_text.bufferSize() || textSize == 0) {
+    return false;
+  }
+  bool lineBreak = false;
+  int currentLocation = location;
+  while (*text != 0) {
+    lineBreak |= *text == '\n';
+    m_text.insertChar(*text++, currentLocation++);
+  }
+  reloadRectFromCursorPosition(currentLocation-1, lineBreak);
+  return true;
+}
+
+bool TextArea::TextArea::ContentView::removeChar() {
+  if (cursorLocation() <= 0) {
+    return false;
+  }
+  bool lineBreak = false;
+  assert(m_cursorIndex > 0);
+  lineBreak = m_text.removeChar(--m_cursorIndex) == '\n';
+  layoutSubviews(); // Reposition the cursor
+  reloadRectFromCursorPosition(cursorLocation(), lineBreak);
+  return true;
+}
+
+bool TextArea::ContentView::removeEndOfLine() {
+  size_t removedLine = m_text.removeRemainingLine(cursorLocation(), 1);
+  if (removedLine > 0) {
+    layoutSubviews();
+    reloadRectFromCursorPosition(cursorLocation(), false);
+    return true;
+  }
+  return false;
+}
+
+bool TextArea::ContentView::removeStartOfLine() {
+  if (cursorLocation() <= 0) {
+    return false;
+  }
+  size_t removedLine = m_text.removeRemainingLine(cursorLocation()-1, -1);
+  if (removedLine > 0) {
+    assert(m_cursorIndex >= removedLine);
+    setCursorLocation(cursorLocation()-removedLine);
+    reloadRectFromCursorPosition(cursorLocation(), false);
+    return true;
+  }
+  return false;
+}
+
+KDRect TextArea::ContentView::characterFrameAtIndex(size_t index) const {
+  KDSize charSize = KDText::charSize(m_fontSize);
+  Text::Position p = m_text.positionAtIndex(index);
+  return KDRect(
+    p.column() * charSize.width(),
+    p.line() * charSize.height(),
+    charSize.width(),
+    charSize.height()
+  );
+}
+
+void TextArea::ContentView::moveCursorGeo(int deltaX, int deltaY) {
+  Text::Position p = m_text.positionAtIndex(m_cursorIndex);
+  setCursorLocation(m_text.indexAtPosition(Text::Position(p.column() + deltaX, p.line() + deltaY)));
 }

--- a/escher/src/text_field.cpp
+++ b/escher/src/text_field.cpp
@@ -7,16 +7,28 @@
 /* TextField::ContentView */
 
 TextField::ContentView::ContentView(char * textBuffer, char * draftTextBuffer, size_t textBufferSize, KDText::FontSize size, float horizontalAlignment, float verticalAlignment, KDColor textColor, KDColor backgroundColor) :
-  TextInput::ContentView(size, textColor, backgroundColor),
+  TextInput::ContentView(size),
   m_isEditing(false),
   m_textBuffer(textBuffer),
   m_draftTextBuffer(draftTextBuffer),
   m_currentDraftTextLength(0),
   m_textBufferSize(textBufferSize),
   m_horizontalAlignment(horizontalAlignment),
-  m_verticalAlignment(verticalAlignment)
+  m_verticalAlignment(verticalAlignment),
+  m_textColor(textColor),
+  m_backgroundColor(backgroundColor)
 {
   assert(m_textBufferSize <= k_maxBufferSize);
+}
+
+void TextField::ContentView::setBackgroundColor(KDColor backgroundColor) {
+  m_backgroundColor = backgroundColor;
+  markRectAsDirty(bounds());
+}
+
+void TextField::ContentView::setTextColor(KDColor textColor) {
+  m_textColor = textColor;
+  markRectAsDirty(bounds());
 }
 
 void TextField::ContentView::setDraftTextBuffer(char * draftTextBuffer) {
@@ -167,6 +179,15 @@ TextField::TextField(Responder * parentResponder, char * textBuffer, char * draf
   m_hasTwoBuffers(hasTwoBuffers),
   m_delegate(delegate)
 {
+}
+
+void TextField::setBackgroundColor(KDColor backgroundColor) {
+  ScrollView::setBackgroundColor(backgroundColor);
+  m_contentView.setBackgroundColor(backgroundColor);
+}
+
+void TextField::setTextColor(KDColor textColor) {
+  m_contentView.setTextColor(textColor);
 }
 
 void TextField::setDraftTextBuffer(char * draftTextBuffer) {

--- a/escher/src/text_input.cpp
+++ b/escher/src/text_input.cpp
@@ -3,24 +3,12 @@
 
 /* TextInput::ContentView */
 
-TextInput::ContentView::ContentView(KDText::FontSize size, KDColor textColor, KDColor backgroundColor) :
+TextInput::ContentView::ContentView(KDText::FontSize size) :
   View(),
   m_cursorView(),
   m_fontSize(size),
-  m_textColor(textColor),
-  m_backgroundColor(backgroundColor),
   m_cursorIndex(0)
 {
-}
-
-void TextInput::ContentView::setBackgroundColor(KDColor backgroundColor) {
-  m_backgroundColor = backgroundColor;
-  markRectAsDirty(bounds());
-}
-
-void TextInput::ContentView::setTextColor(KDColor textColor) {
-  m_textColor = textColor;
-  markRectAsDirty(bounds());
 }
 
 void TextInput::ContentView::setCursorLocation(int location) {
@@ -67,15 +55,6 @@ Toolbox * TextInput::toolbox() {
     return delegate()->toolboxForTextInput(this);
   }
   return nullptr;
-}
-
-void TextInput::setBackgroundColor(KDColor backgroundColor) {
-  ScrollView::setBackgroundColor(backgroundColor);
-  contentView()->setBackgroundColor(backgroundColor);
-}
-
-void TextInput::setTextColor(KDColor textColor) {
-  contentView()->setTextColor(textColor);
 }
 
 bool TextInput::removeChar() {

--- a/escher/src/text_input.cpp
+++ b/escher/src/text_input.cpp
@@ -34,13 +34,17 @@ void TextInput::ContentView::layoutSubviews() {
   m_cursorView.setFrame(cursorRect());
 }
 
-void TextInput::ContentView::reloadRectFromCursorPosition(size_t index, bool lineBreak) {
+KDRect TextInput::ContentView::dirtyRectFromCursorPosition(size_t index, bool lineBreak) const {
   KDRect charRect = characterFrameAtIndex(index);
   KDRect dirtyRect = KDRect(charRect.x(), charRect.y(), bounds().width() - charRect.x(), charRect.height());
   if (lineBreak) {
       dirtyRect = dirtyRect.unionedWith(KDRect(0, charRect.bottom()+1, bounds().width(), bounds().height()-charRect.bottom()-1));
   }
-  markRectAsDirty(dirtyRect);
+  return dirtyRect;
+}
+
+void TextInput::ContentView::reloadRectFromCursorPosition(size_t index, bool lineBreak) {
+  markRectAsDirty(dirtyRectFromCursorPosition(index, lineBreak));
 }
 
 /* TextInput */


### PR DESCRIPTION
Following a very interesting PR by @zardam #435 , here's an updated version.

* TextArea is not tied to Python anymore
* The Python heap is dynamically allocated (it risked overflowing the stack)
* If not enough memory is available, it falls back to black and white drawing
* Uses the MicroPython's lexer, thanks to a very nice PoC by @zaradam
* Reuses and extends TextArea's dirty tracking
* Does syntax-highlighting on a per-line basis (avoids re-rendering the whole screen)
* The color theme that matches the one on https://workshop.numworks.com

Shortcomings:

* Doesn't do anything special for builtins because those aren't recognized by uPy's lexer.
* Doesn't treat function definition differently (because we're using a lexer and not a parser).