### PR TITLE
[shared] Use Simplify instead of Reduce

### DIFF
--- a/apps/sequence/sequence.cpp
+++ b/apps/sequence/sequence.cpp
@@ -96,14 +96,14 @@ void Sequence::setInitialRank(int rank) {
 
 Poincare::Expression Sequence::firstInitialConditionExpression(Context * context) const {
   if (m_firstInitialConditionExpression.isUninitialized()) {
-    m_firstInitialConditionExpression = PoincareHelpers::ParseAndReduce(m_firstInitialConditionText, *context);
+    m_firstInitialConditionExpression = PoincareHelpers::ParseAndSimplify(m_firstInitialConditionText, *context);
   }
   return m_firstInitialConditionExpression;
 }
 
 Poincare::Expression Sequence::secondInitialConditionExpression(Context * context) const {
   if (m_secondInitialConditionExpression.isUninitialized()) {
-    m_secondInitialConditionExpression = PoincareHelpers::ParseAndReduce(m_secondInitialConditionText, *context);
+    m_secondInitialConditionExpression = PoincareHelpers::ParseAndSimplify(m_secondInitialConditionText, *context);
   }
   return m_secondInitialConditionExpression;
 }

--- a/apps/shared/expression_model.cpp
+++ b/apps/shared/expression_model.cpp
@@ -21,7 +21,7 @@ const char * ExpressionModel::text() const {
 
 Poincare::Expression ExpressionModel::expression(Poincare::Context * context) const {
   if (m_expression.isUninitialized()) {
-    m_expression = PoincareHelpers::ParseAndReduce(m_text, *context);
+    m_expression = PoincareHelpers::ParseAndSimplify(m_text, *context);
   }
   return m_expression;
 }

--- a/apps/shared/poincare_helpers.h
+++ b/apps/shared/poincare_helpers.h
@@ -37,10 +37,6 @@ inline T ApproximateToScalar(const char * text, Poincare::Context & context) {
   return Poincare::Expression::approximateToScalar<T>(text, context, Poincare::Preferences::sharedPreferences()->angleUnit());
 }
 
-inline Poincare::Expression ParseAndReduce(const char * text, Poincare::Context & context) {
-  return Poincare::Expression::ParseAndReduce(text, context, Poincare::Preferences::sharedPreferences()->angleUnit());
-}
-
 inline Poincare::Expression ParseAndSimplify(const char * text, Poincare::Context & context) {
   return Poincare::Expression::ParseAndSimplify(text, context, Poincare::Preferences::sharedPreferences()->angleUnit());
 }


### PR DESCRIPTION
 Revert: To approximate an expression, it is more precise to approximate its simplified form than its reduced form. Indeed, we want to minimize the number of nodes in the expression before approximating.
For instance, a/b has fewer nodes than a*b^-1.