### PR TITLE
[apps/regression] Fix vertical navigation if 2 series have same point

### DIFF
--- a/apps/regression/store.cpp
+++ b/apps/regression/store.cpp
@@ -61,7 +61,9 @@ int Store::closestVerticalDot(int direction, double x, double y, int currentSeri
       double currentY = i < numberOfPoints ? m_data[series][1][i] : meanOfColumn(series, 1);
       if (m_xMin <= currentX && currentX <= m_xMax // The next dot is within the window abscissa bounds
           && (std::fabs(currentX - x) <= std::fabs(nextX - x)) // The next dot is the closest to x in abscissa
-          && ((currentY >= y) == (direction > 0)) // The next dot is above/under y
+          && ((currentY > y && direction > 0) // The next dot is above/under y
+            || (currentY < y && direction < 0)
+            || (currentY == y && (currentDot < 0 || ((direction < 0) == (series > currentSeries)))))
           && (nextX != currentX // Edge case: if 2 dots have the same abscissa but different ordinates
             || ((currentY <= nextY) == (direction > 0))))
       {


### PR DESCRIPTION
Data set:
X1: 8 9 10 10
Y1: 2 5 1  2

X2: 10 12 5
Y2: 2  0  8

Navigating vertically on the (10, 2) point goes into a loop