### PR TITLE
[poincare] Fix SequenceToolbox special cells display when scrolling

### DIFF
--- a/apps/sequence/list/list_controller.cpp
+++ b/apps/sequence/list/list_controller.cpp
@@ -91,7 +91,7 @@ Toolbox * ListController::toolboxForSender(Responder * sender) {
   if (sequenceDefinition == 0) {
     recurrenceDepth = sequence->numberOfElements()-1;
   }
-  m_sequenceToolbox.setExtraCells(sequence->name(), recurrenceDepth);
+  m_sequenceToolbox.buildExtraCellsLayouts(sequence->name(), recurrenceDepth);
   // Set sender
   m_sequenceToolbox.setSender(sender);
   return &m_sequenceToolbox;

--- a/apps/sequence/list/sequence_toolbox.cpp
+++ b/apps/sequence/list/sequence_toolbox.cpp
@@ -68,7 +68,7 @@ int SequenceToolbox::typeAtLocation(int i, int j) {
   return MathToolbox::typeAtLocation(i,mathToolboxIndex(j));
 }
 
-void SequenceToolbox::setExtraCells(const char * sequenceName, int recurrenceDepth) {
+void SequenceToolbox::buildExtraCellsLayouts(const char * sequenceName, int recurrenceDepth) {
   for (int i = 0; i < k_maxNumberOfDisplayedRows; i++) {
     if (m_addedCellLayout[i]) {
       delete m_addedCellLayout[i];

--- a/apps/sequence/list/sequence_toolbox.cpp
+++ b/apps/sequence/list/sequence_toolbox.cpp
@@ -54,9 +54,11 @@ HighlightCell * SequenceToolbox::reusableCell(int index, int type) {
 }
 
 void SequenceToolbox::willDisplayCellForIndex(HighlightCell * cell, int index) {
-  if (typeAtLocation(0, index) != 2) {
-    MathToolbox::willDisplayCellForIndex(cell, mathToolboxIndex(index));
+  if (typeAtLocation(0, index) == 2) {
+    static_cast<ExpressionTableCell *>(cell)->setExpressionLayout(m_addedCellLayout[index]);
+    return;
   }
+  MathToolbox::willDisplayCellForIndex(cell, mathToolboxIndex(index));
 }
 
 int SequenceToolbox::typeAtLocation(int i, int j) {
@@ -104,9 +106,6 @@ void SequenceToolbox::setExtraCells(const char * sequenceName, int recurrenceDep
         new CharLayout(otherSequenceName[0], KDText::FontSize::Large),
         new VerticalOffsetLayout(LayoutEngine::createStringLayout(indice, strlen(indice), KDText::FontSize::Small), VerticalOffsetLayout::Type::Subscript, false),
         false);
-  }
-  for (int index = 0; index < k_maxNumberOfDisplayedRows; index++) {
-    m_addedCells[index].setExpressionLayout(m_addedCellLayout[index]);
   }
 }
 

--- a/apps/sequence/list/sequence_toolbox.h
+++ b/apps/sequence/list/sequence_toolbox.h
@@ -18,7 +18,7 @@ public:
   HighlightCell * reusableCell(int index, int type) override;
   void willDisplayCellForIndex(HighlightCell * cell, int index) override;
   int typeAtLocation(int i, int j) override;
-  void setExtraCells(const char * sequenceName, int recurrenceDepth);
+  void buildExtraCellsLayouts(const char * sequenceName, int recurrenceDepth);
 private:
   bool selectAddedCell(int selectedRow);
   int mathToolboxIndex(int index);


### PR DESCRIPTION
When scrolling from "v(n+1)" to "abs(x)", the "v(n+1)" cell disappeared