### PR TITLE
Cast result of strlen to int to match comparison

### DIFF
--- a/apps/code/variable_box_controller.cpp
+++ b/apps/code/variable_box_controller.cpp
@@ -57,7 +57,7 @@ void VariableBoxController::ContentViewController::didEnterResponderChain(Respon
 }
 
 static bool shouldAddObject(const char * name, int maxLength) {
-  if (strlen(name)+1 > maxLength) {
+  if ((int)strlen(name)+1 > maxLength) {
     return false;
   }
   assert(name != nullptr);

--- a/apps/graph/graph/intersection_graph_controller.cpp
+++ b/apps/graph/graph/intersection_graph_controller.cpp
@@ -24,7 +24,7 @@ void IntersectionGraphController::reloadBannerView() {
   size_t bufferSize = FunctionBannerDelegate::k_maxNumberOfCharacters+PrintFloat::bufferSizeForFloatsWithPrecision(Constant::LargeNumberOfSignificantDigits);
   char buffer[bufferSize];
   const char * space = "                  ";
-  int spaceLength = strlen(space);
+  int spaceLength = (int)strlen(space);
   const char * legend = "0(x)=0(x)=";
   int legendLength = strlen(legend);
   int numberOfChar = 0;

--- a/escher/src/text_field.cpp
+++ b/escher/src/text_field.cpp
@@ -104,7 +104,7 @@ bool TextField::ContentView::insertTextAtLocation(const char * text, int locatio
   int overridenCharLocation = location + strlen(text);
   char overridenChar = m_draftTextBuffer[overridenCharLocation];
   strlcpy(&m_draftTextBuffer[location], text, m_textBufferSize-location);
-  assert(overridenCharLocation < m_textBufferSize);
+  assert(overridenCharLocation < (int)m_textBufferSize);
   m_draftTextBuffer[overridenCharLocation] = overridenChar;
   m_currentDraftTextLength += textSize;
 


### PR DESCRIPTION
There are three locations in code that generate a compiler warning because of a comparison of unsigned integer with signed integer types. This is because `strlen` returns `size_t`. I cast these instances to `int`. This silences the compiler warnings.