### PR TITLE
[poincare] Revert: Use Simplify instead of Reduce II

### DIFF
--- a/apps/shared/storage_expression_model.cpp
+++ b/apps/shared/storage_expression_model.cpp
@@ -39,7 +39,12 @@ Expression StorageExpressionModel::expressionReduced(Poincare::Context * context
   if (m_expression.isUninitialized()) {
     assert(!isNull());
     Ion::Storage::Record::Data recordData = value();
-    m_expression = Expression::ExpressionFromAddress(expressionAddressForValue(recordData), expressionSizeForValue(recordData)).reduce(*context, Preferences::sharedPreferences()->angleUnit());
+    m_expression = Expression::ExpressionFromAddress(expressionAddressForValue(recordData), expressionSizeForValue(recordData));
+    PoincareHelpers::Simplify(&m_expression, *context);
+    // simplify might return an uninitialized Expression if interrupted
+    if (m_expression.isUninitialized()) {
+      m_expression = Expression::ExpressionFromAddress(expressionAddressForValue(recordData), expressionSizeForValue(recordData));
+    }
   }
   return m_expression;
 }

--- a/poincare/include/poincare/expression.h
+++ b/poincare/include/poincare/expression.h
@@ -167,7 +167,6 @@ public:
   int serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode = Preferences::PrintFloatMode::Decimal, int numberOfSignificantDigits = PrintFloat::k_numberOfStoredSignificantDigits) const;
 
   /* Simplification */
-  static Expression ParseAndReduce(const char * text, Context & context, Preferences::AngleUnit);
   static Expression ParseAndSimplify(const char * text, Context & context, Preferences::AngleUnit angleUnit);
   Expression simplify(Context & context, Preferences::AngleUnit angleUnit);
   Expression reduce(Context & context, Preferences::AngleUnit angleUnit);

--- a/poincare/src/expression.cpp
+++ b/poincare/src/expression.cpp
@@ -312,14 +312,6 @@ int Expression::serialize(char * buffer, int bufferSize, Preferences::PrintFloat
 
 /* Simplification */
 
-Expression Expression::ParseAndReduce(const char * text, Context & context, Preferences::AngleUnit angleUnit) {
-  Expression exp = Parse(text);
-  if (exp.isUninitialized()) {
-    return Undefined();
-  }
-  return exp.reduce(context, angleUnit);
-}
-
 Expression Expression::ParseAndSimplify(const char * text, Context & context, Preferences::AngleUnit angleUnit) {
   Expression exp = Parse(text);
   if (exp.isUninitialized()) {
@@ -423,7 +415,7 @@ U Expression::approximateToScalar(Context& context, Preferences::AngleUnit angle
 
 template<typename U>
 U Expression::approximateToScalar(const char * text, Context& context, Preferences::AngleUnit angleUnit) {
-  Expression exp = ParseAndReduce(text, context, angleUnit);
+  Expression exp = ParseAndSimplify(text, context, angleUnit);
   return exp.approximateToScalar<U>(context, angleUnit);
 }
 


### PR DESCRIPTION
To approximate an expression, it is more precise to
approximate its simplified form than its reduced form. Indeed, we want
to minimize the number of nodes in the expression before approximating.
For instance, a/b has fewer nodes than a*b^-1.