### PR TITLE
Blending accuracy and speedup

### DIFF
--- a/kandinsky/include/kandinsky/color.h
+++ b/kandinsky/include/kandinsky/color.h
@@ -5,44 +5,76 @@
 
 class KDColor {
 public:
-  constexpr KDColor() : m_value(0) {}
-  // FIXME: This should not be needed, and is probably wasting CPU cycles
-  static constexpr KDColor RGB16(uint16_t rgb) {
-    return KDColor(rgb);
-  }
-  static constexpr KDColor RGB24(uint32_t rgb) {
-    return KDColor(((rgb&0xF80000)>>8)|((rgb&0x00FC00)>>5)|((rgb&0x0000F8)>>3));
-  }
-  static constexpr KDColor RGB888(uint8_t r, uint8_t g, uint8_t b) {
-    return KDColor((r>>3)<<11 | (g>>2) << 5 | (b>>3));
-  }
-  uint8_t red() const {
-    uint8_t r5 = (m_value>>11)&0x1F;
-    return r5 << 3;
+  constexpr KDColor()
+    : m_value(0)
+  {
   }
 
-  uint8_t green() const {
-    uint8_t g6 = (m_value>>5)&0x3F;
-    return g6 << 2;
+  static constexpr KDColor RGB16(uint16_t rgb16)
+  {
+    return KDColor(rgb16);
   }
 
-  uint8_t blue() const {
-    uint8_t b5 = m_value&0x1F;
-    return b5 << 3;
+  static constexpr KDColor RGB24(uint32_t rgb24)
+  {
+    return KDColor ( ((rgb24 >> 8) & 0xF800)
+                   | ((rgb24 >> 5) & 0x07E0)
+                   | ((rgb24 >> 3) & 0x001F) );
   }
 
-  static KDColor blend(KDColor first, KDColor second, uint8_t alpha);
-  operator uint16_t() const { return m_value; }
+  static constexpr KDColor RGB888(uint8_t r, uint8_t g, uint8_t b)
+  {
+    return KDColor ( ((r << 8) & 0xF800)
+                   | ((g << 3) & 0x07E0)
+                   | ((b >> 3) & 0x001F) );
+  }
+
+  uint8_t red() const
+  {
+    const uint8_t r5 = (m_value >> 11) & 0x1F;
+    const uint8_t r8 = (r5 << 3) | (r5 & 0x07);
+
+    return r8;
+  }
+
+  uint8_t green() const
+  {
+    const uint8_t g6 = (m_value >> 5) & 0x3F;
+    const uint8_t g8 = (g6 << 2) | (g6 & 0x03);
+
+    return g8;
+  }
+
+  uint8_t blue() const
+  {
+    const uint8_t b5 = (m_value >> 0) & 0x1F;
+    const uint8_t b8 = (b5 << 3) | (b5 & 0x07);
+
+    return b8;
+  }
+
+  operator uint16_t() const
+  {
+    return m_value;
+  }
+
+  static KDColor blend(const KDColor fg, const KDColor bg, const uint8_t alpha);
+
 private:
-  constexpr KDColor(uint16_t value) : m_value(value) {}
+  constexpr KDColor(const uint16_t value)
+    : m_value(value)
+  {
+  }
+
+private:
   uint16_t m_value;
 };
 
-constexpr KDColor KDColorBlack = KDColor::RGB24(0x000000);
-constexpr KDColor KDColorWhite = KDColor::RGB24(0xFFFFFF);
-constexpr KDColor KDColorRed = KDColor::RGB24(0xFF0000);
-constexpr KDColor KDColorGreen = KDColor::RGB24(0x00FF00);
-constexpr KDColor KDColorBlue = KDColor::RGB24(0x0000FF);
+constexpr KDColor KDColorBlack  = KDColor::RGB24(0x000000);
+constexpr KDColor KDColorWhite  = KDColor::RGB24(0xFFFFFF);
+constexpr KDColor KDColorRed    = KDColor::RGB24(0xFF0000);
+constexpr KDColor KDColorGreen  = KDColor::RGB24(0x00FF00);
+constexpr KDColor KDColorBlue   = KDColor::RGB24(0x0000FF);
 constexpr KDColor KDColorYellow = KDColor::RGB24(0xFFFF00);
 
 #endif


### PR DESCRIPTION
Some code cleanup reordering and constification to help the C++ compiler.

In `KDColor::blend()`, the condition with alpha == 0xFF is tested first because this is the most common case, then alpha == 0x00. This speeds up the most common case.

In `KDColor::red()`, `KDColor::green()`, `KDColor::blue()`, the least significant bits are replicated to be more accurate when converted from 5/6 bits to 8-bits, so we have a quite good approximation from 5/6 bits to 8 bits component.

for example

`KDColor::red()` with a value of `0b1111100000000000` will return `0b11111111` and not `0b11111000`.
`KDColor::green()` with a value of `0b0000011110100000` will return `0b11110101` and not `0b11110100`.

and so on ... This is a well-known trick in computer graphics :-)

The code for blending has been improved to be faster (with less shifts and masks) an to give a more accurate blending (see the comments in `KDColor.cpp`)