### PR TITLE
[apps] Fix pop up clash when plugging the device

### DIFF
--- a/apps/on_boarding/update_controller.cpp
+++ b/apps/on_boarding/update_controller.cpp
@@ -65,7 +65,7 @@ UpdateController::UpdateController() :
 }
 
 bool UpdateController::handleEvent(Ion::Events::Event event) {
-  if (event != Ion::Events::Back && event != Ion::Events::OnOff) {
+  if (event != Ion::Events::Back && event != Ion::Events::OnOff && event != Ion::Events::USBPlug && event != Ion::Events::USBEnumeration) {
     app()->dismissModalViewController();
     AppsContainer * appsContainer = (AppsContainer *)app()->container();
     if (appsContainer->activeApp()->snapshot() == appsContainer->onBoardingAppSnapshot()) {


### PR DESCRIPTION
Build with ON_BOARDING_APP=1 and power off the calculator. When plugging
the calculator, the device did not enter the DFU mode nor quits exam
mode.