### PR TITLE
[escher] TableView::cellAtLocation should return nullptr if the cell is invisible and therefore no view displays it.

### DIFF
--- a/apps/calculation/selectable_table_view.cpp
+++ b/apps/calculation/selectable_table_view.cpp
@@ -63,6 +63,7 @@ void CalculationSelectableTableView::scrollToSubviewOfTypeOfCellAtLocation(Histo
    * selected calculation has not changed. */
   setContentOffset(KDPoint(contentOffsetX, contentOffsetY));
   HighlightCell * cell = cellAtLocation(i, j);
+  assert(cell);
   cell->setHighlighted(true);
   if (m_delegate) {
     m_delegate->tableViewDidChangeSelection(this, selectedColumn(), selectedRow());

--- a/apps/code/console_controller.cpp
+++ b/apps/code/console_controller.cpp
@@ -223,7 +223,9 @@ void ConsoleController::tableViewDidChangeSelection(SelectableTableView * t, int
     if (previousSelectedCellY > -1 && previousSelectedCellY < m_consoleStore.numberOfLines()) {
       // Reset the scroll of the previous cell
       ConsoleLineCell * previousCell = (ConsoleLineCell *)(t->cellAtLocation(previousSelectedCellX, previousSelectedCellY));
-      previousCell->reloadCell();
+      if (previousCell) {
+        previousCell->reloadCell();
+      }
     }
     ConsoleLineCell * selectedCell = (ConsoleLineCell *)(t->selectedCell());
     selectedCell->reloadCell();

--- a/apps/regression/calculation_controller.cpp
+++ b/apps/regression/calculation_controller.cpp
@@ -91,6 +91,7 @@ void CalculationController::tableViewDidChangeSelection(SelectableTableView * t,
       /* If the selection stays in the same column, we copy the subselection
        * from previous cell. Otherwise, the selection has jumped to another
        * column, we thus subselect the other subcell. */
+       assert(myPreviousCell);
       firstSubCellSelected = t->selectedColumn() == previousSelectedCellX ? myPreviousCell->firstTextSelected() : !myPreviousCell->firstTextSelected();
     }
     myCell->selectFirstText(firstSubCellSelected);

--- a/apps/sequence/list/list_parameter_controller.cpp
+++ b/apps/sequence/list/list_parameter_controller.cpp
@@ -159,7 +159,9 @@ void ListParameterController::tableViewDidChangeSelection(SelectableTableView * 
   if (previousSelectedCellY == 1) {
 #endif
     MessageTableCellWithEditableText * myCell = (MessageTableCellWithEditableText *)t->cellAtLocation(previousSelectedCellX, previousSelectedCellY);
-    myCell->setEditing(false);
+    if (myCell) {
+      myCell->setEditing(false);
+    }
     app()->setFirstResponder(&m_selectableTableView);
   }
 #if FUNCTION_COLOR_CHOICE

--- a/escher/src/selectable_table_view.cpp
+++ b/escher/src/selectable_table_view.cpp
@@ -158,6 +158,7 @@ void SelectableTableView::unhighlightSelectedCell() {
   if (selectedColumn() >= 0 && selectedColumn() < dataSource()->numberOfColumns() &&
       selectedRow() >= 0 && selectedRow() < dataSource()->numberOfRows()) {
     HighlightCell * previousCell = cellAtLocation(selectedColumn(), selectedRow());
+    assert(previousCell);
     previousCell->setHighlighted(false);
   }
 }

--- a/escher/src/table_view.cpp
+++ b/escher/src/table_view.cpp
@@ -98,7 +98,10 @@ void TableView::ContentView::scrollToCell(int x, int y) const {
 }
 
 void TableView::ContentView::reloadCellAtLocation(int i, int j) {
-  m_dataSource->willDisplayCellAtLocation(cellAtLocation(i, j), i, j);
+  HighlightCell * cell = cellAtLocation(i, j);
+  if (cell) {
+    m_dataSource->willDisplayCellAtLocation(cellAtLocation(i, j), i, j);
+  }
 }
 
 int TableView::ContentView::typeOfSubviewAtIndex(int index) const {
@@ -123,6 +126,9 @@ int TableView::ContentView::typeIndexFromSubviewIndex(int index, int type) const
 HighlightCell * TableView::ContentView::cellAtLocation(int x, int y) {
   int relativeX = x-columnsScrollingOffset();
   int relativeY = y-rowsScrollingOffset();
+  if (relativeY >= numberOfDisplayableRows() || relativeX >= numberOfDisplayableColumns()) {
+    return nullptr;
+  }
   int type = m_dataSource->typeAtLocation(x, y);
   int index = relativeY*numberOfDisplayableColumns()+relativeX;
   int typeIndex = typeIndexFromSubviewIndex(index, type);


### PR DESCRIPTION
Fix #783