### PR TITLE
Fix warnings about comparing different signedness

### DIFF
--- a/apps/code/python_text_area.cpp
+++ b/apps/code/python_text_area.cpp
@@ -36,7 +36,7 @@ static inline KDColor TokenColor(mp_token_kind_t tokenKind) {
   return KDColorBlack;
 }
 
-static inline int TokenLength(mp_lexer_t * lex) {
+static inline size_t TokenLength(mp_lexer_t * lex) {
   if (lex->tok_kind == MP_TOKEN_STRING) {
     return lex->vstr.len + 2;
   }
@@ -122,7 +122,7 @@ void PythonTextArea::ContentView::drawLine(KDContext * ctx, int line, const char
      * basis. This can work, however the MicroPython lexer won't accept a line
      * starting with a whitespace. So we're discarding leading whitespaces
      * beforehand. */
-    int whitespaceOffset = 0;
+    size_t whitespaceOffset = 0;
     while (text[whitespaceOffset] == ' ' && whitespaceOffset < length) {
       whitespaceOffset++;
     }
@@ -130,8 +130,8 @@ void PythonTextArea::ContentView::drawLine(KDContext * ctx, int line, const char
     mp_lexer_t * lex = mp_lexer_new_from_str_len(0, text + whitespaceOffset, length - whitespaceOffset, 0);
     LOG_DRAW("Pop token %d\n", lex->tok_kind);
 
-    int tokenFrom = 0;
-    int tokenLength = 0;
+    size_t tokenFrom = 0;
+    size_t tokenLength = 0;
     KDColor tokenColor = KDColorBlack;
 
     while (lex->tok_kind != MP_TOKEN_NEWLINE && lex->tok_kind != MP_TOKEN_END) {


### PR DESCRIPTION
Some variables were declared as int while they are size_t. As we try to compare
them to unsigned values, a warning was raised (comparison of integer expressions
of different signedness).