### PR TITLE
[apps] Sandbox handles/absorbs only keyboard events (except Home, OnOff)

### DIFF
--- a/apps/code/sandbox_controller.cpp
+++ b/apps/code/sandbox_controller.cpp
@@ -18,6 +18,7 @@ void SandboxController::viewWillAppear() {
 }
 
 bool SandboxController::handleEvent(Ion::Events::Event event) {
+  // The sandbox handles or "absorbs" all keyboard events except Home and OnOff
   if (event == Ion::Events::Home || event == Ion::Events::OnOff) {
     stackViewController()->pop();
     return false;
@@ -25,7 +26,7 @@ bool SandboxController::handleEvent(Ion::Events::Event event) {
   if (event == Ion::Events::OK || event == Ion::Events::Back) {
     stackViewController()->pop();
   }
-  return true;
+  return event.isKeyboardEvent();
 }
 
 }

--- a/apps/suspend_timer.cpp
+++ b/apps/suspend_timer.cpp
@@ -8,6 +8,7 @@ SuspendTimer::SuspendTimer(AppsContainer * container) :
 }
 
 bool SuspendTimer::fire() {
+  m_container->dispatchEvent(Ion::Events::OnOff);
   m_container->suspend();
   return false;
 }


### PR DESCRIPTION
The sandbox was not exited when the device suspended because of a long
time without use. When the device was powered on again, a blank sandbox
was displayed.
The sandbox also prevented USB enumeration.