### PR TITLE
[python] Clean the time module

### DIFF
--- a/build/toolchain.emscripten.mak
+++ b/build/toolchain.emscripten.mak
@@ -58,12 +58,13 @@ __ZThn32_N4Code17ConsoleController9inputTextEPKc \
 __ZThn36_N4Code17ConsoleController9inputTextEPKc \
 __ZZN4Code14MenuControllerC1EP9ResponderPNS_11ScriptStoreEP19ButtonRowControllerbEN3__08__invokeEPvS8_ \
 __ZZN4Code14MenuControllerC1EP9ResponderPNS_11ScriptStoreEP19ButtonRowControllerbENK3__0clEPvS8_ \
-_delay_ms \
 _do_load \
 _do_load_from_lexer \
 _fun_bc_call \
 _fun_builtin_var_call \
 _main \
+_micropython_port_interruptible_msleep \
+_micropython_port_should_interrupt \
 _micropython_port_vm_hook_loop \
 _mp_builtin___import__ \
 _mp_builtin_input \

--- a/python/port/helpers.cpp
+++ b/python/port/helpers.cpp
@@ -29,3 +29,10 @@ bool micropython_port_should_interrupt() {
   Ion::Keyboard::Key interruptKey = static_cast<Ion::Keyboard::Key>(mp_interrupt_char);
   return scan.keyDown(interruptKey);
 }
+
+void micropython_port_interruptible_msleep(uint32_t delay) {
+  uint32_t start = Ion::Timing::millis();
+  while (Ion::Timing::millis() - start < delay && !micropython_port_should_interrupt()) {
+    Ion::Timing::msleep(1);
+  }
+}

--- a/python/port/helpers.h
+++ b/python/port/helpers.h
@@ -4,10 +4,13 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
 #include <stdbool.h>
+#include <stdint.h>
 
 void micropython_port_vm_hook_loop();
 bool micropython_port_should_interrupt();
+void micropython_port_interruptible_msleep(uint32_t delay);
 
 #ifdef __cplusplus
 }

--- a/python/port/mod/time/modtime.cpp
+++ b/python/port/mod/time/modtime.cpp
@@ -2,26 +2,19 @@ extern "C" {
 #include "modtime.h"
 }
 #include <ion/timing.h>
-
-#include "py/smallint.h"
-#include "py/runtime.h"
-
-static void delay_ms(mp_uint_t delay) {
-  uint32_t start = Ion::Timing::millis();
-  while (Ion::Timing::millis() - start < delay && !micropython_port_should_interrupt()) {
-    Ion::Timing::msleep(1);
-  }
-}
+#include "../../helpers.h"
+#include <py/smallint.h>
+#include <py/runtime.h>
 
 mp_obj_t modtime_sleep(mp_obj_t seconds_o) {
 #if MICROPY_PY_BUILTINS_FLOAT
-  delay_ms((mp_uint_t)(1000 * mp_obj_get_float(seconds_o)));
+  micropython_port_interruptible_msleep(1000 * mp_obj_get_float(seconds_o));
 #else
-  delay_ms(1000 * mp_obj_get_int(seconds_o));
+  micropython_port_interruptible_msleep(1000 * mp_obj_get_int(seconds_o));
 #endif
   return mp_const_none;
 }
 
-mp_obj_t modtime_monotonic(void) {
+mp_obj_t modtime_monotonic() {
     return mp_obj_new_float(Ion::Timing::millis() / 1000.0);
 }


### PR DESCRIPTION
* Mark `micropython_port_should_interrupt` and `micropython_port_interruptible_msleep` as async symbols in Emscripten
* Make `micropython_port_interruptible_msleep` available in a helper