### PR TITLE
[apps] [i18n] Fix default language if not EN

### DIFF
--- a/apps/global_preferences.cpp
+++ b/apps/global_preferences.cpp
@@ -1,7 +1,7 @@
 #include "global_preferences.h"
 
 GlobalPreferences::GlobalPreferences() :
-  m_language(I18n::Language::EN),
+  m_language(I18n::Language::FirstAvailable),
   m_examMode(ExamMode::Desactivate),
   m_showUpdatePopUp(true),
   m_brightnessLevel(Ion::Backlight::MaxBrightness)

--- a/apps/i18n.py
+++ b/apps/i18n.py
@@ -103,6 +103,7 @@ def print_header(data, path, locales):
     f.write("  Default = 0,\n")
     for locale in locales:
         f.write("  " + locale.upper() + ",\n")
+    f.write("  FirstAvailable = 1\n")
     f.write("};\n")
     f.write("\n")
     f.write("constexpr const Message LanguageNames[NumberOfLanguages] = {\n");


### PR DESCRIPTION
When English was not built-in, this value wouldn't be available