### PR TITLE
[apps/stats] Fix color problem when unselecting the box views

### DIFF
--- a/apps/statistics/box_controller.cpp
+++ b/apps/statistics/box_controller.cpp
@@ -9,7 +9,7 @@ namespace Statistics {
 BoxController::BoxController(Responder * parentResponder, ButtonRowController * header, Store * store, BoxView::Quantile * selectedQuantile, int * selectedSeriesIndex) :
   MultipleDataViewController(parentResponder, store, (int *)(selectedQuantile), selectedSeriesIndex),
   ButtonRowDelegate(header, nullptr),
-  m_view(this, store, selectedQuantile)
+  m_view(store, selectedQuantile)
 {
 }
 

--- a/apps/statistics/box_view.cpp
+++ b/apps/statistics/box_view.cpp
@@ -7,10 +7,9 @@ using namespace Shared;
 
 namespace Statistics {
 
-BoxView::BoxView(BoxController * controller, Store * store, int series, Shared::BannerView * bannerView, Quantile * selectedQuantile, KDColor color, KDColor lightColor) :
+BoxView::BoxView(Store * store, int series, Shared::BannerView * bannerView, Quantile * selectedQuantile, KDColor color, KDColor lightColor) :
   CurveView(&m_boxRange, nullptr, bannerView, nullptr),
   m_store(store),
-  m_boxController(controller),
   m_boxRange(BoxRange(store)),
   m_series(series),
   m_selectedQuantile(selectedQuantile),
@@ -64,8 +63,7 @@ void BoxView::drawRect(KDContext * ctx, KDRect rect) const {
   double thirdQuart = m_store->thirdQuartile(m_series);
   double maxVal = m_store->maxValue(m_series);
 
-  bool isSelected = m_boxController->selectedSeriesIndex() == m_series;
-  KDColor boxColor = isSelected ? m_selectedHistogramLightColor : Palette::GreyWhite;
+  KDColor boxColor = isMainViewSelected() ? m_selectedHistogramLightColor : Palette::GreyWhite;
   // Draw the main box
   KDCoordinate firstQuartilePixels = std::round(floatToPixel(Axis::Horizontal, firstQuart));
   KDCoordinate thirdQuartilePixels = std::round(floatToPixel(Axis::Horizontal, thirdQuart));
@@ -73,7 +71,7 @@ void BoxView::drawRect(KDContext * ctx, KDRect rect) const {
     upBoundPixel-lowBoundPixel), boxColor);
 
   // Draw the horizontal lines linking the box to the extreme bounds
-  KDColor horizontalColor = isSelected ? m_selectedHistogramColor : Palette::GreyDark;
+  KDColor horizontalColor = isMainViewSelected() ? m_selectedHistogramColor : Palette::GreyDark;
   float segmentOrd = (lowBound + upBound)/ 2.0f;
   drawSegment(ctx, rect, Axis::Horizontal, segmentOrd, minVal, firstQuart, horizontalColor);
   drawSegment(ctx, rect, Axis::Horizontal, segmentOrd, thirdQuart, maxVal, horizontalColor);

--- a/apps/statistics/box_view.h
+++ b/apps/statistics/box_view.h
@@ -21,7 +21,7 @@ public:
     ThirdQuartile = 3,
     Max = 4
   };
-  BoxView(BoxController * controller, Store * store, int series, Shared::BannerView * bannerView, Quantile * selectedQuantile, KDColor color, KDColor lightColor);
+  BoxView(Store * store, int series, Shared::BannerView * bannerView, Quantile * selectedQuantile, KDColor color, KDColor lightColor);
   Quantile selectedQuantile() const { return *m_selectedQuantile; }
   bool selectQuantile(int selectedQuantile);
   int series() const { return m_series; }
@@ -39,7 +39,6 @@ private:
   KDCoordinate boxUpperBoundPixel() const;
   char * label(Axis axis, int index) const override { return nullptr; }
   Store * m_store;
-  BoxController * m_boxController;
   BoxRange m_boxRange;
   int m_series;
   Quantile * m_selectedQuantile;

--- a/apps/statistics/multiple_boxes_view.cpp
+++ b/apps/statistics/multiple_boxes_view.cpp
@@ -5,11 +5,11 @@ using namespace Shared;
 
 namespace Statistics {
 
-MultipleBoxesView::MultipleBoxesView(BoxController * controller, Store * store, BoxView::Quantile * selectedQuantile) :
+MultipleBoxesView::MultipleBoxesView(Store * store, BoxView::Quantile * selectedQuantile) :
   MultipleDataView(store),
-  m_boxView1(controller, store, 0, nullptr, selectedQuantile, DoublePairStore::colorOfSeriesAtIndex(0), DoublePairStore::colorLightOfSeriesAtIndex(0)),
-  m_boxView2(controller, store, 1, nullptr, selectedQuantile, DoublePairStore::colorOfSeriesAtIndex(1), DoublePairStore::colorLightOfSeriesAtIndex(1)),
-  m_boxView3(controller, store, 2, nullptr, selectedQuantile, DoublePairStore::colorOfSeriesAtIndex(2), DoublePairStore::colorLightOfSeriesAtIndex(2)),
+  m_boxView1(store, 0, nullptr, selectedQuantile, DoublePairStore::colorOfSeriesAtIndex(0), DoublePairStore::colorLightOfSeriesAtIndex(0)),
+  m_boxView2(store, 1, nullptr, selectedQuantile, DoublePairStore::colorOfSeriesAtIndex(1), DoublePairStore::colorLightOfSeriesAtIndex(1)),
+  m_boxView3(store, 2, nullptr, selectedQuantile, DoublePairStore::colorOfSeriesAtIndex(2), DoublePairStore::colorLightOfSeriesAtIndex(2)),
   m_axisView(store),
   m_bannerView()
 {

--- a/apps/statistics/multiple_boxes_view.h
+++ b/apps/statistics/multiple_boxes_view.h
@@ -14,7 +14,7 @@ class BoxController;
 
 class MultipleBoxesView : public MultipleDataView {
 public:
-  MultipleBoxesView(BoxController * controller, Store * store, BoxView::Quantile * selectedQuantile);
+  MultipleBoxesView(Store * store, BoxView::Quantile * selectedQuantile);
   // MultipleDataView
   int seriesOfSubviewAtIndex(int index) override;
   const BoxBannerView * bannerView() const override { return &m_bannerView; }


### PR DESCRIPTION
Problem:
In Statistics, select a box view then press back to select a tab: the
previously seleted box stays colored even though it is unselected.