### PR TITLE
Inverted SwitchView handle position

### DIFF
--- a/escher/src/switch_view.cpp
+++ b/escher/src/switch_view.cpp
@@ -59,7 +59,7 @@ void SwitchView::drawRect(KDContext * ctx, KDRect rect) const {
   KDColor mainColor = m_state ? Palette::YellowDark : Palette::GreyDark;
   KDRect frame(width - k_switchWidth, heightCenter -switchHalfHeight, k_switchWidth, k_switchHeight);
   ctx->blendRectWithMask(frame, mainColor, (const uint8_t *)switchMask, s_switchWorkingBuffer);
-  KDCoordinate onOffX = width - (m_state ? k_switchWidth : k_onOffSize);
+  KDCoordinate onOffX = width - (m_state ? k_onOffSize : k_switchWidth);
   KDRect onOffFrame(onOffX, heightCenter -switchHalfHeight, k_onOffSize, k_onOffSize);
   ctx->blendRectWithMask(onOffFrame, KDColorWhite, (const uint8_t *)onOffMask, s_switchWorkingBuffer);
 }


### PR DESCRIPTION
This pull request invert the handle position in SwitchView. It intends to make the switch a bit less confusing for new users, as it look more like switches on Android or iOS or other platforms.

Off state:
![img_4562](https://user-images.githubusercontent.com/11600393/44570491-5646d280-a77e-11e8-931a-ac03fd3ab35e.JPG)

On state:
![img_2500](https://user-images.githubusercontent.com/11600393/44570492-5646d280-a77e-11e8-8fd4-16f1ac61cf0d.JPG)

