### PR TITLE
[travis] Update .travis.yml to allow Makefile parallelization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: cpp
 
+env:
+  global:
+    - MAKEFLAGS="-j 2"
+
 addons:
   apt:
     sources:


### PR DESCRIPTION
This may not be the most useful PR, but allowing Makefile parallelization can save few seconds on the build time on Travis-CI (as shown on [https://docs.travis-ci.com/user/speeding-up-the-build/](https://docs.travis-ci.com/user/speeding-up-the-build/#makefile-optimization))