### PR TITLE
[code] Fix EditorController: cannot use strcpy when the first char is a flag that can be 0

### DIFF
--- a/apps/code/editor_controller.cpp
+++ b/apps/code/editor_controller.cpp
@@ -22,7 +22,8 @@ void EditorController::setScript(Script script) {
   Script::Data scriptData = m_script.value();
   size_t availableScriptSize = scriptData.size + Ion::Storage::sharedStorage()->availableSize();
   assert(sizeof(m_areaBuffer) >= availableScriptSize);
-  strlcpy(m_areaBuffer, (const char *)scriptData.buffer, scriptData.size);
+  // We cannot use strlcpy as the first char reprensenting the importation status can be 0.
+  memcpy(m_areaBuffer, (const char *)scriptData.buffer, scriptData.size);
   m_editorView.setText(m_areaBuffer+1, availableScriptSize-1); // 1 char is taken by the importation status flag
 }
 


### PR DESCRIPTION
The area buffer given to the EditorController has a reserved char representing the importation status. We thus cannot use strcpy because null termination might be triggered by the importation status before the end of the script content.