### PR TITLE
[Sequences] Edit expression field is not erased in some cases

### DIFF
--- a/apps/sequence/list/list_controller.cpp
+++ b/apps/sequence/list/list_controller.cpp
@@ -105,20 +105,18 @@ Toolbox * ListController::toolboxForSender(Responder * sender) {
 void ListController::editExpression(Sequence * sequence, int sequenceDefinition, Ion::Events::Event event) {
   char * initialText = nullptr;
   char initialTextContent[TextField::maxBufferSize()];
-  if (event == Ion::Events::OK || event == Ion::Events::EXE) {
-    switch (sequenceDefinition) {
-      case 0:
-        strlcpy(initialTextContent, sequence->text(), sizeof(initialTextContent));
-        break;
-      case 1:
-        strlcpy(initialTextContent, sequence->firstInitialConditionText(), sizeof(initialTextContent));
-        break;
-      default:
-        strlcpy(initialTextContent, sequence->secondInitialConditionText(), sizeof(initialTextContent));
-        break;
-    }
-    initialText = initialTextContent;
+  switch (sequenceDefinition) {
+    case 0:
+    strlcpy(initialTextContent, sequence->text(), sizeof(initialTextContent));
+    break;
+    case 1:
+    strlcpy(initialTextContent, sequence->firstInitialConditionText(), sizeof(initialTextContent));
+    break;
+    default:
+    strlcpy(initialTextContent, sequence->secondInitialConditionText(), sizeof(initialTextContent));
+    break;
   }
+  initialText = initialTextContent;
   App * myApp = (App *)app();
   InputViewController * inputController = myApp->inputViewController();
   // Invalidate the sequences context cache

--- a/apps/sequence/list/list_controller.cpp
+++ b/apps/sequence/list/list_controller.cpp
@@ -107,14 +107,14 @@ void ListController::editExpression(Sequence * sequence, int sequenceDefinition,
   char initialTextContent[TextField::maxBufferSize()];
   switch (sequenceDefinition) {
     case 0:
-    strlcpy(initialTextContent, sequence->text(), sizeof(initialTextContent));
-    break;
+      strlcpy(initialTextContent, sequence->text(), sizeof(initialTextContent));
+      break;
     case 1:
-    strlcpy(initialTextContent, sequence->firstInitialConditionText(), sizeof(initialTextContent));
-    break;
+      strlcpy(initialTextContent, sequence->firstInitialConditionText(), sizeof(initialTextContent));
+      break;
     default:
-    strlcpy(initialTextContent, sequence->secondInitialConditionText(), sizeof(initialTextContent));
-    break;
+      strlcpy(initialTextContent, sequence->secondInitialConditionText(), sizeof(initialTextContent));
+      break;
   }
   initialText = initialTextContent;
   App * myApp = (App *)app();


### PR DESCRIPTION
Hello,
I found a bug in Sequences, if you make a Un+1 sequence, the edit expression field is not erased between Un+1 and Un if you edit Un with any key except OK and Exe.

Here is an example:
<img src="https://user-images.githubusercontent.com/11600393/46289965-d38a1200-c58a-11e8-8041-662dfe36943e.gif" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="200" />

This pull request intends to fix that.