### PR TITLE
[apps/code] Fix MenuController::willExitResponderChain

### DIFF
--- a/apps/code/menu_controller.h
+++ b/apps/code/menu_controller.h
@@ -52,7 +52,9 @@ public:
   bool textFieldShouldFinishEditing(TextField * textField, Ion::Events::Event event) override;
   bool textFieldDidReceiveEvent(TextField * textField, Ion::Events::Event event) override;
   bool textFieldDidFinishEditing(TextField * textField, const char * text, Ion::Events::Event event) override;
-  bool textFieldDidAbortEditing(TextField * textField) override;
+  bool textFieldDidAbortEditing(TextField * textField) override {
+    return privateTextFieldDidAbortEditing(textField, true);
+  }
   bool textFieldDidHandleEvent(TextField * textField, bool returnValue, bool textSizeDidChange) override;
 
   /* ButtonRowDelegate */
@@ -74,6 +76,7 @@ private:
   void editScriptAtIndex(int scriptIndex);
   void numberedDefaultScriptName(char * buffer);
   void updateAddScriptRowDisplay();
+  bool privateTextFieldDidAbortEditing(TextField * textField, bool menuControllerStaysInResponderChain);
   ScriptStore * m_scriptStore;
   ScriptNameCell m_scriptCells[k_maxNumberOfDisplayableScriptCells];
   EvenOddCellWithEllipsis m_scriptParameterCells[k_maxNumberOfDisplayableScriptCells];


### PR DESCRIPTION
It called textFieldDidAbortEditing, which called setFirstResponder,
which could clash with another setFirstResponder higher in the call
tree.

Scenario: build with an update popup, create a new script, edit its name
with an unvalid name and press the Power key while editing. When
powering on the device again, the first responder is not the popup even
though it is displayed, and pressing OK does not dismiss it.