### PR TITLE
[apps/stats] Fix pixel row not drawn when there are 3 histograms

### DIFF
--- a/apps/statistics/multiple_data_view.cpp
+++ b/apps/statistics/multiple_data_view.cpp
@@ -72,7 +72,7 @@ void MultipleDataView::layoutDataSubviews() {
   int numberDataSubviews = m_store->numberOfNonEmptySeries();
   assert(numberDataSubviews > 0);
   KDCoordinate bannerHeight = bannerFrame().height();
-  KDCoordinate subviewHeight = (bounds().height() - bannerHeight)/numberDataSubviews;
+  KDCoordinate subviewHeight = (bounds().height() - bannerHeight)/numberDataSubviews + 1; // +1 to make sure that all pixel rows are drawn
   int displayedSubviewIndex = 0;
   for (int i = 0; i < Store::k_numberOfSeries; i++) {
     if (!m_store->seriesIsEmpty(i)) {


### PR DESCRIPTION
To see this pixel row, go in the statistics app, add 3 series, go in the Histogram tab, then switch off and on the calculator. The pixel row on top of the banner view has random colours.