### PR TITLE
[Functions & Solver] Edit expression field is not erased in some cases

### DIFF
--- a/apps/shared/expression_model_list_controller.cpp
+++ b/apps/shared/expression_model_list_controller.cpp
@@ -88,10 +88,8 @@ void ExpressionModelListController::reinitExpression(ExpressionModel * model) {
 void ExpressionModelListController::editExpression(ExpressionModel * model, Ion::Events::Event event) {
   char * initialText = nullptr;
   char initialTextContent[TextField::maxBufferSize()];
-  if (event == Ion::Events::OK || event == Ion::Events::EXE) {
-    strlcpy(initialTextContent, model->text(), sizeof(initialTextContent));
-    initialText = initialTextContent;
-  }
+  strlcpy(initialTextContent, model->text(), sizeof(initialTextContent));
+  initialText = initialTextContent;
   inputController()->edit(this, event, model, initialText,
     [](void * context, void * sender){
     ExpressionModel * myModel = static_cast<ExpressionModel *>(context);


### PR DESCRIPTION
Hello,
I found a bug, and this is quite the same bug as in #695, but in functions and in solver.
The expression field is not erased after another field was edited.

<img src="https://user-images.githubusercontent.com/11600393/46538198-9dfb6680-c8b3-11e8-98ec-30943b90fe62.gif" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="200" />