### PR TITLE
[poincare] Fix Decimal::templatedApproximate

### DIFF
--- a/poincare/src/decimal.cpp
+++ b/poincare/src/decimal.cpp
@@ -205,8 +205,7 @@ template<typename T> T DecimalNode::templatedApproximate() const {
   Integer m = signedMantissa();
   T f = m.approximate<T>();
   int numberOfDigits = Integer::NumberOfBase10DigitsWithoutSign(m);
-  T result = f*std::pow((T)10.0, (T)(m_exponent-numberOfDigits+1));
-  return m_negative ? -result : result;
+  return f*std::pow((T)10.0, (T)(m_exponent-numberOfDigits+1));
 }
 
 int Decimal::Exponent(const char * integralPart, int integralPartLength, const char * fractionalPart, int fractionalPartLength, const char * exponent, int exponentLength) {


### PR DESCRIPTION
Before, we used an unsigned mantissa and needed to set the sign
afterwards, but with the signed mantissa we must not do this.