### PR TITLE
[calculation] Bug in the subview selected with heigh cells

### DIFF
--- a/apps/calculation/history_controller.cpp
+++ b/apps/calculation/history_controller.cpp
@@ -15,6 +15,7 @@ HistoryController::HistoryController(Responder * parentResponder, CalculationSto
 {
   for (int i = 0; i < k_maxNumberOfDisplayedRows; i++) {
     m_calculationHistory[i].setParentResponder(&m_selectableTableView);
+    m_calculationHistory[i].setDataSource(this);
   }
 }
 
@@ -45,12 +46,12 @@ bool HistoryController::handleEvent(Ion::Events::Event event) {
   if (event == Ion::Events::OK || event == Ion::Events::EXE) {
     int focusRow = selectedRow();
     HistoryViewCell * selectedCell = (HistoryViewCell *)m_selectableTableView.selectedCell();
-    HistoryViewCell::SubviewType subviewType = selectedCell->selectedSubviewType();
+    SubviewType subviewType = selectedSubviewType();
     EditExpressionController * editController = (EditExpressionController *)parentResponder();
     m_selectableTableView.deselectTable();
     app()->setFirstResponder(editController);
     Calculation * calculation = m_calculationStore->calculationAtIndex(focusRow);
-    if (subviewType == HistoryViewCell::SubviewType::Input) {
+    if (subviewType == SubviewType::Input) {
       editController->insertTextBody(calculation->inputText());
     } else {
       ScrollableExactApproximateExpressionsView::SubviewPosition outputSubviewPosition = selectedCell->outputView()->selectedSubviewPosition();
@@ -66,8 +67,7 @@ bool HistoryController::handleEvent(Ion::Events::Event event) {
   }
   if (event == Ion::Events::Backspace) {
     int focusRow = selectedRow();
-    HistoryViewCell * selectedCell = (HistoryViewCell *)m_selectableTableView.selectedCell();
-    HistoryViewCell::SubviewType subviewType = selectedCell->selectedSubviewType();
+    SubviewType subviewType = selectedSubviewType();
     m_selectableTableView.deselectTable();
     EditExpressionController * editController = (EditExpressionController *)parentResponder();
     m_calculationStore->deleteCalculationAtIndex(focusRow);
@@ -81,7 +81,7 @@ bool HistoryController::handleEvent(Ion::Events::Event event) {
     } else {
       m_selectableTableView.selectCellAtLocation(0, 0);
     }
-    if (subviewType == HistoryViewCell::SubviewType::Input) {
+    if (subviewType == SubviewType::Input) {
       tableViewDidChangeSelection(&m_selectableTableView, 0, selectedRow());
     } else {
       tableViewDidChangeSelection(&m_selectableTableView, 0, -1);
@@ -106,16 +106,16 @@ bool HistoryController::handleEvent(Ion::Events::Event event) {
 }
 
 void HistoryController::tableViewDidChangeSelection(SelectableTableView * t, int previousSelectedCellX, int previousSelectedCellY) {
+  if (previousSelectedCellY == -1) {
+    setSelectedSubviewType(SubviewType::Output);
+  } else if (selectedRow() < previousSelectedCellY) {
+    setSelectedSubviewType(SubviewType::Output);
+  } else if (selectedRow() > previousSelectedCellY) {
+    setSelectedSubviewType(SubviewType::Input);
+  }
   HistoryViewCell * selectedCell = (HistoryViewCell *)(t->selectedCell());
   if (selectedCell == nullptr) {
     return;
-  }
-  if (previousSelectedCellY == -1) {
-    selectedCell->setSelectedSubviewType(HistoryViewCell::SubviewType::Output);
-  } else if (selectedRow() < previousSelectedCellY) {
-    selectedCell->setSelectedSubviewType(HistoryViewCell::SubviewType::Output);
-  } else if (selectedRow() > previousSelectedCellY) {
-    selectedCell->setSelectedSubviewType(HistoryViewCell::SubviewType::Input);
   }
   app()->setFirstResponder(selectedCell);
   selectedCell->reloadCell();

--- a/apps/calculation/history_controller.h
+++ b/apps/calculation/history_controller.h
@@ -10,7 +10,7 @@ namespace Calculation {
 
 class App;
 
-class HistoryController : public ViewController, public ListViewDataSource, public SelectableTableViewDataSource, public SelectableTableViewDelegate {
+class HistoryController : public ViewController, public ListViewDataSource, public SelectableTableViewDataSource, public SelectableTableViewDelegate, public HistoryViewCellDataSource {
 public:
   HistoryController(Responder * parentResponder, CalculationStore * calculationStore);
   View * view() override { return &m_selectableTableView; }

--- a/apps/calculation/history_view_cell.cpp
+++ b/apps/calculation/history_view_cell.cpp
@@ -7,6 +7,20 @@
 
 namespace Calculation {
 
+/* HistoryViewCellDataSource */
+
+HistoryViewCellDataSource::HistoryViewCellDataSource() :
+  m_selectedSubviewType(HistoryViewCellDataSource::SubviewType::Output) {}
+
+void HistoryViewCellDataSource::setSelectedSubviewType(HistoryViewCellDataSource::SubviewType subviewType, HistoryViewCell * cell) {
+  m_selectedSubviewType = subviewType;
+  if (cell) {
+    cell->setHighlighted(cell->isHighlighted());
+  }
+}
+
+/* HistoryViewCell */
+
 HistoryViewCell::HistoryViewCell(Responder * parentResponder) :
   Responder(parentResponder),
   m_calculation(),
@@ -14,8 +28,7 @@ HistoryViewCell::HistoryViewCell(Responder * parentResponder) :
   m_leftOutputLayout(),
   m_rightOutputLayout(),
   m_inputView(this),
-  m_scrollableOutputView(this),
-  m_selectedSubviewType(HistoryViewCell::SubviewType::Output)
+  m_scrollableOutputView(this)
 {
 }
 
@@ -30,11 +43,12 @@ void HistoryViewCell::setEven(bool even) {
 }
 
 void HistoryViewCell::setHighlighted(bool highlight) {
+  assert(m_dataSource);
   m_highlighted = highlight;
   m_inputView.setBackgroundColor(backgroundColor());
   m_scrollableOutputView.evenOddCell()->setHighlighted(false);
   if (isHighlighted()) {
-    if (m_selectedSubviewType == SubviewType::Input) {
+    if (m_dataSource->selectedSubviewType() == HistoryViewCellDataSource::SubviewType::Input) {
       m_inputView.setBackgroundColor(Palette::Select);
     } else {
       m_scrollableOutputView.evenOddCell()->setHighlighted(true);
@@ -44,7 +58,8 @@ void HistoryViewCell::setHighlighted(bool highlight) {
 }
 
 Poincare::Layout HistoryViewCell::layout() const {
-  if (m_selectedSubviewType == SubviewType::Input) {
+  assert(m_dataSource);
+  if (m_dataSource->selectedSubviewType() == HistoryViewCellDataSource::SubviewType::Input) {
     return m_inputLayout;
   } else {
     return m_scrollableOutputView.layout();
@@ -125,30 +140,23 @@ void HistoryViewCell::setCalculation(Calculation * calculation) {
 }
 
 void HistoryViewCell::didBecomeFirstResponder() {
-  if (m_selectedSubviewType == SubviewType::Input) {
+  assert(m_dataSource);
+  if (m_dataSource->selectedSubviewType() == HistoryViewCellDataSource::SubviewType::Input) {
     app()->setFirstResponder(&m_inputView);
   } else {
     app()->setFirstResponder(&m_scrollableOutputView);
   }
 }
 
-HistoryViewCell::SubviewType HistoryViewCell::selectedSubviewType() {
-  return m_selectedSubviewType;
-}
-
-void HistoryViewCell::setSelectedSubviewType(HistoryViewCell::SubviewType subviewType) {
-  m_selectedSubviewType = subviewType;
-  setHighlighted(isHighlighted());
-}
-
 bool HistoryViewCell::handleEvent(Ion::Events::Event event) {
-  if ((event == Ion::Events::Down && m_selectedSubviewType == SubviewType::Input) ||
-    (event == Ion::Events::Up && m_selectedSubviewType == SubviewType::Output)) {
-    SubviewType otherSubviewType = m_selectedSubviewType == SubviewType::Input ? SubviewType::Output : SubviewType::Input;
+  assert(m_dataSource);
+  if ((event == Ion::Events::Down && m_dataSource->selectedSubviewType() == HistoryViewCellDataSource::SubviewType::Input) ||
+    (event == Ion::Events::Up && m_dataSource->selectedSubviewType() == HistoryViewCellDataSource::SubviewType::Output)) {
+    HistoryViewCellDataSource::SubviewType otherSubviewType = m_dataSource->selectedSubviewType() == HistoryViewCellDataSource::SubviewType::Input ? HistoryViewCellDataSource::SubviewType::Output : HistoryViewCellDataSource::SubviewType::Input;
     CalculationSelectableTableView * tableView = (CalculationSelectableTableView *)parentResponder();
     tableView->scrollToSubviewOfTypeOfCellAtLocation(otherSubviewType, tableView->selectedColumn(), tableView->selectedRow());
     HistoryViewCell * selectedCell = (HistoryViewCell *)(tableView->selectedCell());
-    selectedCell->setSelectedSubviewType(otherSubviewType);
+    m_dataSource->setSelectedSubviewType(otherSubviewType, selectedCell);
     app()->setFirstResponder(selectedCell);
     return true;
   }

--- a/apps/calculation/history_view_cell.h
+++ b/apps/calculation/history_view_cell.h
@@ -8,17 +8,29 @@
 
 namespace Calculation {
 
-class HistoryViewCell : public ::EvenOddCell, public Responder {
+class HistoryViewCell;
+
+class HistoryViewCellDataSource {
 public:
   enum class SubviewType {
     Input,
     Output
   };
+  HistoryViewCellDataSource();
+  void setSelectedSubviewType(HistoryViewCellDataSource::SubviewType subviewType, HistoryViewCell * cell = nullptr);
+  SubviewType selectedSubviewType() { return m_selectedSubviewType; }
+private:
+  SubviewType m_selectedSubviewType;
+};
+
+class HistoryViewCell : public ::EvenOddCell, public Responder {
+public:
   HistoryViewCell(Responder * parentResponder = nullptr);
   void reloadCell() override;
   void reloadScroll();
   void setEven(bool even) override;
   void setHighlighted(bool highlight) override;
+  void setDataSource(HistoryViewCellDataSource * dataSource) { m_dataSource = dataSource; }
   Responder * responder() override {
     return this;
   }
@@ -31,8 +43,6 @@ public:
   void didBecomeFirstResponder() override;
   bool handleEvent(Ion::Events::Event event) override;
   constexpr static KDCoordinate k_digitVerticalMargin = 5;
-  SubviewType selectedSubviewType();
-  void setSelectedSubviewType(HistoryViewCell::SubviewType subviewType);
   Shared::ScrollableExactApproximateExpressionsView * outputView();
 private:
   constexpr static KDCoordinate k_resultWidth = 80;
@@ -42,7 +52,7 @@ private:
   Poincare::Layout m_rightOutputLayout;
   ScrollableExpressionView m_inputView;
   Shared::ScrollableExactApproximateExpressionsView m_scrollableOutputView;
-  SubviewType m_selectedSubviewType;
+  HistoryViewCellDataSource * m_dataSource;
 };
 
 }

--- a/apps/calculation/selectable_table_view.cpp
+++ b/apps/calculation/selectable_table_view.cpp
@@ -38,7 +38,7 @@ void CalculationSelectableTableView::scrollToCell(int i, int j) {
   }
 }
 
-void CalculationSelectableTableView::scrollToSubviewOfTypeOfCellAtLocation(HistoryViewCell::SubviewType subviewType, int i, int j) {
+void CalculationSelectableTableView::scrollToSubviewOfTypeOfCellAtLocation(HistoryViewCellDataSource::SubviewType subviewType, int i, int j) {
   if (dataSource()->rowHeight(j) <= bounds().height()) {
     return;
   }
@@ -51,7 +51,7 @@ void CalculationSelectableTableView::scrollToSubviewOfTypeOfCellAtLocation(Histo
   /* Main part of the scroll */
   KDCoordinate contentOffsetX = contentOffset().x();
   KDCoordinate contentOffsetY = dataSource()->cumulatedHeightFromIndex(j+1) - maxContentHeightDisplayableWithoutScrolling();
-  if (subviewType == HistoryViewCell::SubviewType::Input) {
+  if (subviewType == HistoryViewCellDataSource::SubviewType::Input) {
     if (j == 0) {
       contentOffsetY = 0;
     } else {

--- a/apps/calculation/selectable_table_view.h
+++ b/apps/calculation/selectable_table_view.h
@@ -10,7 +10,7 @@ public:
   CalculationSelectableTableView(Responder * parentResponder, TableViewDataSource * dataSource,
     SelectableTableViewDataSource * selectionDataSource, SelectableTableViewDelegate * delegate = nullptr);
   void scrollToCell(int i, int j) override;
-  void scrollToSubviewOfTypeOfCellAtLocation(HistoryViewCell::SubviewType subviewType, int i, int j);
+  void scrollToSubviewOfTypeOfCellAtLocation(HistoryViewCellDataSource::SubviewType subviewType, int i, int j);
 };
 
 }


### PR DESCRIPTION
In SelectableTableView::selectCellAtLocation, we call 'tableViewDidChangeSelection'
before scrolling. Therefore, the cell with updated with the right selected subview
is not the one drawn... To solve this issue, we keep the selectedSubview ('model')
 in the HistoryController instead of in the limited-lifespan view.