### PR TITLE
Improve function scroll speed when many functions

### DIFF
--- a/apps/shared/storage_expression_model_list_controller.cpp
+++ b/apps/shared/storage_expression_model_list_controller.cpp
@@ -8,10 +8,9 @@ namespace Shared {
 
 StorageExpressionModelListController::StorageExpressionModelListController(Responder * parentResponder, I18n::Message text) :
   ViewController(parentResponder),
-  m_addNewModel(),
-  m_memoizedCellHeight {k_resetedMemoizedValue, k_resetedMemoizedValue, k_resetedMemoizedValue, k_resetedMemoizedValue, k_resetedMemoizedValue},
-  m_cumulatedHeightForSelectedIndex(k_resetedMemoizedValue)
+  m_addNewModel()
 {
+  resetMemoization();
   m_addNewModel.setMessage(text);
 }
 

--- a/apps/shared/storage_expression_model_list_controller.cpp
+++ b/apps/shared/storage_expression_model_list_controller.cpp
@@ -9,8 +9,8 @@ namespace Shared {
 StorageExpressionModelListController::StorageExpressionModelListController(Responder * parentResponder, I18n::Message text) :
   ViewController(parentResponder),
   m_addNewModel(),
-  m_memoizedCellHeight {-1, -1, -1, -1, -1},
-  m_cumulatedHeightForSelectedIndex(-1)
+  m_memoizedCellHeight {k_resetedMemoizedValue, k_resetedMemoizedValue, k_resetedMemoizedValue, k_resetedMemoizedValue, k_resetedMemoizedValue},
+  m_cumulatedHeightForSelectedIndex(k_resetedMemoizedValue)
 {
   m_addNewModel.setMessage(text);
 }
@@ -20,7 +20,7 @@ void StorageExpressionModelListController::tableSelectionDidChange(int previousS
   int currentSelectedRow = selectedRow();
 
   // The previously selected cell's height might have changed.
-  m_memoizedCellHeight[currentSelectedMemoizedIndex] = -1;
+  m_memoizedCellHeight[currentSelectedMemoizedIndex] = k_resetedMemoizedValue;
 
   // Update m_cumulatedHeightForSelectedIndex if we scrolled one cell up/down
   if (currentSelectedRow == previousSelectedRow + 1) {
@@ -29,7 +29,7 @@ void StorageExpressionModelListController::tableSelectionDidChange(int previousS
     for (int i = 0; i < k_memoizedCellHeightsCount - 1; i++) {
       m_memoizedCellHeight[i] = m_memoizedCellHeight[i+1];
     }
-    m_memoizedCellHeight[k_memoizedCellHeightsCount-1] = -1;
+    m_memoizedCellHeight[k_memoizedCellHeightsCount-1] = k_resetedMemoizedValue;
     // Update m_cumulatedHeightForSelectedIndex
     if (previousSelectedRow >= 0) {
       m_cumulatedHeightForSelectedIndex+= memoizedRowHeight(previousSelectedRow);
@@ -43,7 +43,7 @@ void StorageExpressionModelListController::tableSelectionDidChange(int previousS
     for (int i = k_memoizedCellHeightsCount - 1; i > 0; i--) {
       m_memoizedCellHeight[i] = m_memoizedCellHeight[i-1];
     }
-    m_memoizedCellHeight[0] = -1;
+    m_memoizedCellHeight[0] = k_resetedMemoizedValue;
     // Update m_cumulatedHeightForSelectedIndex
     if (currentSelectedRow >= 0) {
       m_cumulatedHeightForSelectedIndex-= memoizedRowHeight(currentSelectedRow);
@@ -63,7 +63,7 @@ KDCoordinate StorageExpressionModelListController::memoizedRowHeight(int j) {
   constexpr int halfMemoizationCount = k_memoizedCellHeightsCount/2;
   if (j >= currentSelectedRow - halfMemoizationCount && j <= currentSelectedRow + halfMemoizationCount) {
     int memoizedIndex = j - (currentSelectedRow - halfMemoizationCount);
-    if (m_memoizedCellHeight[memoizedIndex] < 0) {
+    if (m_memoizedCellHeight[memoizedIndex] == k_resetedMemoizedValue) {
       m_memoizedCellHeight[memoizedIndex] = expressionRowHeight(j);
     }
     return m_memoizedCellHeight[memoizedIndex];
@@ -83,7 +83,7 @@ KDCoordinate StorageExpressionModelListController::memoizedCumulatedHeightFromIn
     return notMemoizedCumulatedHeightFromIndex(j);
   }
   // Recompute the memoized cumulatedHeight if needed
-  if (m_cumulatedHeightForSelectedIndex < 0) {
+  if (m_cumulatedHeightForSelectedIndex == k_resetedMemoizedValue) {
     m_cumulatedHeightForSelectedIndex = notMemoizedCumulatedHeightFromIndex(currentSelectedRow);
   }
   /* Compute the wanted cumulated height by adding/removing memoized cell
@@ -226,9 +226,9 @@ bool StorageExpressionModelListController::isAddEmptyRow(int j) {
 }
 
 void StorageExpressionModelListController::resetMemoization() {
-  m_cumulatedHeightForSelectedIndex = -1;
+  m_cumulatedHeightForSelectedIndex = k_resetedMemoizedValue;
   for (int i = 0; i < k_memoizedCellHeightsCount; i++) {
-    m_memoizedCellHeight[i] = -1;
+    m_memoizedCellHeight[i] = k_resetedMemoizedValue;
   }
 }
 

--- a/apps/shared/storage_expression_model_list_controller.h
+++ b/apps/shared/storage_expression_model_list_controller.h
@@ -37,12 +37,26 @@ protected:
   EvenOddMessageTextCell m_addNewModel;
 protected:
   // Memoization
-  static constexpr int k_memoizedCellHeightsCount = 5;
+  static constexpr int k_memoizedCellHeightsCount = 7;
+  /* We use memoization to speed up indexFromHeight(offset) in the children
+   * classes: if offset is "around" the memoized cumulatedHeightForIndex, we can
+   * compute its value easily by adding/substracting memoized row heights. We
+   * thus need to memoize 3 cells (see under for explanation on the 3) above the
+   * selected one, and 3 under, which gives 7 cells.
+   * 3 is the maximal number of non selected visible rows if the selected cell
+   * is completely [on top/at the bottom] of the screen. To compute this value:
+   * (ScreenHeight - Metric::TitleBarHeight - Metric::TabHeight - ButtonRowHeight
+   * - currentSelectedRowHeight) / Metric::StoreRowHeight
+   *   =  (240-18-27-20-50)/50 = 2.5 */
+  static_assert(StorageExpressionModelListController::k_memoizedCellHeightsCount % 2 == 1, "StorageExpressionModelListController::k_memoizedCellHeightsCount should be odd.");
+  /* We memoize values for indexes around the selectedRow index.
+   * k_memoizedCellHeightsCount needs to be odd to compute things such as:
+   * constexpr int halfMemoizationCount = k_memoizedCellHeightsCount/2;
+   * if (j < selectedRow - halfMemoizationCount
+   *   || j > selectedRow + halfMemoizationCount) { ... } */
 private:
   // Memoization
   static constexpr int k_resetedMemoizedValue = -1;
-  static_assert(StorageExpressionModelListController::k_memoizedCellHeightsCount == 5, "Wrong array size in initialization of StorageExpressionModelListController::m_memoizedCellHeight.");
-  static_assert(StorageExpressionModelListController::k_memoizedCellHeightsCount % 2 == 1, "StorageExpressionModelListController::k_memoizedCellHeightsCount should be odd to be able to compute the middle element.");
   void resetMemoization();
   virtual KDCoordinate notMemoizedCumulatedHeightFromIndex(int j) = 0;
   KDCoordinate m_memoizedCellHeight[k_memoizedCellHeightsCount];

--- a/apps/shared/storage_expression_model_list_controller.h
+++ b/apps/shared/storage_expression_model_list_controller.h
@@ -39,9 +39,10 @@ private:
   // Memoization
   static constexpr int k_memoizedCellHeightsCount = 5;
   static_assert(StorageExpressionModelListController::k_memoizedCellHeightsCount == 5, "Wrong array size in initialization of StorageExpressionModelListController::m_memoizedCellHeight.");
-static_assert(StorageExpressionModelListController::k_memoizedCellHeightsCount % 2 == 1, "StorageExpressionModelListController::k_memoizedCellHeightsCount should be odd to be able to compute the middle element.");
+  static_assert(StorageExpressionModelListController::k_memoizedCellHeightsCount % 2 == 1, "StorageExpressionModelListController::k_memoizedCellHeightsCount should be odd to be able to compute the middle element.");
   void resetMemoization();
   virtual KDCoordinate notMemoizedCumulatedHeightFromIndex(int j) = 0;
+  static constexpr int k_resetedMemoizedValue = -1;
   KDCoordinate m_memoizedCellHeight[k_memoizedCellHeightsCount];
   KDCoordinate m_cumulatedHeightForSelectedIndex;
 };

--- a/apps/shared/storage_expression_model_list_controller.h
+++ b/apps/shared/storage_expression_model_list_controller.h
@@ -35,14 +35,16 @@ protected:
   virtual StorageExpressionModelStore * modelStore() = 0;
   virtual InputViewController * inputController() = 0;
   EvenOddMessageTextCell m_addNewModel;
-private:
+protected:
   // Memoization
   static constexpr int k_memoizedCellHeightsCount = 5;
+private:
+  // Memoization
+  static constexpr int k_resetedMemoizedValue = -1;
   static_assert(StorageExpressionModelListController::k_memoizedCellHeightsCount == 5, "Wrong array size in initialization of StorageExpressionModelListController::m_memoizedCellHeight.");
   static_assert(StorageExpressionModelListController::k_memoizedCellHeightsCount % 2 == 1, "StorageExpressionModelListController::k_memoizedCellHeightsCount should be odd to be able to compute the middle element.");
   void resetMemoization();
   virtual KDCoordinate notMemoizedCumulatedHeightFromIndex(int j) = 0;
-  static constexpr int k_resetedMemoizedValue = -1;
   KDCoordinate m_memoizedCellHeight[k_memoizedCellHeightsCount];
   KDCoordinate m_cumulatedHeightForSelectedIndex;
 };

--- a/apps/shared/storage_function_list_controller.h
+++ b/apps/shared/storage_function_list_controller.h
@@ -26,6 +26,7 @@ public:
   KDCoordinate cumulatedWidthFromIndex(int i) override;
   KDCoordinate cumulatedHeightFromIndex(int j) override;
   int indexFromCumulatedWidth(KDCoordinate offsetX) override;
+  int indexFromCumulatedHeight(KDCoordinate offsetY) override;
   int typeAtLocation(int i, int j) override;
   HighlightCell * reusableCell(int index, int type) override;
   int reusableCellCount(int type) override;


### PR DESCRIPTION
When there were more than 13 functions in the Graph app, scrolling was very slow near the bottom of the list.