### PR TITLE
Decorator

### DIFF
--- a/apps/calculation/history_controller.cpp
+++ b/apps/calculation/history_controller.cpp
@@ -150,7 +150,7 @@ KDCoordinate HistoryController::rowHeight(int j) {
   }
   Calculation * calculation = m_calculationStore->calculationAtIndex(j);
   App * calculationApp = (App *)app();
-  return calculation->height(calculationApp->localContext()) + 3*HistoryViewCell::k_digitVerticalMargin;
+  return calculation->height(calculationApp->localContext()) + 4 * Metric::CommonSmallMargin;
 }
 
 int HistoryController::typeAtLocation(int i, int j) {

--- a/apps/calculation/history_view_cell.cpp
+++ b/apps/calculation/history_view_cell.cpp
@@ -98,16 +98,16 @@ void HistoryViewCell::layoutSubviews() {
   KDSize inputSize = m_inputView.minimalSizeForOptimalDisplay();
   m_inputView.setFrame(KDRect(
     0,
-    k_digitVerticalMargin,
+    0,
     min(maxFrameWidth, inputSize.width()),
     inputSize.height()
   ));
   KDSize outputSize = m_scrollableOutputView.minimalSizeForOptimalDisplay();
   m_scrollableOutputView.setFrame(KDRect(
     max(0, maxFrameWidth - outputSize.width()),
-    inputSize.height() + 2*k_digitVerticalMargin,
+    inputSize.height(),
     min(maxFrameWidth, outputSize.width()),
-    bounds().height() - inputSize.height() - 3*k_digitVerticalMargin
+    bounds().height() - inputSize.height()
   ));
 }
 

--- a/apps/calculation/history_view_cell.cpp
+++ b/apps/calculation/history_view_cell.cpp
@@ -10,9 +10,9 @@ namespace Calculation {
 /* HistoryViewCellDataSource */
 
 HistoryViewCellDataSource::HistoryViewCellDataSource() :
-  m_selectedSubviewType(HistoryViewCellDataSource::SubviewType::Output) {}
+  m_selectedSubviewType(SubviewType::Output) {}
 
-void HistoryViewCellDataSource::setSelectedSubviewType(HistoryViewCellDataSource::SubviewType subviewType, HistoryViewCell * cell) {
+void HistoryViewCellDataSource::setSelectedSubviewType(SubviewType subviewType, HistoryViewCell * cell) {
   m_selectedSubviewType = subviewType;
   if (cell) {
     cell->setHighlighted(cell->isHighlighted());

--- a/apps/calculation/history_view_cell.cpp
+++ b/apps/calculation/history_view_cell.cpp
@@ -39,17 +39,18 @@ Shared::ScrollableExactApproximateExpressionsView * HistoryViewCell::outputView(
 void HistoryViewCell::setEven(bool even) {
   EvenOddCell::setEven(even);
   m_inputView.setBackgroundColor(backgroundColor());
+  m_scrollableOutputView.setBackgroundColor(backgroundColor());
   m_scrollableOutputView.evenOddCell()->setEven(even);
 }
 
 void HistoryViewCell::setHighlighted(bool highlight) {
   assert(m_dataSource);
   m_highlighted = highlight;
-  m_inputView.setBackgroundColor(backgroundColor());
+  m_inputView.setExpressionBackgroundColor(backgroundColor());
   m_scrollableOutputView.evenOddCell()->setHighlighted(false);
   if (isHighlighted()) {
     if (m_dataSource->selectedSubviewType() == HistoryViewCellDataSource::SubviewType::Input) {
-      m_inputView.setBackgroundColor(Palette::Select);
+      m_inputView.setExpressionBackgroundColor(Palette::Select);
     } else {
       m_scrollableOutputView.evenOddCell()->setHighlighted(true);
     }

--- a/apps/calculation/history_view_cell.cpp
+++ b/apps/calculation/history_view_cell.cpp
@@ -93,20 +93,21 @@ View * HistoryViewCell::subviewAtIndex(int index) {
 }
 
 void HistoryViewCell::layoutSubviews() {
-  KDCoordinate width = bounds().width();
-  KDCoordinate height = bounds().height();
+  KDCoordinate maxFrameWidth = bounds().width();
   KDSize inputSize = m_inputView.minimalSizeForOptimalDisplay();
-  if (inputSize.width() + Metric::HistoryHorizontalMargin > width) {
-    m_inputView.setFrame(KDRect(Metric::HistoryHorizontalMargin, k_digitVerticalMargin, width - Metric::HistoryHorizontalMargin, inputSize.height()));
-  } else {
-    m_inputView.setFrame(KDRect(Metric::HistoryHorizontalMargin, k_digitVerticalMargin, inputSize.width(), inputSize.height()));
-  }
+  m_inputView.setFrame(KDRect(
+    0,
+    k_digitVerticalMargin,
+    min(maxFrameWidth, inputSize.width()),
+    inputSize.height()
+  ));
   KDSize outputSize = m_scrollableOutputView.minimalSizeForOptimalDisplay();
-  if (outputSize.width() + Metric::HistoryHorizontalMargin > width) {
-    m_scrollableOutputView.setFrame(KDRect(Metric::HistoryHorizontalMargin, inputSize.height() + 2*k_digitVerticalMargin, width - Metric::HistoryHorizontalMargin, height - inputSize.height() - 3*k_digitVerticalMargin));
-  } else {
-    m_scrollableOutputView.setFrame(KDRect(width - outputSize.width() - Metric::HistoryHorizontalMargin, inputSize.height() + 2*k_digitVerticalMargin, outputSize.width(), height - inputSize.height() - 3*k_digitVerticalMargin));
-  }
+  m_scrollableOutputView.setFrame(KDRect(
+    max(0, maxFrameWidth - outputSize.width()),
+    inputSize.height() + 2*k_digitVerticalMargin,
+    min(maxFrameWidth, outputSize.width()),
+    bounds().height() - inputSize.height() - 3*k_digitVerticalMargin
+  ));
 }
 
 void HistoryViewCell::setCalculation(Calculation * calculation) {

--- a/apps/calculation/history_view_cell.h
+++ b/apps/calculation/history_view_cell.h
@@ -17,7 +17,7 @@ public:
     Output
   };
   HistoryViewCellDataSource();
-  void setSelectedSubviewType(HistoryViewCellDataSource::SubviewType subviewType, HistoryViewCell * cell = nullptr);
+  void setSelectedSubviewType(SubviewType subviewType, HistoryViewCell * cell = nullptr);
   SubviewType selectedSubviewType() { return m_selectedSubviewType; }
 private:
   SubviewType m_selectedSubviewType;

--- a/apps/calculation/history_view_cell.h
+++ b/apps/calculation/history_view_cell.h
@@ -42,7 +42,6 @@ public:
   void layoutSubviews() override;
   void didBecomeFirstResponder() override;
   bool handleEvent(Ion::Events::Event event) override;
-  constexpr static KDCoordinate k_digitVerticalMargin = 5;
   Shared::ScrollableExactApproximateExpressionsView * outputView();
 private:
   constexpr static KDCoordinate k_resultWidth = 80;

--- a/apps/calculation/scrollable_expression_view.cpp
+++ b/apps/calculation/scrollable_expression_view.cpp
@@ -20,8 +20,4 @@ void ScrollableExpressionView::setBackgroundColor(KDColor backgroundColor) {
   ScrollableView::setBackgroundColor(backgroundColor);
 }
 
-KDSize ScrollableExpressionView::minimalSizeForOptimalDisplay() const {
-  return m_expressionView.minimalSizeForOptimalDisplay();
-}
-
 }

--- a/apps/calculation/scrollable_expression_view.cpp
+++ b/apps/calculation/scrollable_expression_view.cpp
@@ -12,7 +12,6 @@ ScrollableExpressionView::ScrollableExpressionView(Responder * parentResponder) 
 
 void ScrollableExpressionView::setLayout(Layout layout) {
   m_expressionView.setLayout(layout);
-  layoutSubviews();
 }
 
 void ScrollableExpressionView::setBackgroundColor(KDColor backgroundColor) {

--- a/apps/calculation/scrollable_expression_view.cpp
+++ b/apps/calculation/scrollable_expression_view.cpp
@@ -9,7 +9,12 @@ ScrollableExpressionView::ScrollableExpressionView(Responder * parentResponder) 
   m_expressionView()
 {
   setDecoratorType(ScrollView::Decorator::Type::Arrows);
-  setMargins(0, Metric::HistoryHorizontalMargin, 0, Metric::HistoryHorizontalMargin);
+  setMargins(
+    Metric::CommonSmallMargin,
+    Metric::CommonLargeMargin,
+    Metric::CommonSmallMargin,
+    Metric::CommonLargeMargin
+  );
 }
 
 void ScrollableExpressionView::setLayout(Layout layout) {

--- a/apps/calculation/scrollable_expression_view.cpp
+++ b/apps/calculation/scrollable_expression_view.cpp
@@ -19,4 +19,8 @@ void ScrollableExpressionView::setBackgroundColor(KDColor backgroundColor) {
   ScrollableView::setBackgroundColor(backgroundColor);
 }
 
+void ScrollableExpressionView::setExpressionBackgroundColor(KDColor backgroundColor) {
+  m_expressionView.setBackgroundColor(backgroundColor);
+}
+
 }

--- a/apps/calculation/scrollable_expression_view.cpp
+++ b/apps/calculation/scrollable_expression_view.cpp
@@ -8,6 +8,8 @@ ScrollableExpressionView::ScrollableExpressionView(Responder * parentResponder) 
   ScrollableView(parentResponder, &m_expressionView, this),
   m_expressionView()
 {
+  setDecoratorType(ScrollView::Decorator::Type::Arrows);
+  setMargins(0, Metric::HistoryHorizontalMargin, 0, Metric::HistoryHorizontalMargin);
 }
 
 void ScrollableExpressionView::setLayout(Layout layout) {

--- a/apps/calculation/scrollable_expression_view.h
+++ b/apps/calculation/scrollable_expression_view.h
@@ -10,6 +10,7 @@ public:
   ScrollableExpressionView(Responder * parentResponder);
   void setLayout(Poincare::Layout layout);
   void setBackgroundColor(KDColor backgroundColor) override;
+  void setExpressionBackgroundColor(KDColor backgroundColor);
 private:
   ExpressionView m_expressionView;
 };

--- a/apps/calculation/scrollable_expression_view.h
+++ b/apps/calculation/scrollable_expression_view.h
@@ -10,7 +10,6 @@ public:
   ScrollableExpressionView(Responder * parentResponder);
   void setLayout(Poincare::Layout layout);
   void setBackgroundColor(KDColor backgroundColor) override;
-  KDSize minimalSizeForOptimalDisplay() const override;
 private:
   ExpressionView m_expressionView;
 };

--- a/apps/calculation/selectable_table_view.cpp
+++ b/apps/calculation/selectable_table_view.cpp
@@ -8,7 +8,7 @@ CalculationSelectableTableView::CalculationSelectableTableView(Responder * paren
 {
   setVerticalCellOverlap(0);
   setMargins(0);
-  setShowsIndicators(false);
+  setDecoratorType(ScrollView::Decorator::Type::None);
 }
 
 void CalculationSelectableTableView::scrollToCell(int i, int j) {

--- a/apps/code/console_line_cell.cpp
+++ b/apps/code/console_line_cell.cpp
@@ -31,10 +31,6 @@ ConsoleLineCell::ScrollableConsoleLineView::ScrollableConsoleLineView(Responder 
 {
 }
 
-KDSize ConsoleLineCell::ScrollableConsoleLineView::minimalSizeForOptimalDisplay() const {
-  return m_consoleLineView.minimalSizeForOptimalDisplay();
-}
-
 ConsoleLineCell::ConsoleLineCell(Responder * parentResponder) :
   HighlightCell(),
   Responder(parentResponder),

--- a/apps/code/console_line_cell.h
+++ b/apps/code/console_line_cell.h
@@ -48,7 +48,6 @@ private:
     };
 
     ScrollableConsoleLineView(Responder * parentResponder);
-    KDSize minimalSizeForOptimalDisplay() const override;
     ConsoleLineView * consoleLineView() { return &m_consoleLineView; }
   private:
     ConsoleLineView m_consoleLineView;

--- a/apps/code/menu_controller.cpp
+++ b/apps/code/menu_controller.cpp
@@ -26,7 +26,7 @@ MenuController::MenuController(Responder * parentResponder, App * pythonDelegate
   m_shouldDisplayAddScriptRow(true)
 {
   m_selectableTableView.setMargins(0);
-  m_selectableTableView.setShowsIndicators(false);
+  m_selectableTableView.setDecoratorType(ScrollView::Decorator::Type::None);
   m_addNewScriptCell.setMessage(I18n::Message::AddScript);
   for (int i = 0; i < k_maxNumberOfDisplayableScriptCells; i++) {
     m_scriptCells[i].setParentResponder(&m_selectableTableView);

--- a/apps/code/script_name_cell.h
+++ b/apps/code/script_name_cell.h
@@ -38,7 +38,7 @@ public:
 
 private:
   constexpr static size_t k_extensionLength = 1+ScriptStore::k_scriptExtensionLength; // '.' + "py"
-  constexpr static KDCoordinate k_leftMargin = Metric::HistoryHorizontalMargin;
+  constexpr static KDCoordinate k_leftMargin = Metric::CommonLargeMargin;
 
   // View
   int numberOfSubviews() const override { return 1; }

--- a/apps/home/controller.cpp
+++ b/apps/home/controller.cpp
@@ -12,8 +12,8 @@ Controller::ContentView::ContentView(Controller * controller, SelectableTableVie
   m_selectableTableView.setVerticalCellOverlap(0);
   m_selectableTableView.setMargins(0, k_sideMargin, k_bottomMargin, k_sideMargin);
   m_selectableTableView.setColorsBackground(false);
-  m_selectableTableView.setIndicatorThickness(k_indicatorThickness);
-  m_selectableTableView.verticalScrollIndicator()->setMargin(k_indicatorMargin);
+  m_selectableTableView.decorator()->setIndicatorThickness(k_indicatorThickness);
+  m_selectableTableView.decorator()->verticalBar()->setMargin(k_indicatorMargin);
 }
 
 SelectableTableView * Controller::ContentView::selectableTableView() {

--- a/apps/home/controller.cpp
+++ b/apps/home/controller.cpp
@@ -12,8 +12,8 @@ Controller::ContentView::ContentView(Controller * controller, SelectableTableVie
   m_selectableTableView.setVerticalCellOverlap(0);
   m_selectableTableView.setMargins(0, k_sideMargin, k_bottomMargin, k_sideMargin);
   m_selectableTableView.setColorsBackground(false);
-  m_selectableTableView.decorator()->setBarsFrameBreadth(k_scrollBarsFrameBreadth);
-  m_selectableTableView.decorator()->verticalBar()->setMargin(k_indicatorMargin);
+  static_cast<ScrollView::BarDecorator *>(m_selectableTableView.decorator())->setBarsFrameBreadth(k_scrollBarsFrameBreadth);
+  static_cast<ScrollView::BarDecorator *>(m_selectableTableView.decorator())->verticalBar()->setMargin(k_indicatorMargin);
 }
 
 SelectableTableView * Controller::ContentView::selectableTableView() {

--- a/apps/home/controller.cpp
+++ b/apps/home/controller.cpp
@@ -11,7 +11,7 @@ Controller::ContentView::ContentView(Controller * controller, SelectableTableVie
 {
   m_selectableTableView.setVerticalCellOverlap(0);
   m_selectableTableView.setMargins(0, k_sideMargin, k_bottomMargin, k_sideMargin);
-  m_selectableTableView.setColorsBackground(false);
+  m_selectableTableView.setBackgroundColor(KDColorWhite);
   static_cast<ScrollView::BarDecorator *>(m_selectableTableView.decorator())->setBarsFrameBreadth(k_scrollBarsFrameBreadth);
   static_cast<ScrollView::BarDecorator *>(m_selectableTableView.decorator())->verticalBar()->setMargin(k_indicatorMargin);
 }

--- a/apps/home/controller.cpp
+++ b/apps/home/controller.cpp
@@ -12,7 +12,7 @@ Controller::ContentView::ContentView(Controller * controller, SelectableTableVie
   m_selectableTableView.setVerticalCellOverlap(0);
   m_selectableTableView.setMargins(0, k_sideMargin, k_bottomMargin, k_sideMargin);
   m_selectableTableView.setColorsBackground(false);
-  m_selectableTableView.decorator()->setIndicatorThickness(k_indicatorThickness);
+  m_selectableTableView.decorator()->setBarsFrameBreadth(k_scrollBarsFrameBreadth);
   m_selectableTableView.decorator()->verticalBar()->setMargin(k_indicatorMargin);
 }
 

--- a/apps/home/controller.cpp
+++ b/apps/home/controller.cpp
@@ -12,7 +12,6 @@ Controller::ContentView::ContentView(Controller * controller, SelectableTableVie
   m_selectableTableView.setVerticalCellOverlap(0);
   m_selectableTableView.setMargins(0, k_sideMargin, k_bottomMargin, k_sideMargin);
   m_selectableTableView.setBackgroundColor(KDColorWhite);
-  static_cast<ScrollView::BarDecorator *>(m_selectableTableView.decorator())->setBarsFrameBreadth(k_scrollBarsFrameBreadth);
   static_cast<ScrollView::BarDecorator *>(m_selectableTableView.decorator())->verticalBar()->setMargin(k_indicatorMargin);
 }
 

--- a/apps/home/controller.h
+++ b/apps/home/controller.h
@@ -43,7 +43,6 @@ private:
   AppsContainer * m_container;
   static constexpr KDCoordinate k_sideMargin = 4;
   static constexpr KDCoordinate k_bottomMargin = 14;
-  static constexpr KDCoordinate k_scrollBarsFrameBreadth = 15;
   static constexpr KDCoordinate k_indicatorMargin = 61;
   static constexpr int k_numberOfColumns = 3;
   static constexpr int k_maxNumberOfCells = 16;

--- a/apps/home/controller.h
+++ b/apps/home/controller.h
@@ -43,7 +43,7 @@ private:
   AppsContainer * m_container;
   static constexpr KDCoordinate k_sideMargin = 4;
   static constexpr KDCoordinate k_bottomMargin = 14;
-  static constexpr KDCoordinate k_indicatorThickness = 15;
+  static constexpr KDCoordinate k_scrollBarsFrameBreadth = 15;
   static constexpr KDCoordinate k_indicatorMargin = 61;
   static constexpr int k_numberOfColumns = 3;
   static constexpr int k_maxNumberOfCells = 16;

--- a/apps/probability/calculation_controller.cpp
+++ b/apps/probability/calculation_controller.cpp
@@ -66,7 +66,7 @@ CalculationController::CalculationController(Responder * parentResponder, InputE
   assert(calculation != nullptr);
   m_selectableTableView.setMargins(k_tableMargin);
   m_selectableTableView.setVerticalCellOverlap(0);
-  m_selectableTableView.setShowsIndicators(false);
+  m_selectableTableView.setDecoratorType(ScrollView::Decorator::Type::None);
   m_selectableTableView.setBackgroundColor(KDColorWhite);
 
 

--- a/apps/probability/calculation_type_controller.cpp
+++ b/apps/probability/calculation_type_controller.cpp
@@ -22,7 +22,7 @@ CalculationTypeController::CalculationTypeController(Responder * parentResponder
   assert(m_calculation != nullptr);
   m_selectableTableView.setMargins(0);
   m_selectableTableView.setVerticalCellOverlap(0);
-  m_selectableTableView.setShowsIndicators(false);
+  m_selectableTableView.setDecoratorType(ScrollView::Decorator::Type::None);
   m_selectableTableView.setColorsBackground(false);
 }
 

--- a/apps/probability/calculation_type_controller.cpp
+++ b/apps/probability/calculation_type_controller.cpp
@@ -23,7 +23,6 @@ CalculationTypeController::CalculationTypeController(Responder * parentResponder
   m_selectableTableView.setMargins(0);
   m_selectableTableView.setVerticalCellOverlap(0);
   m_selectableTableView.setDecoratorType(ScrollView::Decorator::Type::None);
-  m_selectableTableView.setColorsBackground(false);
 }
 
 View * CalculationTypeController::view() {

--- a/apps/probability/parameters_controller.cpp
+++ b/apps/probability/parameters_controller.cpp
@@ -16,7 +16,7 @@ ParametersController::ContentView::ContentView(Responder * parentResponder, Sele
 }
 
 void ParametersController::ContentView::drawRect(KDContext * ctx, KDRect rect) const {
-  int tableHeight = m_selectableTableView->minimalSizeForOptimalDisplay().height()+ Metric::CommonTopMargin + Metric::CommonBottomMargin;
+  int tableHeight = m_selectableTableView->minimalSizeForOptimalDisplay().height();
   ctx->fillRect(KDRect(0, tableHeight, bounds().width(), bounds().height() - tableHeight), Palette::WallScreen);
 }
 
@@ -53,7 +53,7 @@ View * ParametersController::ContentView::subviewAtIndex(int index) {
 void ParametersController::ContentView::layoutSubviews() {
   KDCoordinate titleHeight = KDFont::SmallFont->glyphSize().height()+k_titleMargin;
   m_titleView.setFrame(KDRect(0, 0, bounds().width(), titleHeight));
-  KDCoordinate tableHeight = m_selectableTableView->minimalSizeForOptimalDisplay().height() + Metric::CommonTopMargin + Metric::CommonBottomMargin;
+  KDCoordinate tableHeight = m_selectableTableView->minimalSizeForOptimalDisplay().height();
   m_selectableTableView->setFrame(KDRect(0, titleHeight, bounds().width(),  tableHeight));
   KDCoordinate textHeight = KDFont::SmallFont->glyphSize().height();
   KDCoordinate defOrigin = (titleHeight+tableHeight)/2+(bounds().height()-textHeight)/2;

--- a/apps/sequence/list/type_parameter_controller.cpp
+++ b/apps/sequence/list/type_parameter_controller.cpp
@@ -23,7 +23,7 @@ TypeParameterController::TypeParameterController(Responder * parentResponder, Se
   m_listController(list)
 {
   m_selectableTableView.setMargins(topMargin, rightMargin, bottomMargin, leftMargin);
-  m_selectableTableView.setShowsIndicators(false);
+  m_selectableTableView.setDecoratorType(ScrollView::Decorator::Type::None);
 }
 
 const char * TypeParameterController::title() {

--- a/apps/shared/scrollable_exact_approximate_expressions_cell.cpp
+++ b/apps/shared/scrollable_exact_approximate_expressions_cell.cpp
@@ -17,6 +17,7 @@ void ScrollableExactApproximateExpressionsCell::setHighlighted(bool highlight) {
 
 void ScrollableExactApproximateExpressionsCell::setEven(bool even) {
   EvenOddCell::setEven(even);
+  m_view.setBackgroundColor(backgroundColor());
   m_view.evenOddCell()->setEven(even);
 }
 

--- a/apps/shared/scrollable_exact_approximate_expressions_cell.cpp
+++ b/apps/shared/scrollable_exact_approximate_expressions_cell.cpp
@@ -41,7 +41,7 @@ View * ScrollableExactApproximateExpressionsCell::subviewAtIndex(int index) {
 }
 
 void ScrollableExactApproximateExpressionsCell::layoutSubviews() {
-  m_view.setFrame(KDRect(k_margin,k_margin, bounds().width()-2*k_margin, bounds().height()-2*k_margin));
+  m_view.setFrame(bounds());
 }
 
 }

--- a/apps/shared/scrollable_exact_approximate_expressions_cell.h
+++ b/apps/shared/scrollable_exact_approximate_expressions_cell.h
@@ -24,7 +24,6 @@ public:
   }
   Poincare::Layout layout() const override { return m_view.layout(); }
   void didBecomeFirstResponder() override;
-  constexpr static KDCoordinate k_margin = 5;
 private:
   int numberOfSubviews() const override;
   View * subviewAtIndex(int index) override;

--- a/apps/shared/scrollable_exact_approximate_expressions_view.cpp
+++ b/apps/shared/scrollable_exact_approximate_expressions_view.cpp
@@ -102,6 +102,8 @@ ScrollableExactApproximateExpressionsView::ScrollableExactApproximateExpressions
   ScrollableView(parentResponder, &m_contentCell, this),
   m_contentCell()
 {
+  setDecoratorType(ScrollView::Decorator::Type::Arrows);
+  setMargins(0, Metric::HistoryHorizontalMargin, 0, Metric::HistoryHorizontalMargin);
 }
 
 void ScrollableExactApproximateExpressionsView::setLayouts(Poincare::Layout rightLayout, Poincare::Layout leftLayout) {

--- a/apps/shared/scrollable_exact_approximate_expressions_view.cpp
+++ b/apps/shared/scrollable_exact_approximate_expressions_view.cpp
@@ -53,7 +53,7 @@ KDSize ScrollableExactApproximateExpressionsView::ContentCell::minimalSizeForOpt
   KDCoordinate rightBaseline = m_rightExpressionView.layout().baseline();
   KDCoordinate height = max(leftBaseline, rightBaseline) + max(leftExpressionSize.height()-leftBaseline, rightExpressionSize.height()-rightBaseline);
   KDSize approximateSignSize = m_approximateSign.minimalSizeForOptimalDisplay();
-  return KDSize(leftExpressionSize.width()+approximateSignSize.width()+rightExpressionSize.width()+2*k_digitHorizontalMargin, height);
+  return KDSize(leftExpressionSize.width()+approximateSignSize.width()+rightExpressionSize.width()+2*Metric::CommonLargeMargin, height);
 }
 
 void ScrollableExactApproximateExpressionsView::ContentCell::setSelectedSubviewPosition(ScrollableExactApproximateExpressionsView::SubviewPosition subviewPosition) {
@@ -94,8 +94,8 @@ void ScrollableExactApproximateExpressionsView::ContentCell::layoutSubviews() {
   KDSize leftExpressionSize = m_leftExpressionView.minimalSizeForOptimalDisplay();
   KDSize approximateSignSize = m_approximateSign.minimalSizeForOptimalDisplay();
   m_leftExpressionView.setFrame(KDRect(0, baseline-leftBaseline, leftExpressionSize));
-  m_rightExpressionView.setFrame(KDRect(2*k_digitHorizontalMargin+leftExpressionSize.width()+approximateSignSize.width(), baseline-rightBaseline, rightExpressionSize));
-  m_approximateSign.setFrame(KDRect(k_digitHorizontalMargin+leftExpressionSize.width(), baseline-approximateSignSize.height()/2, approximateSignSize));
+  m_rightExpressionView.setFrame(KDRect(2*Metric::CommonLargeMargin+leftExpressionSize.width()+approximateSignSize.width(), baseline-rightBaseline, rightExpressionSize));
+  m_approximateSign.setFrame(KDRect(Metric::CommonLargeMargin+leftExpressionSize.width(), baseline-approximateSignSize.height()/2, approximateSignSize));
 }
 
 ScrollableExactApproximateExpressionsView::ScrollableExactApproximateExpressionsView(Responder * parentResponder) :
@@ -103,7 +103,12 @@ ScrollableExactApproximateExpressionsView::ScrollableExactApproximateExpressions
   m_contentCell()
 {
   setDecoratorType(ScrollView::Decorator::Type::Arrows);
-  setMargins(0, Metric::HistoryHorizontalMargin, 0, Metric::HistoryHorizontalMargin);
+  setMargins(
+    Metric::CommonSmallMargin,
+    Metric::CommonLargeMargin,
+    Metric::CommonSmallMargin,
+    Metric::CommonLargeMargin
+  );
 }
 
 void ScrollableExactApproximateExpressionsView::setLayouts(Poincare::Layout rightLayout, Poincare::Layout leftLayout) {

--- a/apps/shared/scrollable_exact_approximate_expressions_view.cpp
+++ b/apps/shared/scrollable_exact_approximate_expressions_view.cpp
@@ -138,8 +138,4 @@ bool ScrollableExactApproximateExpressionsView::handleEvent(Ion::Events::Event e
   return ScrollableView::handleEvent(event);
 }
 
-KDSize ScrollableExactApproximateExpressionsView::minimalSizeForOptimalDisplay() const {
-  return m_contentCell.minimalSizeForOptimalDisplay();
-}
-
 }

--- a/apps/shared/scrollable_exact_approximate_expressions_view.h
+++ b/apps/shared/scrollable_exact_approximate_expressions_view.h
@@ -25,7 +25,6 @@ public:
   }
   void didBecomeFirstResponder() override;
   bool handleEvent(Ion::Events::Event event) override;
-  KDSize minimalSizeForOptimalDisplay() const override;
   Poincare::Layout layout() const {
     return m_contentCell.layout();
   }

--- a/apps/shared/scrollable_exact_approximate_expressions_view.h
+++ b/apps/shared/scrollable_exact_approximate_expressions_view.h
@@ -60,7 +60,7 @@ private:
     MessageTextView m_approximateSign;
     ExpressionView m_leftExpressionView;
     SubviewPosition m_selectedSubviewPosition;
-};
+  };
   ContentCell m_contentCell;
 };
 

--- a/apps/shared/scrollable_exact_approximate_expressions_view.h
+++ b/apps/shared/scrollable_exact_approximate_expressions_view.h
@@ -54,7 +54,6 @@ private:
     Poincare::Layout layout() const override;
   private:
     View * subviewAtIndex(int index) override;
-    constexpr static KDCoordinate k_digitHorizontalMargin = 10;
     ExpressionView m_rightExpressionView;
     MessageTextView m_approximateSign;
     ExpressionView m_leftExpressionView;

--- a/apps/shared/storage_values_controller.cpp
+++ b/apps/shared/storage_values_controller.cpp
@@ -32,7 +32,7 @@ StorageValuesController::StorageValuesController(Responder * parentResponder, In
   m_selectableTableView.setBottomMargin(k_bottomMargin);
   m_selectableTableView.setLeftMargin(k_leftMargin);
   m_selectableTableView.setBackgroundColor(Palette::WallScreenDark);
-  m_selectableTableView.decorator()->setBarsFrameBreadth(13);
+  static_cast<ScrollView::BarDecorator *>(m_selectableTableView.decorator())->setBarsFrameBreadth(13);
   m_abscissaTitleCell.setMessageFont(k_font);
   for (int i = 0; i < k_maxNumberOfAbscissaCells; i++) {
     m_abscissaCells[i].setParentResponder(&m_selectableTableView);

--- a/apps/shared/storage_values_controller.cpp
+++ b/apps/shared/storage_values_controller.cpp
@@ -32,7 +32,7 @@ StorageValuesController::StorageValuesController(Responder * parentResponder, In
   m_selectableTableView.setBottomMargin(k_bottomMargin);
   m_selectableTableView.setLeftMargin(k_leftMargin);
   m_selectableTableView.setBackgroundColor(Palette::WallScreenDark);
-  m_selectableTableView.setIndicatorThickness(13);
+  m_selectableTableView.decorator()->setIndicatorThickness(13);
   m_abscissaTitleCell.setMessageFont(k_font);
   for (int i = 0; i < k_maxNumberOfAbscissaCells; i++) {
     m_abscissaCells[i].setParentResponder(&m_selectableTableView);

--- a/apps/shared/storage_values_controller.cpp
+++ b/apps/shared/storage_values_controller.cpp
@@ -32,7 +32,6 @@ StorageValuesController::StorageValuesController(Responder * parentResponder, In
   m_selectableTableView.setBottomMargin(k_bottomMargin);
   m_selectableTableView.setLeftMargin(k_leftMargin);
   m_selectableTableView.setBackgroundColor(Palette::WallScreenDark);
-  static_cast<ScrollView::BarDecorator *>(m_selectableTableView.decorator())->setBarsFrameBreadth(13);
   m_abscissaTitleCell.setMessageFont(k_font);
   for (int i = 0; i < k_maxNumberOfAbscissaCells; i++) {
     m_abscissaCells[i].setParentResponder(&m_selectableTableView);

--- a/apps/shared/storage_values_controller.cpp
+++ b/apps/shared/storage_values_controller.cpp
@@ -32,7 +32,7 @@ StorageValuesController::StorageValuesController(Responder * parentResponder, In
   m_selectableTableView.setBottomMargin(k_bottomMargin);
   m_selectableTableView.setLeftMargin(k_leftMargin);
   m_selectableTableView.setBackgroundColor(Palette::WallScreenDark);
-  m_selectableTableView.decorator()->setIndicatorThickness(13);
+  m_selectableTableView.decorator()->setBarsFrameBreadth(13);
   m_abscissaTitleCell.setMessageFont(k_font);
   for (int i = 0; i < k_maxNumberOfAbscissaCells; i++) {
     m_abscissaCells[i].setParentResponder(&m_selectableTableView);

--- a/apps/shared/values_controller.cpp
+++ b/apps/shared/values_controller.cpp
@@ -32,7 +32,7 @@ ValuesController::ValuesController(Responder * parentResponder, InputEventHandle
   m_selectableTableView.setBottomMargin(k_bottomMargin);
   m_selectableTableView.setLeftMargin(k_leftMargin);
   m_selectableTableView.setBackgroundColor(Palette::WallScreenDark);
-  m_selectableTableView.decorator()->setBarsFrameBreadth(13);
+  static_cast<ScrollView::BarDecorator *>(m_selectableTableView.decorator())->setBarsFrameBreadth(13);
   m_abscissaTitleCell.setMessageFont(KDFont::SmallFont);
   for (int i = 0; i < k_maxNumberOfAbscissaCells; i++) {
     m_abscissaCells[i].setParentResponder(&m_selectableTableView);

--- a/apps/shared/values_controller.cpp
+++ b/apps/shared/values_controller.cpp
@@ -32,7 +32,6 @@ ValuesController::ValuesController(Responder * parentResponder, InputEventHandle
   m_selectableTableView.setBottomMargin(k_bottomMargin);
   m_selectableTableView.setLeftMargin(k_leftMargin);
   m_selectableTableView.setBackgroundColor(Palette::WallScreenDark);
-  static_cast<ScrollView::BarDecorator *>(m_selectableTableView.decorator())->setBarsFrameBreadth(13);
   m_abscissaTitleCell.setMessageFont(KDFont::SmallFont);
   for (int i = 0; i < k_maxNumberOfAbscissaCells; i++) {
     m_abscissaCells[i].setParentResponder(&m_selectableTableView);

--- a/apps/shared/values_controller.cpp
+++ b/apps/shared/values_controller.cpp
@@ -32,7 +32,7 @@ ValuesController::ValuesController(Responder * parentResponder, InputEventHandle
   m_selectableTableView.setBottomMargin(k_bottomMargin);
   m_selectableTableView.setLeftMargin(k_leftMargin);
   m_selectableTableView.setBackgroundColor(Palette::WallScreenDark);
-  m_selectableTableView.setIndicatorThickness(13);
+  m_selectableTableView.decorator()->setIndicatorThickness(13);
   m_abscissaTitleCell.setMessageFont(KDFont::SmallFont);
   for (int i = 0; i < k_maxNumberOfAbscissaCells; i++) {
     m_abscissaCells[i].setParentResponder(&m_selectableTableView);

--- a/apps/shared/values_controller.cpp
+++ b/apps/shared/values_controller.cpp
@@ -32,7 +32,7 @@ ValuesController::ValuesController(Responder * parentResponder, InputEventHandle
   m_selectableTableView.setBottomMargin(k_bottomMargin);
   m_selectableTableView.setLeftMargin(k_leftMargin);
   m_selectableTableView.setBackgroundColor(Palette::WallScreenDark);
-  m_selectableTableView.decorator()->setIndicatorThickness(13);
+  m_selectableTableView.decorator()->setBarsFrameBreadth(13);
   m_abscissaTitleCell.setMessageFont(KDFont::SmallFont);
   for (int i = 0; i < k_maxNumberOfAbscissaCells; i++) {
     m_abscissaCells[i].setParentResponder(&m_selectableTableView);

--- a/apps/solver/equation_list_view.cpp
+++ b/apps/solver/equation_list_view.cpp
@@ -14,10 +14,10 @@ EquationListView::EquationListView(Responder * parentResponder, TableViewDataSou
 {
   m_listView.setMargins(0);
   m_listView.setVerticalCellOverlap(0);
-  m_listView.setShowsIndicators(false);
+  m_listView.setDecoratorType(ScrollView::Decorator::Type::None);
   selectionDataSource->setScrollViewDelegate(this);
   m_scrollBraceView.setMargins(k_margin, k_margin, k_margin, k_margin);
-  m_scrollBraceView.setShowsIndicators(false);
+  m_scrollBraceView.setDecoratorType(ScrollView::Decorator::Type::None);
   m_scrollBraceView.setBackgroundColor(KDColorWhite);
 }
 

--- a/apps/solver/equation_models_parameter_controller.cpp
+++ b/apps/solver/equation_models_parameter_controller.cpp
@@ -20,7 +20,7 @@ EquationModelsParameterController::EquationModelsParameterController(Responder *
   m_listController(listController)
 {
   m_selectableTableView.setMargins(0);
-  m_selectableTableView.setShowsIndicators(false);
+  m_selectableTableView.setDecoratorType(ScrollView::Decorator::Type::None);
   for (int i = 0; i < k_numberOfExpressionCells; i++) {
     Poincare::Expression e = Expression::Parse(k_models[i+1]);
     m_layouts[i] = e.createLayout(Poincare::Preferences::PrintFloatMode::Decimal, Constant::ShortNumberOfSignificantDigits);

--- a/apps/solver/solutions_controller.cpp
+++ b/apps/solver/solutions_controller.cpp
@@ -220,7 +220,7 @@ KDCoordinate SolutionsController::rowHeight(int j) {
   KDCoordinate exactLayoutHeight = exactLayout.layoutSize().height();
   KDCoordinate approximateLayoutHeight = approximateLayout.layoutSize().height();
   KDCoordinate layoutHeight = max(exactLayout.baseline(), approximateLayout.baseline()) + max(exactLayoutHeight-exactLayout.baseline(), approximateLayoutHeight-approximateLayout.baseline());
-  return layoutHeight+ScrollableExactApproximateExpressionsCell::k_margin*2;
+  return layoutHeight + 2 * Metric::CommonSmallMargin;
 }
 
 KDCoordinate SolutionsController::cumulatedWidthFromIndex(int i) {

--- a/escher/include/escher/alternate_empty_view_controller.h
+++ b/escher/include/escher/alternate_empty_view_controller.h
@@ -12,6 +12,7 @@ public:
   const char * title() override;
   bool handleEvent(Ion::Events::Event event) override;
   void didBecomeFirstResponder() override;
+  void initView() override;
   void viewWillAppear() override;
   void viewDidDisappear() override;
 private:

--- a/escher/include/escher/bank_view_controller.h
+++ b/escher/include/escher/bank_view_controller.h
@@ -15,6 +15,7 @@ public:
 
   View * view() override { return &m_view; }
   void didEnterResponderChain(Responder * previousResponder) override;
+  void initView() override;
   void viewWillAppear() override;
   void viewDidDisappear() override;
 private:

--- a/escher/include/escher/button_row_controller.h
+++ b/escher/include/escher/button_row_controller.h
@@ -33,6 +33,7 @@ public:
   int selectedButton();
   bool setSelectedButton(int selectedButton);
   void setMessageOfButtonAtIndex(I18n::Message message, int index);
+  void initView() override;
   void viewWillAppear() override;
   void viewDidDisappear() override;
   ViewController::DisplayParameter displayParameter() override { return DisplayParameter::DoNotShowOwnTitle; }

--- a/escher/include/escher/layout_field.h
+++ b/escher/include/escher/layout_field.h
@@ -43,12 +43,6 @@ public:
     return m_delegate->layoutFieldShouldFinishEditing(this, event);
   }
 
-  /* View */
-  KDSize minimalSizeForOptimalDisplay() const override {
-    KDSize contentViewSize = m_contentView.minimalSizeForOptimalDisplay();
-    return KDSize(contentViewSize.width(), contentViewSize.height());
-  }
-
 protected:
   void reload(KDSize previousSize);
   virtual bool privateHandleEvent(Ion::Events::Event event);

--- a/escher/include/escher/metric.h
+++ b/escher/include/escher/metric.h
@@ -9,7 +9,8 @@ public:
   constexpr static KDCoordinate CommonRightMargin = 20;
   constexpr static KDCoordinate CommonTopMargin = 15;
   constexpr static KDCoordinate CommonBottomMargin = 15;
-  constexpr static KDCoordinate HistoryHorizontalMargin = 10;
+  constexpr static KDCoordinate CommonLargeMargin = 10;
+  constexpr static KDCoordinate CommonSmallMargin = 5;
   constexpr static KDCoordinate TitleBarExternHorizontalMargin = 5;
   constexpr static KDCoordinate TitleBarHeight = 18;
   constexpr static KDCoordinate ParameterCellHeight = 35;

--- a/escher/include/escher/modal_view_controller.h
+++ b/escher/include/escher/modal_view_controller.h
@@ -16,6 +16,7 @@ public:
   void reloadModalViewController();
   void dismissModalViewController();
   bool isDisplayingModal();
+  void initView() override;
   void viewWillAppear() override;
   void viewDidDisappear() override;
 protected:

--- a/escher/include/escher/scroll_view.h
+++ b/escher/include/escher/scroll_view.h
@@ -73,8 +73,6 @@ public:
 
   Decorator * decorator();
   void setDecoratorType(Decorator::Type t) { m_decoratorType = t; }
-  void setShowsIndicators(bool s) { m_showsIndicators = s; }
-  bool showsIndicators() const { return m_showsIndicators; }
   void setColorsBackground(bool c) { m_colorsBackground = c; }
   bool colorsBackground() const { return m_colorsBackground; }
   virtual void setBackgroundColor(KDColor c) { m_backgroundColor = c; }
@@ -98,8 +96,8 @@ protected:
   View * m_contentView;
 private:
   ScrollViewDataSource * m_dataSource;
-  int numberOfSubviews() const override;
-  View * subviewAtIndex(int index) override;
+  int numberOfSubviews() const override { return 1 + const_cast<ScrollView *>(this)->decorator()->numberOfIndicators(); }
+  View * subviewAtIndex(int index) override { return (index == 0) ? m_contentView : decorator()->indicatorAtIndex(index); }
 
   KDCoordinate m_topMargin;
   KDCoordinate m_rightMargin;
@@ -110,7 +108,6 @@ private:
   Decorator m_decorator;
   BarDecorator m_barDecorator;
   ArrowDecorator m_arrowDecorator;
-  bool m_showsIndicators;
   bool m_colorsBackground;
   KDColor m_backgroundColor;
 };

--- a/escher/include/escher/scroll_view.h
+++ b/escher/include/escher/scroll_view.h
@@ -24,7 +24,6 @@ public:
     setTopMargin(top); setRightMargin(right); setBottomMargin(bottom); setLeftMargin(left);
   }
   void setMargins(KDCoordinate m) { setMargins(m, m, m, m); }
-  void setCommonMargins();
 
   class Decorator {
   public:

--- a/escher/include/escher/scroll_view.h
+++ b/escher/include/escher/scroll_view.h
@@ -8,7 +8,6 @@
 class ScrollView : public View {
 public:
   ScrollView(View * contentView, ScrollViewDataSource * dataSource);
-  void drawRect(KDContext * ctx, KDRect rect) const override;
 
   void setTopMargin(KDCoordinate m) { m_topMargin = m; }
   KDCoordinate topMargin() const { return m_topMargin; }
@@ -99,13 +98,27 @@ protected:
 private:
   ScrollViewDataSource * m_dataSource;
   int numberOfSubviews() const override { return 1 + const_cast<ScrollView *>(this)->decorator()->numberOfIndicators(); }
-  View * subviewAtIndex(int index) override { return (index == 0) ? m_contentView : decorator()->indicatorAtIndex(index); }
+  View * subviewAtIndex(int index) override { return (index == 0) ? &m_innerView : decorator()->indicatorAtIndex(index); }
+
+  class InnerView : public View {
+  public:
+    InnerView(ScrollView * scrollView) : View(), m_scrollView(scrollView) {}
+    void drawRect(KDContext * ctx, KDRect rect) const override;
+  private:
+    int numberOfSubviews() const override { return 1; }
+    View * subviewAtIndex(int index) override {
+      assert(index == 0);
+      return m_scrollView->m_contentView;
+    }
+    const ScrollView * m_scrollView;
+  };
 
   KDCoordinate m_topMargin;
   KDCoordinate m_rightMargin;
   KDCoordinate m_bottomMargin;
   KDCoordinate m_leftMargin;
 
+  InnerView m_innerView;
   Decorator::Type m_decoratorType;
   Decorator m_decorator;
   BarDecorator m_barDecorator;

--- a/escher/include/escher/scroll_view.h
+++ b/escher/include/escher/scroll_view.h
@@ -27,13 +27,20 @@ public:
 
   class Decorator {
   public:
-    Decorator();
-    int numberOfIndicators() { return 2; }
-    View * indicatorAtIndex(int index) {
+    virtual int numberOfIndicators() { return 0; }
+    virtual View * indicatorAtIndex(int index) { assert(false); return nullptr; }
+    virtual void layoutIndicators(KDSize content, KDPoint offset, KDSize frame) {}
+  };
+
+  class BarDecorator : public Decorator {
+  public:
+    BarDecorator();
+    int numberOfIndicators() override { return 2; }
+    View * indicatorAtIndex(int index) override {
       assert(0 < index && index <= numberOfIndicators());
       return &m_verticalBar + (index-1);
     }
-    void layoutIndicators(KDSize content, KDPoint offset, KDSize frame);
+    void layoutIndicators(KDSize content, KDPoint offset, KDSize frame) override;
     ScrollViewVerticalBar * verticalBar() { return &m_verticalBar; }
     ScrollViewHorizontalBar * horizontalBar() { return &m_horizontalBar; }
     void setBarsFrameBreadth(KDCoordinate t) { m_barsFrameBreadth = t; }
@@ -43,15 +50,15 @@ public:
     KDCoordinate m_barsFrameBreadth;
   };
 
-  class DecoratorV2 {
+  class ArrowDecorator : public Decorator {
   public:
-    DecoratorV2();
-    int numberOfIndicators() { return 4; }
-    View * indicatorAtIndex(int index) {
+    ArrowDecorator();
+    int numberOfIndicators() override { return 4; }
+    View * indicatorAtIndex(int index) override {
       assert(0 < index && index <= numberOfIndicators());
       return &m_topArrow + (index-1);
     }
-    void layoutIndicators(KDSize content, KDPoint offset, KDSize frame);
+    void layoutIndicators(KDSize content, KDPoint offset, KDSize frame) override;
   private:
     ScrollViewArrow m_topArrow;
     ScrollViewArrow m_rightArrow;
@@ -93,7 +100,7 @@ private:
   KDCoordinate m_bottomMargin;
   KDCoordinate m_leftMargin;
 
-  Decorator m_decorator;
+  BarDecorator m_decorator;
   bool m_showsIndicators;
   bool m_colorsBackground;
   KDColor m_backgroundColor;

--- a/escher/include/escher/scroll_view.h
+++ b/escher/include/escher/scroll_view.h
@@ -28,8 +28,11 @@ public:
   class Decorator {
   public:
     Decorator();
-    int numberOfIndicators();
-    View * indicatorAtIndex(int index);
+    int numberOfIndicators() { return 2; }
+    View * indicatorAtIndex(int index) {
+      assert(0 < index && index <= numberOfIndicators());
+      return &m_verticalBar + (index-1);
+    }
     void layoutIndicators(KDSize content, KDPoint offset, KDSize frame);
     ScrollViewVerticalBar * verticalBar() { return &m_verticalBar; }
     ScrollViewHorizontalBar * horizontalBar() { return &m_horizontalBar; }

--- a/escher/include/escher/scroll_view.h
+++ b/escher/include/escher/scroll_view.h
@@ -25,17 +25,28 @@ public:
   void setMargins(KDCoordinate m) { setMargins(m, m, m, m); }
   void setCommonMargins();
 
+  class Decorator {
+  public:
+    Decorator();
+    int numberOfIndicators();
+    View * indicatorAtIndex(int index);
+    void layoutIndicators(KDSize content, KDPoint offset, KDSize frame);
+    ScrollViewVerticalIndicator * verticalBar() { return &m_verticalScrollIndicator; }
+    ScrollViewHorizontalIndicator * horizontalBar() { return &m_horizontalScrollIndicator; }
+    void setIndicatorThickness(KDCoordinate t) { m_indicatorThickness = t; }
+  private:
+    ScrollViewVerticalIndicator m_verticalScrollIndicator;
+    ScrollViewHorizontalIndicator m_horizontalScrollIndicator;
+    KDCoordinate m_indicatorThickness;
+  };
+
+  Decorator * decorator() { return &m_decorator; }
   void setShowsIndicators(bool s) { m_showsIndicators = s; }
   bool showsIndicators() const { return m_showsIndicators; }
   void setColorsBackground(bool c) { m_colorsBackground = c; }
   bool colorsBackground() const { return m_colorsBackground; }
   virtual void setBackgroundColor(KDColor c) { m_backgroundColor = c; }
   KDColor backgroundColor() const { return m_backgroundColor; }
-
-  ScrollViewVerticalIndicator * verticalScrollIndicator() { return &m_verticalScrollIndicator; }
-  ScrollViewHorizontalIndicator * horizontalScrollIndicator() { return &m_horizontalScrollIndicator; }
-  void setIndicatorThickness(KDCoordinate t) { m_indicatorThickness = t; }
-  KDCoordinate indicatorThickness() const { return m_indicatorThickness; }
 
   void setContentOffset(KDPoint offset, bool forceRelayout = false);
   KDPoint contentOffset() const { return m_dataSource->offset(); }
@@ -58,13 +69,12 @@ private:
   int numberOfSubviews() const override;
   View * subviewAtIndex(int index) override;
 
-  ScrollViewVerticalIndicator m_verticalScrollIndicator;
-  ScrollViewHorizontalIndicator m_horizontalScrollIndicator;
   KDCoordinate m_topMargin;
   KDCoordinate m_rightMargin;
   KDCoordinate m_bottomMargin;
   KDCoordinate m_leftMargin;
-  KDCoordinate m_indicatorThickness;
+
+  Decorator m_decorator;
   bool m_showsIndicators;
   bool m_colorsBackground;
   KDColor m_backgroundColor;

--- a/escher/include/escher/scroll_view.h
+++ b/escher/include/escher/scroll_view.h
@@ -8,6 +8,7 @@
 class ScrollView : public View {
 public:
   ScrollView(View * contentView, ScrollViewDataSource * dataSource);
+  KDSize minimalSizeForOptimalDisplay() const override;
 
   void setTopMargin(KDCoordinate m) { m_topMargin = m; }
   KDCoordinate topMargin() const { return m_topMargin; }

--- a/escher/include/escher/scroll_view.h
+++ b/escher/include/escher/scroll_view.h
@@ -8,6 +8,7 @@
 class ScrollView : public View {
 public:
   ScrollView(View * contentView, ScrollViewDataSource * dataSource);
+  ScrollView(ScrollView&& other);
   KDSize minimalSizeForOptimalDisplay() const override;
 
   void setTopMargin(KDCoordinate m) { m_topMargin = m; }
@@ -73,8 +74,11 @@ public:
     ScrollViewArrow m_leftArrow;
   };
 
-  Decorator * decorator();
-  void setDecoratorType(Decorator::Type t) { m_decoratorType = t; }
+  Decorator * decorator() { return m_decorators.activeDecorator(); }
+  void setDecoratorType(Decorator::Type t) {
+    m_decoratorType = t;
+    m_decorators.setActiveDecorator(t);
+  }
   virtual void setBackgroundColor(KDColor c) {
     m_backgroundColor = c;
     decorator()->setBackgroundColor(m_backgroundColor);
@@ -126,9 +130,19 @@ private:
 
   InnerView m_innerView;
   Decorator::Type m_decoratorType;
-  Decorator m_decorator;
-  BarDecorator m_barDecorator;
-  ArrowDecorator m_arrowDecorator;
+  union Decorators {
+  public:
+    /* Enforce trivial constructor and destructor that just leaves the memory unmodified. */
+    Decorators() {}
+    ~Decorators() {}
+    Decorator * activeDecorator() { return &m_none; }
+    void setActiveDecorator(Decorator::Type t);
+  private:
+    Decorator m_none;
+    BarDecorator m_bars;
+    ArrowDecorator m_arrows;
+  };
+  Decorators m_decorators;
   KDColor m_backgroundColor;
 };
 

--- a/escher/include/escher/scroll_view.h
+++ b/escher/include/escher/scroll_view.h
@@ -32,8 +32,8 @@ public:
   virtual void setBackgroundColor(KDColor c) { m_backgroundColor = c; }
   KDColor backgroundColor() const { return m_backgroundColor; }
 
-  ScrollViewIndicator * verticalScrollIndicator() { return &m_verticalScrollIndicator; }
-  ScrollViewIndicator * horizontalScrollIndicator() { return &m_horizontalScrollIndicator; }
+  ScrollViewVerticalIndicator * verticalScrollIndicator() { return &m_verticalScrollIndicator; }
+  ScrollViewHorizontalIndicator * horizontalScrollIndicator() { return &m_horizontalScrollIndicator; }
   void setIndicatorThickness(KDCoordinate t) { m_indicatorThickness = t; }
   KDCoordinate indicatorThickness() const { return m_indicatorThickness; }
 
@@ -58,8 +58,8 @@ private:
   int numberOfSubviews() const override;
   View * subviewAtIndex(int index) override;
 
-  ScrollViewIndicator m_verticalScrollIndicator;
-  ScrollViewIndicator m_horizontalScrollIndicator;
+  ScrollViewVerticalIndicator m_verticalScrollIndicator;
+  ScrollViewHorizontalIndicator m_horizontalScrollIndicator;
   KDCoordinate m_topMargin;
   KDCoordinate m_rightMargin;
   KDCoordinate m_bottomMargin;

--- a/escher/include/escher/scroll_view.h
+++ b/escher/include/escher/scroll_view.h
@@ -47,7 +47,6 @@ protected:
   KDCoordinate maxContentHeightDisplayableWithoutScrolling();
   KDRect visibleContentRect();
   void layoutSubviews() override;
-  void updateScrollIndicator();
   KDSize contentSize();
 #if ESCHER_VIEW_LOGGING
   virtual const char * className() const override;
@@ -61,8 +60,6 @@ private:
 
   ScrollViewIndicator m_verticalScrollIndicator;
   ScrollViewIndicator m_horizontalScrollIndicator;
-  bool hasVerticalIndicator() const;
-  bool hasHorizontalIndicator() const;
   KDCoordinate m_topMargin;
   KDCoordinate m_rightMargin;
   KDCoordinate m_bottomMargin;

--- a/escher/include/escher/scroll_view.h
+++ b/escher/include/escher/scroll_view.h
@@ -46,10 +46,7 @@ public:
   public:
     BarDecorator();
     int numberOfIndicators() const override { return 2; }
-    View * indicatorAtIndex(int index) override {
-      assert(0 < index && index <= numberOfIndicators());
-      return &m_verticalBar + (index-1);
-    }
+    View * indicatorAtIndex(int index) override;
     KDRect layoutIndicators(KDSize content, KDPoint offset, KDRect frame) override;
     ScrollViewVerticalBar * verticalBar() { return &m_verticalBar; }
     ScrollViewHorizontalBar * horizontalBar() { return &m_horizontalBar; }
@@ -64,10 +61,7 @@ public:
   public:
     ArrowDecorator();
     int numberOfIndicators() const override { return 4; }
-    View * indicatorAtIndex(int index) override {
-      assert(0 < index && index <= numberOfIndicators());
-      return &m_topArrow + (index-1);
-    }
+    View * indicatorAtIndex(int index) override;
     KDRect layoutIndicators(KDSize content, KDPoint offset, KDRect frame) override;
     void setBackgroundColor(KDColor c) override;
   private:

--- a/escher/include/escher/scroll_view.h
+++ b/escher/include/escher/scroll_view.h
@@ -36,11 +36,11 @@ public:
     void layoutIndicators(KDSize content, KDPoint offset, KDSize frame);
     ScrollViewVerticalBar * verticalBar() { return &m_verticalBar; }
     ScrollViewHorizontalBar * horizontalBar() { return &m_horizontalBar; }
-    void setIndicatorThickness(KDCoordinate t) { m_indicatorThickness = t; }
+    void setBarsFrameBreadth(KDCoordinate t) { m_barsFrameBreadth = t; }
   private:
     ScrollViewVerticalBar m_verticalBar;
     ScrollViewHorizontalBar m_horizontalBar;
-    KDCoordinate m_indicatorThickness;
+    KDCoordinate m_barsFrameBreadth;
   };
 
   Decorator * decorator() { return &m_decorator; }

--- a/escher/include/escher/scroll_view.h
+++ b/escher/include/escher/scroll_view.h
@@ -92,7 +92,7 @@ protected:
   }
   KDRect visibleContentRect();
   void layoutSubviews() override;
-  KDSize contentSize();
+  virtual KDSize contentSize() const { return m_contentView->minimalSizeForOptimalDisplay(); }
 #if ESCHER_VIEW_LOGGING
   virtual const char * className() const override;
   virtual void logAttributes(std::ostream &os) const override;

--- a/escher/include/escher/scroll_view.h
+++ b/escher/include/escher/scroll_view.h
@@ -73,8 +73,6 @@ public:
 
   Decorator * decorator();
   void setDecoratorType(Decorator::Type t) { m_decoratorType = t; }
-  void setColorsBackground(bool c) { m_colorsBackground = c; }
-  bool colorsBackground() const { return m_colorsBackground; }
   virtual void setBackgroundColor(KDColor c) { m_backgroundColor = c; }
   KDColor backgroundColor() const { return m_backgroundColor; }
 
@@ -112,7 +110,6 @@ private:
   Decorator m_decorator;
   BarDecorator m_barDecorator;
   ArrowDecorator m_arrowDecorator;
-  bool m_colorsBackground;
   KDColor m_backgroundColor;
 };
 

--- a/escher/include/escher/scroll_view.h
+++ b/escher/include/escher/scroll_view.h
@@ -33,7 +33,7 @@ public:
       Bars,
       Arrows
     };
-    virtual int numberOfIndicators() { return 0; }
+    virtual int numberOfIndicators() const { return 0; }
     virtual View * indicatorAtIndex(int index) { assert(false); return nullptr; }
     virtual KDRect layoutIndicators(KDSize content, KDPoint offset, KDRect frame) { return frame; }
     virtual void setBackgroundColor(KDColor c) {}
@@ -42,7 +42,7 @@ public:
   class BarDecorator : public Decorator {
   public:
     BarDecorator();
-    int numberOfIndicators() override { return 2; }
+    int numberOfIndicators() const override { return 2; }
     View * indicatorAtIndex(int index) override {
       assert(0 < index && index <= numberOfIndicators());
       return &m_verticalBar + (index-1);
@@ -60,7 +60,7 @@ public:
   class ArrowDecorator : public Decorator {
   public:
     ArrowDecorator();
-    int numberOfIndicators() override { return 4; }
+    int numberOfIndicators() const override { return 4; }
     View * indicatorAtIndex(int index) override {
       assert(0 < index && index <= numberOfIndicators());
       return &m_topArrow + (index-1);

--- a/escher/include/escher/scroll_view.h
+++ b/escher/include/escher/scroll_view.h
@@ -35,6 +35,7 @@ public:
     virtual int numberOfIndicators() { return 0; }
     virtual View * indicatorAtIndex(int index) { assert(false); return nullptr; }
     virtual void layoutIndicators(KDSize content, KDPoint offset, KDSize frame) {}
+    virtual void setBackgroundColor(KDColor c) {}
   };
 
   class BarDecorator : public Decorator {
@@ -64,6 +65,7 @@ public:
       return &m_topArrow + (index-1);
     }
     void layoutIndicators(KDSize content, KDPoint offset, KDSize frame) override;
+    void setBackgroundColor(KDColor c) override;
   private:
     ScrollViewArrow m_topArrow;
     ScrollViewArrow m_rightArrow;
@@ -73,7 +75,10 @@ public:
 
   Decorator * decorator();
   void setDecoratorType(Decorator::Type t) { m_decoratorType = t; }
-  virtual void setBackgroundColor(KDColor c) { m_backgroundColor = c; }
+  virtual void setBackgroundColor(KDColor c) {
+    m_backgroundColor = c;
+    decorator()->setBackgroundColor(m_backgroundColor);
+  }
   KDColor backgroundColor() const { return m_backgroundColor; }
 
   void setContentOffset(KDPoint offset, bool forceRelayout = false);

--- a/escher/include/escher/scroll_view.h
+++ b/escher/include/escher/scroll_view.h
@@ -50,11 +50,10 @@ public:
     KDRect layoutIndicators(KDSize content, KDPoint offset, KDRect frame) override;
     ScrollViewVerticalBar * verticalBar() { return &m_verticalBar; }
     ScrollViewHorizontalBar * horizontalBar() { return &m_horizontalBar; }
-    void setBarsFrameBreadth(KDCoordinate t) { m_barsFrameBreadth = t; }
   private:
     ScrollViewVerticalBar m_verticalBar;
     ScrollViewHorizontalBar m_horizontalBar;
-    KDCoordinate m_barsFrameBreadth;
+    static constexpr KDCoordinate k_barsFrameBreadth = 13;
   };
 
   class ArrowDecorator : public Decorator {

--- a/escher/include/escher/scroll_view.h
+++ b/escher/include/escher/scroll_view.h
@@ -31,12 +31,12 @@ public:
     int numberOfIndicators();
     View * indicatorAtIndex(int index);
     void layoutIndicators(KDSize content, KDPoint offset, KDSize frame);
-    ScrollViewVerticalIndicator * verticalBar() { return &m_verticalScrollIndicator; }
-    ScrollViewHorizontalIndicator * horizontalBar() { return &m_horizontalScrollIndicator; }
+    ScrollViewVerticalBar * verticalBar() { return &m_verticalBar; }
+    ScrollViewHorizontalBar * horizontalBar() { return &m_horizontalBar; }
     void setIndicatorThickness(KDCoordinate t) { m_indicatorThickness = t; }
   private:
-    ScrollViewVerticalIndicator m_verticalScrollIndicator;
-    ScrollViewHorizontalIndicator m_horizontalScrollIndicator;
+    ScrollViewVerticalBar m_verticalBar;
+    ScrollViewHorizontalBar m_horizontalBar;
     KDCoordinate m_indicatorThickness;
   };
 

--- a/escher/include/escher/scroll_view.h
+++ b/escher/include/escher/scroll_view.h
@@ -43,6 +43,22 @@ public:
     KDCoordinate m_barsFrameBreadth;
   };
 
+  class DecoratorV2 {
+  public:
+    DecoratorV2();
+    int numberOfIndicators() { return 4; }
+    View * indicatorAtIndex(int index) {
+      assert(0 < index && index <= numberOfIndicators());
+      return &m_topArrow + (index-1);
+    }
+    void layoutIndicators(KDSize content, KDPoint offset, KDSize frame);
+  private:
+    ScrollViewArrow m_topArrow;
+    ScrollViewArrow m_rightArrow;
+    ScrollViewArrow m_bottomArrow;
+    ScrollViewArrow m_leftArrow;
+  };
+
   Decorator * decorator() { return &m_decorator; }
   void setShowsIndicators(bool s) { m_showsIndicators = s; }
   bool showsIndicators() const { return m_showsIndicators; }

--- a/escher/include/escher/scroll_view.h
+++ b/escher/include/escher/scroll_view.h
@@ -84,8 +84,12 @@ public:
   void scrollToContentPoint(KDPoint p, bool allowOverscroll = false);
   void scrollToContentRect(KDRect rect, bool allowOverscroll = false); // Minimal scrolling to make this rect visible
 protected:
-  KDCoordinate maxContentWidthDisplayableWithoutScrolling();
-  KDCoordinate maxContentHeightDisplayableWithoutScrolling();
+  KDCoordinate maxContentWidthDisplayableWithoutScrolling() const {
+    return m_frame.width() - m_leftMargin - m_rightMargin;
+  }
+  KDCoordinate maxContentHeightDisplayableWithoutScrolling() const {
+    return m_frame.height() - m_topMargin - m_bottomMargin;
+  }
   KDRect visibleContentRect();
   void layoutSubviews() override;
   KDSize contentSize();

--- a/escher/include/escher/scroll_view.h
+++ b/escher/include/escher/scroll_view.h
@@ -27,6 +27,11 @@ public:
 
   class Decorator {
   public:
+    enum class Type {
+      None,
+      Bars,
+      Arrows
+    };
     virtual int numberOfIndicators() { return 0; }
     virtual View * indicatorAtIndex(int index) { assert(false); return nullptr; }
     virtual void layoutIndicators(KDSize content, KDPoint offset, KDSize frame) {}
@@ -66,7 +71,8 @@ public:
     ScrollViewArrow m_leftArrow;
   };
 
-  Decorator * decorator() { return &m_decorator; }
+  Decorator * decorator();
+  void setDecoratorType(Decorator::Type t) { m_decoratorType = t; }
   void setShowsIndicators(bool s) { m_showsIndicators = s; }
   bool showsIndicators() const { return m_showsIndicators; }
   void setColorsBackground(bool c) { m_colorsBackground = c; }
@@ -100,7 +106,10 @@ private:
   KDCoordinate m_bottomMargin;
   KDCoordinate m_leftMargin;
 
-  BarDecorator m_decorator;
+  Decorator::Type m_decoratorType;
+  Decorator m_decorator;
+  BarDecorator m_barDecorator;
+  ArrowDecorator m_arrowDecorator;
   bool m_showsIndicators;
   bool m_colorsBackground;
   KDColor m_backgroundColor;

--- a/escher/include/escher/scroll_view.h
+++ b/escher/include/escher/scroll_view.h
@@ -34,7 +34,7 @@ public:
     };
     virtual int numberOfIndicators() { return 0; }
     virtual View * indicatorAtIndex(int index) { assert(false); return nullptr; }
-    virtual void layoutIndicators(KDSize content, KDPoint offset, KDSize frame) {}
+    virtual KDRect layoutIndicators(KDSize content, KDPoint offset, KDRect frame) { return frame; }
     virtual void setBackgroundColor(KDColor c) {}
   };
 
@@ -46,7 +46,7 @@ public:
       assert(0 < index && index <= numberOfIndicators());
       return &m_verticalBar + (index-1);
     }
-    void layoutIndicators(KDSize content, KDPoint offset, KDSize frame) override;
+    KDRect layoutIndicators(KDSize content, KDPoint offset, KDRect frame) override;
     ScrollViewVerticalBar * verticalBar() { return &m_verticalBar; }
     ScrollViewHorizontalBar * horizontalBar() { return &m_horizontalBar; }
     void setBarsFrameBreadth(KDCoordinate t) { m_barsFrameBreadth = t; }
@@ -64,7 +64,7 @@ public:
       assert(0 < index && index <= numberOfIndicators());
       return &m_topArrow + (index-1);
     }
-    void layoutIndicators(KDSize content, KDPoint offset, KDSize frame) override;
+    KDRect layoutIndicators(KDSize content, KDPoint offset, KDRect frame) override;
     void setBackgroundColor(KDColor c) override;
   private:
     ScrollViewArrow m_topArrow;

--- a/escher/include/escher/scroll_view.h
+++ b/escher/include/escher/scroll_view.h
@@ -33,6 +33,9 @@ public:
       Bars,
       Arrows
     };
+    /* We want (Decorator *)->~Decorator() to call ~BarDecorator() or ~ArrowDecorator()
+     * when required. */
+    virtual ~Decorator() = default;
     virtual int numberOfIndicators() const { return 0; }
     virtual View * indicatorAtIndex(int index) { assert(false); return nullptr; }
     virtual KDRect layoutIndicators(KDSize content, KDPoint offset, KDRect frame) { return frame; }
@@ -132,9 +135,8 @@ private:
   Decorator::Type m_decoratorType;
   union Decorators {
   public:
-    /* Enforce trivial constructor and destructor that just leaves the memory unmodified. */
-    Decorators() {}
-    ~Decorators() {}
+    Decorators();
+    ~Decorators();
     Decorator * activeDecorator() { return &m_none; }
     void setActiveDecorator(Decorator::Type t);
   private:

--- a/escher/include/escher/scroll_view_indicator.h
+++ b/escher/include/escher/scroll_view_indicator.h
@@ -43,4 +43,21 @@ private:
   KDCoordinate totalLength() const { return m_frame.height() - 2*m_margin; }
 };
 
+class ScrollViewArrow : public ScrollViewIndicator {
+public:
+  enum Side : char { //FIXME
+    Top = 't',
+    Right = '>',
+    Bottom = 'b',
+    Left = '<'
+  };
+  ScrollViewArrow(Side side);
+  bool update(bool visible);
+  void drawRect(KDContext * ctx, KDRect rect) const override;
+private:
+  bool m_visible;
+  const char m_arrow;
+  KDColor m_backgroundColor;
+};
+
 #endif

--- a/escher/include/escher/scroll_view_indicator.h
+++ b/escher/include/escher/scroll_view_indicator.h
@@ -20,10 +20,10 @@ protected:
 class ScrollViewBar : public ScrollViewIndicator {
 public:
   ScrollViewBar();
-  void update(KDCoordinate totalContentLength, KDCoordinate contentOffset, KDCoordinate visibleContentLength);
-  bool visible() const { return 0 < m_offset || m_visibleLength < 1; }
+  bool update(KDCoordinate totalContentLength, KDCoordinate contentOffset, KDCoordinate visibleContentLength);
 protected:
   constexpr static KDCoordinate k_indicatorThickness = 4;
+  bool visible() const { return 0 < m_offset || m_visibleLength < 1; }
   float m_offset;
   float m_visibleLength;
   KDColor m_trackColor;

--- a/escher/include/escher/scroll_view_indicator.h
+++ b/escher/include/escher/scroll_view_indicator.h
@@ -19,11 +19,8 @@ public:
   void setMargin(KDCoordinate m) { m_margin = m; }
   KDCoordinate margin() const { return m_margin; }
 
-  float start() const;
-  void setStart(float start);
-  float end() const;
-  void setEnd(float end);
-  KDRect frame();
+  void update(KDCoordinate totalContentLength, KDCoordinate contentOffset, KDCoordinate visibleContentLength);
+  bool visible() const { return 0 < m_offset || m_visibleLength < 1; }
 protected:
 #if ESCHER_VIEW_LOGGING
   virtual const char * className() const override;
@@ -32,8 +29,11 @@ protected:
 private:
   constexpr static KDCoordinate k_indicatorThickness = 4;
   Direction m_direction;
-  float m_start;
-  float m_end;
+  KDCoordinate totalLength() const {
+    return ((m_direction == Direction::Horizontal) ? m_frame.width() : m_frame.height()) - 2*m_margin;
+  }
+  float m_offset;
+  float m_visibleLength;
   KDColor m_indicatorColor;
   KDColor m_backgroundColor;
   KDCoordinate m_margin;

--- a/escher/include/escher/scroll_view_indicator.h
+++ b/escher/include/escher/scroll_view_indicator.h
@@ -53,6 +53,7 @@ public:
   };
   ScrollViewArrow(Side side);
   bool update(bool visible);
+  void setBackgroundColor(KDColor c) { m_backgroundColor = c; }
   void drawRect(KDContext * ctx, KDRect rect) const override;
 private:
   bool m_visible;

--- a/escher/include/escher/scroll_view_indicator.h
+++ b/escher/include/escher/scroll_view_indicator.h
@@ -6,37 +6,37 @@
 class ScrollViewIndicator : public View {
 public:
   ScrollViewIndicator();
-
-  void setIndicatorColor(KDColor c) { m_indicatorColor = c; }
-  KDColor indicatorColor() const { return m_indicatorColor; }
-  void setBackgroundColor(KDColor c) { m_backgroundColor = c; }
-  KDColor backgroundColor() const { return m_backgroundColor; }
   void setMargin(KDCoordinate m) { m_margin = m; }
   KDCoordinate margin() const { return m_margin; }
-
-  void update(KDCoordinate totalContentLength, KDCoordinate contentOffset, KDCoordinate visibleContentLength);
-  bool visible() const { return 0 < m_offset || m_visibleLength < 1; }
 protected:
 #if ESCHER_VIEW_LOGGING
   virtual const char * className() const override;
   virtual void logAttributes(std::ostream &os) const override;
 #endif
-  constexpr static KDCoordinate k_indicatorThickness = 4;
-  float m_offset;
-  float m_visibleLength;
-  KDColor m_indicatorColor;
-  KDColor m_backgroundColor;
+  KDColor m_color;
   KDCoordinate m_margin;
 };
 
-class ScrollViewHorizontalIndicator : public ScrollViewIndicator {
+class ScrollViewBar : public ScrollViewIndicator {
+public:
+  ScrollViewBar();
+  void update(KDCoordinate totalContentLength, KDCoordinate contentOffset, KDCoordinate visibleContentLength);
+  bool visible() const { return 0 < m_offset || m_visibleLength < 1; }
+protected:
+  constexpr static KDCoordinate k_indicatorThickness = 4;
+  float m_offset;
+  float m_visibleLength;
+  KDColor m_trackColor;
+};
+
+class ScrollViewHorizontalBar : public ScrollViewBar {
 public:
   void drawRect(KDContext * ctx, KDRect rect) const override;
 private:
   KDCoordinate totalLength() const { return m_frame.width() - 2*m_margin; }
 };
 
-class ScrollViewVerticalIndicator : public ScrollViewIndicator {
+class ScrollViewVerticalBar : public ScrollViewBar {
 public:
   void drawRect(KDContext * ctx, KDRect rect) const override;
 private:

--- a/escher/include/escher/scroll_view_indicator.h
+++ b/escher/include/escher/scroll_view_indicator.h
@@ -5,12 +5,7 @@
 
 class ScrollViewIndicator : public View {
 public:
-  enum class Direction {
-    Horizontal,
-    Vertical
-  };
-  ScrollViewIndicator(Direction direction);
-  void drawRect(KDContext * ctx, KDRect rect) const override;
+  ScrollViewIndicator();
 
   void setIndicatorColor(KDColor c) { m_indicatorColor = c; }
   KDColor indicatorColor() const { return m_indicatorColor; }
@@ -26,17 +21,26 @@ protected:
   virtual const char * className() const override;
   virtual void logAttributes(std::ostream &os) const override;
 #endif
-private:
   constexpr static KDCoordinate k_indicatorThickness = 4;
-  Direction m_direction;
-  KDCoordinate totalLength() const {
-    return ((m_direction == Direction::Horizontal) ? m_frame.width() : m_frame.height()) - 2*m_margin;
-  }
   float m_offset;
   float m_visibleLength;
   KDColor m_indicatorColor;
   KDColor m_backgroundColor;
   KDCoordinate m_margin;
+};
+
+class ScrollViewHorizontalIndicator : public ScrollViewIndicator {
+public:
+  void drawRect(KDContext * ctx, KDRect rect) const override;
+private:
+  KDCoordinate totalLength() const { return m_frame.width() - 2*m_margin; }
+};
+
+class ScrollViewVerticalIndicator : public ScrollViewIndicator {
+public:
+  void drawRect(KDContext * ctx, KDRect rect) const override;
+private:
+  KDCoordinate totalLength() const { return m_frame.height() - 2*m_margin; }
 };
 
 #endif

--- a/escher/include/escher/scrollable_view.h
+++ b/escher/include/escher/scrollable_view.h
@@ -11,7 +11,7 @@ public:
   bool handleEvent(Ion::Events::Event event) override;
   void reloadScroll(bool forceRelayout = false);
 protected:
-  void layoutSubviews() override;
+  KDSize contentSize() const override;
   KDPoint m_manualScrollingOffset;
 };
 

--- a/escher/include/escher/stack_view_controller.h
+++ b/escher/include/escher/stack_view_controller.h
@@ -21,6 +21,7 @@ public:
   const char * title() override;
   bool handleEvent(Ion::Events::Event event) override;
   void didBecomeFirstResponder() override;
+  void initView() override;
   void viewWillAppear() override;
   void viewDidDisappear() override;
 private:

--- a/escher/include/escher/tab_view_controller.h
+++ b/escher/include/escher/tab_view_controller.h
@@ -19,6 +19,7 @@ public:
   void didBecomeFirstResponder() override;
   void didEnterResponderChain(Responder * previousResponder) override;
   void willResignFirstResponder() override;
+  void initView() override;
   void viewWillAppear() override;
   void viewDidDisappear() override;
 private:

--- a/escher/include/escher/table_view.h
+++ b/escher/include/escher/table_view.h
@@ -38,12 +38,12 @@ protected:
     void scrollToCell(int i, int j) const;
     void reloadCellAtLocation(int i, int j);
     HighlightCell * cellAtLocation(int i, int j);
-    void resizeToFitContent();
     TableViewDataSource * dataSource();
     int rowsScrollingOffset() const;
     int columnsScrollingOffset() const;
     int numberOfDisplayableRows() const;
     int numberOfDisplayableColumns() const;
+    void layoutSubviews() override;
   protected:
 #if ESCHER_VIEW_LOGGING
     const char * className() const override;
@@ -54,7 +54,6 @@ protected:
 
     int numberOfSubviews() const override;
     View * subviewAtIndex(int index) override;
-    void layoutSubviews() override;
 
     /* realCellWidth enables to handle list view for which
      * TableViewDataSource->cellWidht = 0 */

--- a/escher/include/escher/table_view.h
+++ b/escher/include/escher/table_view.h
@@ -20,7 +20,6 @@ public:
   virtual void scrollToCell(int i, int j);
   HighlightCell * cellAtLocation(int i, int j);
   void reloadCellAtLocation(int i, int j);
-  KDSize minimalSizeForOptimalDisplay() const override;
 protected:
 #if ESCHER_VIEW_LOGGING
   const char * className() const override;

--- a/escher/include/escher/table_view.h
+++ b/escher/include/escher/table_view.h
@@ -56,7 +56,7 @@ protected:
 
     /* realCellWidth enables to handle list view for which
      * TableViewDataSource->cellWidht = 0 */
-    KDCoordinate columnWidth(int x) const;
+    KDRect cellFrame(int i, int j) const;
     /* These two methods transform an index (of subview for instance) into
      * coordinates that refer to the data source entire table */
     int absoluteColumnNumberFromSubviewIndex(int index) const;

--- a/escher/include/escher/text_field.h
+++ b/escher/include/escher/text_field.h
@@ -20,7 +20,6 @@ public:
   void setText(const char * text);
   void setAlignment(float horizontalAlignment, float verticalAlignment);
   virtual void setEditing(bool isEditing, bool reinitDraftBuffer = true) override;
-  KDSize minimalSizeForOptimalDisplay() const override;
   char XNTChar(char defaultXNTChar) override;
   bool handleEventWithText(const char * text, bool indentation = false, bool forceCursorRightOfText = false) override;
   bool handleEvent(Ion::Events::Event event) override;

--- a/escher/include/escher/view_controller.h
+++ b/escher/include/escher/view_controller.h
@@ -21,8 +21,12 @@ extern "C" {
  * - viewWillDisappear
  * - willExitResponderChain
  * - willResignFirstResponder
- * Both methods are always called after setting a view and layouting it
- * subviews. */
+ *
+ * Both methods are always called after setting a view and laying its subwiews
+ * out.
+ *
+ * The method initView is called before setting a View (or often sets itself)
+ * and laying it out. */
 
 #include <escher/view.h>
 #include <escher/responder.h>
@@ -43,6 +47,7 @@ public:
   ViewController(Responder * parentResponder);
   virtual const char * title();
   virtual View * view() = 0;
+  virtual void initView() {}
   virtual void viewWillAppear();
   virtual void viewDidDisappear();
   virtual DisplayParameter displayParameter() { return DisplayParameter::Default; }

--- a/escher/src/alternate_empty_view_controller.cpp
+++ b/escher/src/alternate_empty_view_controller.cpp
@@ -71,6 +71,10 @@ void AlternateEmptyViewController::didBecomeFirstResponder() {
   }
 }
 
+void AlternateEmptyViewController::initView() {
+  m_contentView.mainViewController()->initView();
+}
+
 void AlternateEmptyViewController::viewWillAppear() {
   m_contentView.layoutSubviews();
   if (!m_contentView.alternateEmptyViewDelegate()->isEmpty()) {

--- a/escher/src/app.cpp
+++ b/escher/src/app.cpp
@@ -108,8 +108,9 @@ const Container * App::container() const {
 void App::didBecomeActive(Window * window) {
   View * view = m_modalViewController.view();
   assert(m_modalViewController.app() == this);
-  m_modalViewController.viewWillAppear();
+  m_modalViewController.initView();
   window->setContentView(view);
+  m_modalViewController.viewWillAppear();
   setFirstResponder(&m_modalViewController);
 }
 

--- a/escher/src/bank_view_controller.cpp
+++ b/escher/src/bank_view_controller.cpp
@@ -24,8 +24,14 @@ void BankViewController::didEnterResponderChain(Responder * previousResponder) {
   app()->setFirstResponder(activeViewController());
 }
 
-void BankViewController::viewWillAppear() {
+void BankViewController::initView() {
+  for (int i = 0; i < numberOfChildren(); i++) {
+    childAtIndex(i)->initView();
+  }
   m_view.setSubview(activeViewController()->view());
+}
+
+void BankViewController::viewWillAppear() {
   activeViewController()->viewWillAppear();
 }
 

--- a/escher/src/button_row_controller.cpp
+++ b/escher/src/button_row_controller.cpp
@@ -211,6 +211,10 @@ bool ButtonRowController::handleEvent(Ion::Events::Event event) {
   return false;
 }
 
+void ButtonRowController::initView() {
+  m_contentView.mainViewController()->initView();
+}
+
 void ButtonRowController::viewWillAppear() {
   /* We need to layout subviews at first appearance because the number of
    * buttons might have changed between 2 appearences. */

--- a/escher/src/expression_field.cpp
+++ b/escher/src/expression_field.cpp
@@ -13,11 +13,9 @@ ExpressionField::ExpressionField(Responder * parentResponder, char * textBuffer,
   // Initialize text field
   m_textField.setMargins(0, k_horizontalMargin, 0, k_horizontalMargin);
   m_textField.setBackgroundColor(KDColorWhite);
-  m_textField.setColorsBackground(true);
   // Initialize layout field
   m_layoutField.setMargins(k_verticalMargin, k_horizontalMargin, k_verticalMargin, k_horizontalMargin);
   m_layoutField.setBackgroundColor(KDColorWhite);
-  m_layoutField.setColorsBackground(true);
 }
 
 void ExpressionField::setEditing(bool isEditing, bool reinitDraftBuffer) {

--- a/escher/src/modal_view_controller.cpp
+++ b/escher/src/modal_view_controller.cpp
@@ -118,6 +118,7 @@ void ModalViewController::displayModalViewController(ViewController * vc, float 
   m_currentModalViewController = vc;
   vc->setParentResponder(this);
   m_previousResponder = app()->firstResponder();
+  m_currentModalViewController->initView();
   m_contentView.presentModalView(vc->view(), verticalAlignment, horizontalAlignment, topMargin, leftMargin, bottomMargin, rightMargin);
   m_currentModalViewController->viewWillAppear();
   app()->setFirstResponder(vc);
@@ -152,8 +153,12 @@ bool ModalViewController::handleEvent(Ion::Events::Event event) {
   return false;
 }
 
-void ModalViewController::viewWillAppear() {
+void ModalViewController::initView() {
   m_contentView.setMainView(m_regularViewController->view());
+  m_regularViewController->initView();
+}
+
+void ModalViewController::viewWillAppear() {
   m_contentView.layoutSubviews();
   if (m_contentView.isDisplayingModal()) {
     m_currentModalViewController->viewWillAppear();

--- a/escher/src/nested_menu_controller.cpp
+++ b/escher/src/nested_menu_controller.cpp
@@ -94,7 +94,7 @@ NestedMenuController::NestedMenuController(Responder * parentResponder, I18n::Me
   m_sender(nullptr)
 {
   m_selectableTableView.setMargins(0);
-  m_selectableTableView.setShowsIndicators(false);
+  m_selectableTableView.setDecoratorType(ScrollView::Decorator::Type::None);
 }
 
 bool NestedMenuController::handleEvent(Ion::Events::Event event) {

--- a/escher/src/scroll_view.cpp
+++ b/escher/src/scroll_view.cpp
@@ -14,7 +14,10 @@ ScrollView::ScrollView(View * contentView, ScrollViewDataSource * dataSource) :
   m_rightMargin(0),
   m_bottomMargin(0),
   m_leftMargin(0),
+  m_decoratorType(Decorator::Type::Bars),
   m_decorator(),
+  m_barDecorator(),
+  m_arrowDecorator(),
   m_showsIndicators(true),
   m_colorsBackground(true),
   m_backgroundColor(Palette::WallScreen)
@@ -27,6 +30,18 @@ void ScrollView::setCommonMargins() {
   setRightMargin(Metric::CommonRightMargin);
   setBottomMargin(Metric::CommonBottomMargin);
   setLeftMargin(Metric::CommonLeftMargin);
+}
+
+ScrollView::Decorator * ScrollView::decorator() {
+  switch (m_decoratorType) {
+    case Decorator::Type::Bars:
+      return &m_barDecorator;
+    case Decorator::Type::Arrows:
+      return &m_arrowDecorator;
+    default:
+      assert(m_decoratorType == Decorator::Type::None);
+      return &m_decorator;
+  }
 }
 
 int ScrollView::numberOfSubviews() const {

--- a/escher/src/scroll_view.cpp
+++ b/escher/src/scroll_view.cpp
@@ -184,6 +184,12 @@ void ScrollView::ArrowDecorator::layoutIndicators(KDSize content, KDPoint offset
   ));
 }
 
+void ScrollView::ArrowDecorator::setBackgroundColor(KDColor c) {
+  for (int i = 0; i < numberOfIndicators(); i++) {
+    (&m_topArrow + i)->setBackgroundColor(c);
+  }
+}
+
 #if ESCHER_VIEW_LOGGING
 const char * ScrollView::className() const {
   return "ScrollView";

--- a/escher/src/scroll_view.cpp
+++ b/escher/src/scroll_view.cpp
@@ -1,6 +1,5 @@
 #include <escher/scroll_view.h>
 #include <escher/palette.h>
-#include <escher/metric.h>
 
 #include <new>
 
@@ -45,12 +44,6 @@ KDSize ScrollView::minimalSizeForOptimalDisplay() const {
   );
 }
 
-void ScrollView::setCommonMargins() {
-  setTopMargin(Metric::CommonTopMargin);
-  setRightMargin(Metric::CommonRightMargin);
-  setBottomMargin(Metric::CommonBottomMargin);
-  setLeftMargin(Metric::CommonLeftMargin);
-}
 
 void ScrollView::scrollToContentPoint(KDPoint p, bool allowOverscroll) {
   if (!allowOverscroll && !m_contentView->bounds().contains(p)) {

--- a/escher/src/scroll_view.cpp
+++ b/escher/src/scroll_view.cpp
@@ -139,32 +139,19 @@ void ScrollView::layoutSubviews() {
   // Layout indicators
   /* If the two indicators are visible, we leave an empty rectangle in the right
    * bottom corner. Otherwise, the only indicator uses all the height/width. */
-  if (hasHorizontalIndicator() && hasVerticalIndicator()) {
-      KDRect verticalIndicatorFrame = KDRect(
+  if (hasVerticalIndicator()) {
+    KDRect verticalIndicatorFrame = KDRect(
       m_frame.width() - m_indicatorThickness, 0,
-      m_indicatorThickness, m_frame.height() - m_indicatorThickness
+      m_indicatorThickness, m_frame.height() - hasHorizontalIndicator() * m_indicatorThickness
     );
     m_verticalScrollIndicator.setFrame(verticalIndicatorFrame);
+  }
+  if (hasHorizontalIndicator()) {
     KDRect horizontalIndicatorFrame = KDRect(
       0, m_frame.height() - m_indicatorThickness,
-      m_frame.width() - m_indicatorThickness, m_indicatorThickness
+      m_frame.width() - hasVerticalIndicator() * m_indicatorThickness, m_indicatorThickness
     );
-  m_horizontalScrollIndicator.setFrame(horizontalIndicatorFrame);
-  } else {
-    if (hasVerticalIndicator()) {
-      KDRect verticalIndicatorFrame = KDRect(
-      m_frame.width() - m_indicatorThickness, 0,
-      m_indicatorThickness, m_frame.height()
-      );
-      m_verticalScrollIndicator.setFrame(verticalIndicatorFrame);
-    }
-    if (hasHorizontalIndicator()) {
-      KDRect horizontalIndicatorFrame = KDRect(
-      0, m_frame.height() - m_indicatorThickness,
-      m_frame.width(), m_indicatorThickness
-      );
-      m_horizontalScrollIndicator.setFrame(horizontalIndicatorFrame);
-    }
+    m_horizontalScrollIndicator.setFrame(horizontalIndicatorFrame);
   }
 }
 

--- a/escher/src/scroll_view.cpp
+++ b/escher/src/scroll_view.cpp
@@ -175,6 +175,38 @@ void ScrollView::Decorator::layoutIndicators(KDSize content, KDPoint offset, KDS
   ));
 }
 
+ScrollView::DecoratorV2::DecoratorV2() :
+  m_topArrow(ScrollViewArrow::Side::Top),
+  m_rightArrow(ScrollViewArrow::Side::Right),
+  m_bottomArrow(ScrollViewArrow::Side::Bottom),
+  m_leftArrow(ScrollViewArrow::Side::Left)
+{
+}
+
+void ScrollView::DecoratorV2::layoutIndicators(KDSize content, KDPoint offset, KDSize frame) {
+  KDSize arrowSize = KDFont::LargeFont->glyphSize();
+  KDCoordinate topArrowFrameBreadth = arrowSize.height() * m_topArrow.update(0 < offset.y());
+  KDCoordinate rightArrowFrameBreadth = arrowSize.width() * m_rightArrow.update(offset.x() + frame.width() < content.width());
+  KDCoordinate bottomArrowFrameBreadth = arrowSize.height() * m_bottomArrow.update(offset.y() + frame.height() < content.height());
+  KDCoordinate leftArrowFrameBreadth = arrowSize.width() * m_leftArrow.update(0 < offset.x());
+  m_topArrow.setFrame(KDRect(
+    0, 0,
+    frame.width(), topArrowFrameBreadth
+  ));
+  m_rightArrow.setFrame(KDRect(
+    frame.width() - rightArrowFrameBreadth, 0,
+    rightArrowFrameBreadth, frame.height()
+  ));
+  m_bottomArrow.setFrame(KDRect(
+    0, frame.height() - bottomArrowFrameBreadth,
+    frame.width(), bottomArrowFrameBreadth
+  ));
+  m_leftArrow.setFrame(KDRect(
+    0, 0,
+    leftArrowFrameBreadth, frame.height()
+  ));
+}
+
 #if ESCHER_VIEW_LOGGING
 const char * ScrollView::className() const {
   return "ScrollView";

--- a/escher/src/scroll_view.cpp
+++ b/escher/src/scroll_view.cpp
@@ -146,53 +146,53 @@ KDCoordinate ScrollView::maxContentHeightDisplayableWithoutScrolling() {
 }
 
 ScrollView::Decorator::Decorator() :
-  m_verticalScrollIndicator(),
-  m_horizontalScrollIndicator(),
+  m_verticalBar(),
+  m_horizontalBar(),
   m_indicatorThickness(20)
 {
 }
 
 int ScrollView::Decorator::numberOfIndicators() {
-  return m_verticalScrollIndicator.visible() + m_horizontalScrollIndicator.visible();
+  return m_verticalBar.visible() + m_horizontalBar.visible();
 }
 
 View * ScrollView::Decorator::indicatorAtIndex(int index) {
   switch (index) {
     case 1:
-      if (m_horizontalScrollIndicator.visible()) {
-        return &m_horizontalScrollIndicator;
+      if (m_horizontalBar.visible()) {
+        return &m_horizontalBar;
       } else {
-        return &m_verticalScrollIndicator;
+        return &m_verticalBar;
       }
     case 2:
-      return &m_verticalScrollIndicator;
+      return &m_verticalBar;
   }
   return nullptr;
 }
 
 void ScrollView::Decorator::layoutIndicators(KDSize content, KDPoint offset, KDSize frame) {
-  m_horizontalScrollIndicator.update(
+  m_horizontalBar.update(
     content.width(),
     offset.x(),
     frame.width()
   );
-  m_verticalScrollIndicator.update(
+  m_verticalBar.update(
     content.height(),
     offset.y(),
     frame.height()
   );
   /* If the two indicators are visible, we leave an empty rectangle in the right
    * bottom corner. Otherwise, the only indicator uses all the height/width. */
-  if (m_verticalScrollIndicator.visible()) {
-    m_verticalScrollIndicator.setFrame(KDRect(
+  if (m_verticalBar.visible()) {
+    m_verticalBar.setFrame(KDRect(
       frame.width() - m_indicatorThickness, 0,
-      m_indicatorThickness, frame.height() - m_horizontalScrollIndicator.visible() * m_indicatorThickness
+      m_indicatorThickness, frame.height() - m_horizontalBar.visible() * m_indicatorThickness
     ));
   }
-  if (m_horizontalScrollIndicator.visible()) {
-    m_horizontalScrollIndicator.setFrame(KDRect(
+  if (m_horizontalBar.visible()) {
+    m_horizontalBar.setFrame(KDRect(
       0, frame.height() - m_indicatorThickness,
-      frame.width() - m_verticalScrollIndicator.visible() * m_indicatorThickness, m_indicatorThickness
+      frame.width() - m_verticalBar.visible() * m_indicatorThickness, m_indicatorThickness
     ));
   }
 }

--- a/escher/src/scroll_view.cpp
+++ b/escher/src/scroll_view.cpp
@@ -32,7 +32,7 @@ void ScrollView::setCommonMargins() {
 int ScrollView::numberOfSubviews() const {
   int result = 1;
   if (m_showsIndicators) {
-    result += const_cast<ScrollView *>(this)->m_decorator.numberOfIndicators();
+    result += const_cast<ScrollView *>(this)->decorator()->numberOfIndicators();
   }
   return result;
 }
@@ -42,7 +42,7 @@ View * ScrollView::subviewAtIndex(int index) {
     return m_contentView;
   }
   if (m_showsIndicators) {
-    return m_decorator.indicatorAtIndex(index);
+    return decorator()->indicatorAtIndex(index);
   }
   return nullptr;
 }
@@ -123,7 +123,7 @@ void ScrollView::layoutSubviews() {
       m_contentView->bounds().width() + m_leftMargin + m_rightMargin,
       m_contentView->bounds().height() + m_topMargin + m_bottomMargin
     );
-    m_decorator.layoutIndicators(content, contentOffset(), m_frame.size());
+    decorator()->layoutIndicators(content, contentOffset(), m_frame.size());
   }
 }
 

--- a/escher/src/scroll_view.cpp
+++ b/escher/src/scroll_view.cpp
@@ -104,20 +104,14 @@ KDRect ScrollView::visibleContentRect() {
 }
 
 void ScrollView::layoutSubviews() {
-  // Layout contentView
-  // We're only re-positionning the contentView, not modifying its size.
   KDPoint absoluteOffset = contentOffset().opposite().translatedBy(KDPoint(m_leftMargin, m_topMargin));
-  KDRect contentFrame = KDRect(absoluteOffset, m_contentView->bounds().size());
+  KDRect contentFrame = KDRect(absoluteOffset, contentSize());
   m_contentView->setFrame(contentFrame);
   KDSize content(
     m_contentView->bounds().width() + m_leftMargin + m_rightMargin,
     m_contentView->bounds().height() + m_topMargin + m_bottomMargin
   );
   decorator()->layoutIndicators(content, contentOffset(), m_frame.size());
-}
-
-KDSize ScrollView::contentSize() {
-  return m_contentView->minimalSizeForOptimalDisplay();
 }
 
 void ScrollView::setContentOffset(KDPoint offset, bool forceRelayout) {

--- a/escher/src/scroll_view.cpp
+++ b/escher/src/scroll_view.cpp
@@ -126,14 +126,6 @@ void ScrollView::setContentOffset(KDPoint offset, bool forceRelayout) {
   }
 }
 
-KDCoordinate ScrollView::maxContentWidthDisplayableWithoutScrolling() {
-  return m_frame.width() - m_leftMargin - m_rightMargin;
-}
-
-KDCoordinate ScrollView::maxContentHeightDisplayableWithoutScrolling() {
-  return m_frame.height() - m_topMargin - m_bottomMargin;
-}
-
 ScrollView::BarDecorator::BarDecorator() :
   m_verticalBar(),
   m_horizontalBar(),

--- a/escher/src/scroll_view.cpp
+++ b/escher/src/scroll_view.cpp
@@ -125,8 +125,7 @@ void ScrollView::InnerView::drawRect(KDContext * ctx, KDRect rect) const {
 
 ScrollView::BarDecorator::BarDecorator() :
   m_verticalBar(),
-  m_horizontalBar(),
-  m_barsFrameBreadth(20)
+  m_horizontalBar()
 {
 }
 
@@ -141,12 +140,12 @@ View * ScrollView::BarDecorator::indicatorAtIndex(int index) {
 }
 
 KDRect ScrollView::BarDecorator::layoutIndicators(KDSize content, KDPoint offset, KDRect frame) {
-  KDCoordinate hBarFrameBreadth = m_barsFrameBreadth * m_horizontalBar.update(
+  KDCoordinate hBarFrameBreadth = k_barsFrameBreadth * m_horizontalBar.update(
     content.width(),
     offset.x(),
     frame.width()
   );
-  KDCoordinate vBarFrameBreadth = m_barsFrameBreadth * m_verticalBar.update(
+  KDCoordinate vBarFrameBreadth = k_barsFrameBreadth * m_verticalBar.update(
     content.height(),
     offset.y(),
     frame.height()

--- a/escher/src/scroll_view.cpp
+++ b/escher/src/scroll_view.cpp
@@ -24,6 +24,14 @@ ScrollView::ScrollView(View * contentView, ScrollViewDataSource * dataSource) :
   assert(m_dataSource != nullptr);
 }
 
+KDSize ScrollView::minimalSizeForOptimalDisplay() const {
+  KDSize contentSize = m_contentView->minimalSizeForOptimalDisplay();
+  return KDSize(
+    contentSize.width() + m_leftMargin + m_rightMargin,
+    contentSize.height() + m_topMargin + m_bottomMargin
+  );
+}
+
 void ScrollView::setCommonMargins() {
   setTopMargin(Metric::CommonTopMargin);
   setRightMargin(Metric::CommonRightMargin);
@@ -68,8 +76,8 @@ void ScrollView::scrollToContentPoint(KDPoint p, bool allowOverscroll) {
 
   /* Handle cases when the size of the view has decreased. */
   setContentOffset(KDPoint(
-    min(contentOffset().x(), max(contentSize().width() - maxContentWidthDisplayableWithoutScrolling(), 0)),
-    min(contentOffset().y(), max(contentSize().height() - maxContentHeightDisplayableWithoutScrolling(), 0))
+    min(contentOffset().x(), max(minimalSizeForOptimalDisplay().width() - bounds().width(), 0)),
+    min(contentOffset().y(), max(minimalSizeForOptimalDisplay().height() - bounds().height(), 0))
   ));
 }
 
@@ -92,11 +100,7 @@ void ScrollView::layoutSubviews() {
   KDPoint absoluteOffset = contentOffset().opposite().translatedBy(KDPoint(m_leftMargin, m_topMargin));
   KDRect contentFrame = KDRect(absoluteOffset, contentSize());
   m_contentView->setFrame(contentFrame);
-  KDSize content(
-    m_contentView->bounds().width() + m_leftMargin + m_rightMargin,
-    m_contentView->bounds().height() + m_topMargin + m_bottomMargin
-  );
-  decorator()->layoutIndicators(content, contentOffset(), m_frame.size());
+  decorator()->layoutIndicators(minimalSizeForOptimalDisplay(), contentOffset(), m_frame.size());
 }
 
 void ScrollView::setContentOffset(KDPoint offset, bool forceRelayout) {

--- a/escher/src/scroll_view.cpp
+++ b/escher/src/scroll_view.cpp
@@ -14,6 +14,7 @@ ScrollView::ScrollView(View * contentView, ScrollViewDataSource * dataSource) :
   m_rightMargin(0),
   m_bottomMargin(0),
   m_leftMargin(0),
+  m_innerView(this),
   m_decoratorType(Decorator::Type::Bars),
   m_decorator(),
   m_barDecorator(),
@@ -40,19 +41,6 @@ ScrollView::Decorator * ScrollView::decorator() {
       assert(m_decoratorType == Decorator::Type::None);
       return &m_decorator;
   }
-}
-
-void ScrollView::drawRect(KDContext * ctx, KDRect rect) const {
-  KDCoordinate height = bounds().height();
-  KDCoordinate width = bounds().width();
-  KDCoordinate offsetX = contentOffset().x();
-  KDCoordinate offsetY = contentOffset().y();
-  KDCoordinate contentHeight = m_contentView->bounds().height();
-  KDCoordinate contentWidth = m_contentView->bounds().width();
-  ctx->fillRect(KDRect(0, 0, width, m_topMargin-offsetY), m_backgroundColor);
-  ctx->fillRect(KDRect(0, contentHeight+m_topMargin-offsetY, width, height - contentHeight - m_topMargin + offsetY), m_backgroundColor);
-  ctx->fillRect(KDRect(0, 0, m_leftMargin-offsetX, height), m_backgroundColor);
-  ctx->fillRect(KDRect(contentWidth + m_leftMargin - offsetX, 0, width - contentWidth - m_leftMargin + offsetX, height), m_backgroundColor);
 }
 
 void ScrollView::scrollToContentPoint(KDPoint p, bool allowOverscroll) {
@@ -100,6 +88,7 @@ KDRect ScrollView::visibleContentRect() {
 }
 
 void ScrollView::layoutSubviews() {
+  m_innerView.setFrame(bounds());
   KDPoint absoluteOffset = contentOffset().opposite().translatedBy(KDPoint(m_leftMargin, m_topMargin));
   KDRect contentFrame = KDRect(absoluteOffset, contentSize());
   m_contentView->setFrame(contentFrame);
@@ -114,6 +103,19 @@ void ScrollView::setContentOffset(KDPoint offset, bool forceRelayout) {
   if (m_dataSource->setOffset(offset) || forceRelayout) {
     layoutSubviews();
   }
+}
+
+void ScrollView::InnerView::drawRect(KDContext * ctx, KDRect rect) const {
+  KDCoordinate height = bounds().height();
+  KDCoordinate width = bounds().width();
+  KDCoordinate offsetX = m_scrollView->contentOffset().x();
+  KDCoordinate offsetY = m_scrollView->contentOffset().y();
+  KDCoordinate contentHeight = m_scrollView->m_contentView->bounds().height();
+  KDCoordinate contentWidth = m_scrollView->m_contentView->bounds().width();
+  ctx->fillRect(KDRect(0, 0, width, m_scrollView->m_topMargin-offsetY), m_scrollView->m_backgroundColor);
+  ctx->fillRect(KDRect(0, contentHeight+m_scrollView->m_topMargin-offsetY, width, height - contentHeight - m_scrollView->m_topMargin + offsetY), m_scrollView->m_backgroundColor);
+  ctx->fillRect(KDRect(0, 0, m_scrollView->m_leftMargin-offsetX, height), m_scrollView->m_backgroundColor);
+  ctx->fillRect(KDRect(contentWidth + m_scrollView->m_leftMargin - offsetX, 0, width - contentWidth - m_scrollView->m_leftMargin + offsetX, height), m_scrollView->m_backgroundColor);
 }
 
 ScrollView::BarDecorator::BarDecorator() :

--- a/escher/src/scroll_view.cpp
+++ b/escher/src/scroll_view.cpp
@@ -18,7 +18,6 @@ ScrollView::ScrollView(View * contentView, ScrollViewDataSource * dataSource) :
   m_decorator(),
   m_barDecorator(),
   m_arrowDecorator(),
-  m_colorsBackground(true),
   m_backgroundColor(Palette::WallScreen)
 {
   assert(m_dataSource != nullptr);
@@ -44,9 +43,6 @@ ScrollView::Decorator * ScrollView::decorator() {
 }
 
 void ScrollView::drawRect(KDContext * ctx, KDRect rect) const {
-  if (!m_colorsBackground) {
-    return;
-  }
   KDCoordinate height = bounds().height();
   KDCoordinate width = bounds().width();
   KDCoordinate offsetX = contentOffset().x();

--- a/escher/src/scroll_view.cpp
+++ b/escher/src/scroll_view.cpp
@@ -10,8 +10,8 @@ ScrollView::ScrollView(View * contentView, ScrollViewDataSource * dataSource) :
   View(),
   m_contentView(contentView),
   m_dataSource(dataSource),
-  m_verticalScrollIndicator(ScrollViewIndicator::Direction::Vertical),
-  m_horizontalScrollIndicator(ScrollViewIndicator::Direction::Horizontal),
+  m_verticalScrollIndicator(),
+  m_horizontalScrollIndicator(),
   m_topMargin(0),
   m_rightMargin(0),
   m_bottomMargin(0),
@@ -42,7 +42,10 @@ View * ScrollView::subviewAtIndex(int index) {
   if (m_showsIndicators) {
     switch (index) {
       case 1:
-        return m_horizontalScrollIndicator.visible() ? &m_horizontalScrollIndicator : &m_verticalScrollIndicator;
+        if (m_horizontalScrollIndicator.visible()) {
+          return &m_horizontalScrollIndicator;
+        }
+        return &m_verticalScrollIndicator;
       case 2:
         return &m_verticalScrollIndicator;
     }

--- a/escher/src/scroll_view.cpp
+++ b/escher/src/scroll_view.cpp
@@ -148,17 +148,17 @@ KDCoordinate ScrollView::maxContentHeightDisplayableWithoutScrolling() {
 ScrollView::Decorator::Decorator() :
   m_verticalBar(),
   m_horizontalBar(),
-  m_indicatorThickness(20)
+  m_barsFrameBreadth(20)
 {
 }
 
 void ScrollView::Decorator::layoutIndicators(KDSize content, KDPoint offset, KDSize frame) {
-  KDCoordinate hBarFrameBreadth = m_indicatorThickness * m_horizontalBar.update(
+  KDCoordinate hBarFrameBreadth = m_barsFrameBreadth * m_horizontalBar.update(
     content.width(),
     offset.x(),
     frame.width()
   );
-  KDCoordinate vBarFrameBreadth = m_indicatorThickness * m_verticalBar.update(
+  KDCoordinate vBarFrameBreadth = m_barsFrameBreadth * m_verticalBar.update(
     content.height(),
     offset.y(),
     frame.height()

--- a/escher/src/scroll_view.cpp
+++ b/escher/src/scroll_view.cpp
@@ -153,30 +153,26 @@ ScrollView::Decorator::Decorator() :
 }
 
 void ScrollView::Decorator::layoutIndicators(KDSize content, KDPoint offset, KDSize frame) {
-  m_horizontalBar.update(
+  KDCoordinate hBarFrameBreadth = m_indicatorThickness * m_horizontalBar.update(
     content.width(),
     offset.x(),
     frame.width()
   );
-  m_verticalBar.update(
+  KDCoordinate vBarFrameBreadth = m_indicatorThickness * m_verticalBar.update(
     content.height(),
     offset.y(),
     frame.height()
   );
   /* If the two indicators are visible, we leave an empty rectangle in the right
    * bottom corner. Otherwise, the only indicator uses all the height/width. */
-  if (m_verticalBar.visible()) {
-    m_verticalBar.setFrame(KDRect(
-      frame.width() - m_indicatorThickness, 0,
-      m_indicatorThickness, frame.height() - m_horizontalBar.visible() * m_indicatorThickness
-    ));
-  }
-  if (m_horizontalBar.visible()) {
-    m_horizontalBar.setFrame(KDRect(
-      0, frame.height() - m_indicatorThickness,
-      frame.width() - m_verticalBar.visible() * m_indicatorThickness, m_indicatorThickness
-    ));
-  }
+  m_verticalBar.setFrame(KDRect(
+    frame.width() - vBarFrameBreadth, 0,
+    vBarFrameBreadth, frame.height() - hBarFrameBreadth
+  ));
+  m_horizontalBar.setFrame(KDRect(
+    0, frame.height() - hBarFrameBreadth,
+    frame.width() - vBarFrameBreadth, hBarFrameBreadth
+  ));
 }
 
 #if ESCHER_VIEW_LOGGING

--- a/escher/src/scroll_view.cpp
+++ b/escher/src/scroll_view.cpp
@@ -18,7 +18,6 @@ ScrollView::ScrollView(View * contentView, ScrollViewDataSource * dataSource) :
   m_decorator(),
   m_barDecorator(),
   m_arrowDecorator(),
-  m_showsIndicators(true),
   m_colorsBackground(true),
   m_backgroundColor(Palette::WallScreen)
 {
@@ -42,24 +41,6 @@ ScrollView::Decorator * ScrollView::decorator() {
       assert(m_decoratorType == Decorator::Type::None);
       return &m_decorator;
   }
-}
-
-int ScrollView::numberOfSubviews() const {
-  int result = 1;
-  if (m_showsIndicators) {
-    result += const_cast<ScrollView *>(this)->decorator()->numberOfIndicators();
-  }
-  return result;
-}
-
-View * ScrollView::subviewAtIndex(int index) {
-  if (index == 0) {
-    return m_contentView;
-  }
-  if (m_showsIndicators) {
-    return decorator()->indicatorAtIndex(index);
-  }
-  return nullptr;
 }
 
 void ScrollView::drawRect(KDContext * ctx, KDRect rect) const {
@@ -133,13 +114,11 @@ void ScrollView::layoutSubviews() {
   KDPoint absoluteOffset = contentOffset().opposite().translatedBy(KDPoint(m_leftMargin, m_topMargin));
   KDRect contentFrame = KDRect(absoluteOffset, m_contentView->bounds().size());
   m_contentView->setFrame(contentFrame);
-  if (m_showsIndicators) {
-    KDSize content(
-      m_contentView->bounds().width() + m_leftMargin + m_rightMargin,
-      m_contentView->bounds().height() + m_topMargin + m_bottomMargin
-    );
-    decorator()->layoutIndicators(content, contentOffset(), m_frame.size());
-  }
+  KDSize content(
+    m_contentView->bounds().width() + m_leftMargin + m_rightMargin,
+    m_contentView->bounds().height() + m_topMargin + m_bottomMargin
+  );
+  decorator()->layoutIndicators(content, contentOffset(), m_frame.size());
 }
 
 KDSize ScrollView::contentSize() {

--- a/escher/src/scroll_view.cpp
+++ b/escher/src/scroll_view.cpp
@@ -145,14 +145,14 @@ KDCoordinate ScrollView::maxContentHeightDisplayableWithoutScrolling() {
   return m_frame.height() - m_topMargin - m_bottomMargin;
 }
 
-ScrollView::Decorator::Decorator() :
+ScrollView::BarDecorator::BarDecorator() :
   m_verticalBar(),
   m_horizontalBar(),
   m_barsFrameBreadth(20)
 {
 }
 
-void ScrollView::Decorator::layoutIndicators(KDSize content, KDPoint offset, KDSize frame) {
+void ScrollView::BarDecorator::layoutIndicators(KDSize content, KDPoint offset, KDSize frame) {
   KDCoordinate hBarFrameBreadth = m_barsFrameBreadth * m_horizontalBar.update(
     content.width(),
     offset.x(),
@@ -175,7 +175,7 @@ void ScrollView::Decorator::layoutIndicators(KDSize content, KDPoint offset, KDS
   ));
 }
 
-ScrollView::DecoratorV2::DecoratorV2() :
+ScrollView::ArrowDecorator::ArrowDecorator() :
   m_topArrow(ScrollViewArrow::Side::Top),
   m_rightArrow(ScrollViewArrow::Side::Right),
   m_bottomArrow(ScrollViewArrow::Side::Bottom),
@@ -183,7 +183,7 @@ ScrollView::DecoratorV2::DecoratorV2() :
 {
 }
 
-void ScrollView::DecoratorV2::layoutIndicators(KDSize content, KDPoint offset, KDSize frame) {
+void ScrollView::ArrowDecorator::layoutIndicators(KDSize content, KDPoint offset, KDSize frame) {
   KDSize arrowSize = KDFont::LargeFont->glyphSize();
   KDCoordinate topArrowFrameBreadth = arrowSize.height() * m_topArrow.update(0 < offset.y());
   KDCoordinate rightArrowFrameBreadth = arrowSize.width() * m_rightArrow.update(offset.x() + frame.width() < content.width());

--- a/escher/src/scroll_view.cpp
+++ b/escher/src/scroll_view.cpp
@@ -152,24 +152,6 @@ ScrollView::Decorator::Decorator() :
 {
 }
 
-int ScrollView::Decorator::numberOfIndicators() {
-  return m_verticalBar.visible() + m_horizontalBar.visible();
-}
-
-View * ScrollView::Decorator::indicatorAtIndex(int index) {
-  switch (index) {
-    case 1:
-      if (m_horizontalBar.visible()) {
-        return &m_horizontalBar;
-      } else {
-        return &m_verticalBar;
-      }
-    case 2:
-      return &m_verticalBar;
-  }
-  return nullptr;
-}
-
 void ScrollView::Decorator::layoutIndicators(KDSize content, KDPoint offset, KDSize frame) {
   m_horizontalBar.update(
     content.width(),

--- a/escher/src/scroll_view.cpp
+++ b/escher/src/scroll_view.cpp
@@ -83,15 +83,10 @@ void ScrollView::scrollToContentPoint(KDPoint p, bool allowOverscroll) {
   }
 
   /* Handle cases when the size of the view has decreased. */
-  KDCoordinate contentOffsetX = contentOffset().x();
-  KDCoordinate contentOffsetY = contentOffset().y();
-  if (maxContentHeightDisplayableWithoutScrolling() > contentSize().height()-contentOffsetY) {
-    contentOffsetY = contentSize().height() > maxContentHeightDisplayableWithoutScrolling() ? contentSize().height()-maxContentHeightDisplayableWithoutScrolling() : 0;
-  }
-  if (maxContentWidthDisplayableWithoutScrolling() > contentSize().width()-contentOffsetX) {
-    contentOffsetX = contentSize().width() > maxContentWidthDisplayableWithoutScrolling() ? contentSize().width()-maxContentWidthDisplayableWithoutScrolling() : 0;
-  }
-  setContentOffset(KDPoint(contentOffsetX, contentOffsetY));
+  setContentOffset(KDPoint(
+    min(contentOffset().x(), max(contentSize().width() - maxContentWidthDisplayableWithoutScrolling(), 0)),
+    min(contentOffset().y(), max(contentSize().height() - maxContentHeightDisplayableWithoutScrolling(), 0))
+  ));
 }
 
 void ScrollView::scrollToContentRect(KDRect rect, bool allowOverscroll) {

--- a/escher/src/scroll_view.cpp
+++ b/escher/src/scroll_view.cpp
@@ -130,6 +130,16 @@ ScrollView::BarDecorator::BarDecorator() :
 {
 }
 
+View * ScrollView::BarDecorator::indicatorAtIndex(int index) {
+  switch(index) {
+    case 1:
+      return &m_verticalBar;
+    default:
+      assert(index == 2);
+      return &m_horizontalBar;
+  }
+}
+
 KDRect ScrollView::BarDecorator::layoutIndicators(KDSize content, KDPoint offset, KDRect frame) {
   KDCoordinate hBarFrameBreadth = m_barsFrameBreadth * m_horizontalBar.update(
     content.width(),
@@ -160,6 +170,20 @@ ScrollView::ArrowDecorator::ArrowDecorator() :
   m_bottomArrow(ScrollViewArrow::Side::Bottom),
   m_leftArrow(ScrollViewArrow::Side::Left)
 {
+}
+
+View * ScrollView::ArrowDecorator::indicatorAtIndex(int index) {
+  switch(index) {
+    case 1:
+      return &m_topArrow;
+    case 2:
+      return &m_rightArrow;
+    case 3:
+      return &m_bottomArrow;
+    default:
+      assert(index == 4);
+      return &m_leftArrow;
+  }
 }
 
 KDRect ScrollView::ArrowDecorator::layoutIndicators(KDSize content, KDPoint offset, KDRect frame) {
@@ -193,8 +217,8 @@ KDRect ScrollView::ArrowDecorator::layoutIndicators(KDSize content, KDPoint offs
 }
 
 void ScrollView::ArrowDecorator::setBackgroundColor(KDColor c) {
-  for (int i = 0; i < numberOfIndicators(); i++) {
-    (&m_topArrow + i)->setBackgroundColor(c);
+  for (int index = 1; index <= numberOfIndicators(); index++) {
+    static_cast<ScrollViewArrow *>(indicatorAtIndex(index))->setBackgroundColor(c);
   }
 }
 

--- a/escher/src/scroll_view.cpp
+++ b/escher/src/scroll_view.cpp
@@ -198,8 +198,20 @@ void ScrollView::ArrowDecorator::setBackgroundColor(KDColor c) {
   }
 }
 
+ScrollView::Decorators::Decorators() {
+  /* We need to initiate the Union at construction to avoid destructing an
+   * uninitialized object when changing the decorator type. */
+  new (this) Decorator();
+}
+
+ScrollView::Decorators::~Decorators() {
+  activeDecorator()->~Decorator();
+}
+
 void ScrollView::Decorators::setActiveDecorator(Decorator::Type t) {
-  /* We do NOT need to destroy the previous decorator because they don't have a destructor */
+  /* Decorator destructor is virtual so calling ~Decorator() on a Decorator
+   * pointer will call the appropriate destructor. */
+  activeDecorator()->~Decorator();
   switch (t) {
     case Decorator::Type::Bars:
       new (&m_bars) BarDecorator();

--- a/escher/src/scroll_view_indicator.cpp
+++ b/escher/src/scroll_view_indicator.cpp
@@ -6,49 +6,20 @@ extern "C" {
 
 ScrollViewIndicator::ScrollViewIndicator() :
   View(),
-  m_offset(0),
-  m_visibleLength(0),
-  m_indicatorColor(Palette::GreyDark),
-  m_backgroundColor(Palette::GreyMiddle),
+  m_color(Palette::GreyDark),
   m_margin(14)
 {
 }
 
-void ScrollViewHorizontalIndicator::drawRect(KDContext * ctx, KDRect rect) const {
-  ctx->fillRect(
-    KDRect(
-      m_margin, (m_frame.height() - k_indicatorThickness)/2,
-      totalLength(), k_indicatorThickness
-    ),
-    m_backgroundColor
-  );
-  ctx->fillRect(
-    KDRect(
-      m_margin+m_offset*totalLength(), (m_frame.height() - k_indicatorThickness)/2,
-      m_visibleLength*totalLength(), k_indicatorThickness
-    ),
-    m_indicatorColor
-  );
+ScrollViewBar::ScrollViewBar() :
+  ScrollViewIndicator(),
+  m_offset(0),
+  m_visibleLength(0),
+  m_trackColor(Palette::GreyMiddle)
+{
 }
 
-void ScrollViewVerticalIndicator::drawRect(KDContext * ctx, KDRect rect) const {
-  ctx->fillRect(
-    KDRect(
-      (m_frame.width() - k_indicatorThickness)/2, m_margin,
-      k_indicatorThickness, totalLength()
-    ),
-    m_backgroundColor
-  );
-  ctx->fillRect(
-    KDRect(
-      (m_frame.width() - k_indicatorThickness)/2, m_margin+m_offset*totalLength(),
-      k_indicatorThickness, m_visibleLength*totalLength()
-    ),
-    m_indicatorColor
-  );
-}
-
-void ScrollViewIndicator::update(KDCoordinate totalContentLength, KDCoordinate contentOffset, KDCoordinate visibleContentLength) {
+void ScrollViewBar::update(KDCoordinate totalContentLength, KDCoordinate contentOffset, KDCoordinate visibleContentLength) {
   float offset = contentOffset;
   float visibleLength = visibleContentLength;
   offset = offset / totalContentLength;
@@ -58,6 +29,40 @@ void ScrollViewIndicator::update(KDCoordinate totalContentLength, KDCoordinate c
     m_visibleLength = visibleLength;
     markRectAsDirty(bounds());
   }
+}
+
+void ScrollViewHorizontalBar::drawRect(KDContext * ctx, KDRect rect) const {
+  ctx->fillRect(
+    KDRect(
+      m_margin, (m_frame.height() - k_indicatorThickness)/2,
+      totalLength(), k_indicatorThickness
+    ),
+    m_trackColor
+  );
+  ctx->fillRect(
+    KDRect(
+      m_margin+m_offset*totalLength(), (m_frame.height() - k_indicatorThickness)/2,
+      m_visibleLength*totalLength(), k_indicatorThickness
+    ),
+    m_color
+  );
+}
+
+void ScrollViewVerticalBar::drawRect(KDContext * ctx, KDRect rect) const {
+  ctx->fillRect(
+    KDRect(
+      (m_frame.width() - k_indicatorThickness)/2, m_margin,
+      k_indicatorThickness, totalLength()
+    ),
+    m_trackColor
+  );
+  ctx->fillRect(
+    KDRect(
+      (m_frame.width() - k_indicatorThickness)/2, m_margin+m_offset*totalLength(),
+      k_indicatorThickness, m_visibleLength*totalLength()
+    ),
+    m_color
+  );
 }
 
 #if ESCHER_VIEW_LOGGING

--- a/escher/src/scroll_view_indicator.cpp
+++ b/escher/src/scroll_view_indicator.cpp
@@ -4,9 +4,8 @@ extern "C" {
 #include <assert.h>
 }
 
-ScrollViewIndicator::ScrollViewIndicator(ScrollViewIndicator::Direction direction) :
+ScrollViewIndicator::ScrollViewIndicator() :
   View(),
-  m_direction(direction),
   m_offset(0),
   m_visibleLength(0),
   m_indicatorColor(Palette::GreyDark),
@@ -15,27 +14,38 @@ ScrollViewIndicator::ScrollViewIndicator(ScrollViewIndicator::Direction directio
 {
 }
 
-void ScrollViewIndicator::drawRect(KDContext * ctx, KDRect rect) const {
-  KDRect frame = KDRectZero;
-  if (m_direction == Direction::Horizontal) {
-    frame = KDRect(m_margin, (m_frame.height() - k_indicatorThickness)/2,
-        totalLength(), k_indicatorThickness);
-  } else {
-    assert(m_direction == Direction::Vertical);
-    frame = KDRect((m_frame.width() - k_indicatorThickness)/2, m_margin,
-        k_indicatorThickness, totalLength());
-  }
-  ctx->fillRect(frame, m_backgroundColor);
-  KDRect indicatorFrame = KDRectZero;
-  if (m_direction == Direction::Horizontal) {
-    indicatorFrame = KDRect(m_margin+m_offset*totalLength(), (m_frame.height() - k_indicatorThickness)/2,
-        m_visibleLength*totalLength(), k_indicatorThickness);
-  } else {
-    assert(m_direction == Direction::Vertical);
-    indicatorFrame = KDRect((m_frame.width() - k_indicatorThickness)/2, m_margin+m_offset*totalLength(),
-        k_indicatorThickness, m_visibleLength*totalLength());
-  }
-  ctx->fillRect(indicatorFrame, m_indicatorColor);
+void ScrollViewHorizontalIndicator::drawRect(KDContext * ctx, KDRect rect) const {
+  ctx->fillRect(
+    KDRect(
+      m_margin, (m_frame.height() - k_indicatorThickness)/2,
+      totalLength(), k_indicatorThickness
+    ),
+    m_backgroundColor
+  );
+  ctx->fillRect(
+    KDRect(
+      m_margin+m_offset*totalLength(), (m_frame.height() - k_indicatorThickness)/2,
+      m_visibleLength*totalLength(), k_indicatorThickness
+    ),
+    m_indicatorColor
+  );
+}
+
+void ScrollViewVerticalIndicator::drawRect(KDContext * ctx, KDRect rect) const {
+  ctx->fillRect(
+    KDRect(
+      (m_frame.width() - k_indicatorThickness)/2, m_margin,
+      k_indicatorThickness, totalLength()
+    ),
+    m_backgroundColor
+  );
+  ctx->fillRect(
+    KDRect(
+      (m_frame.width() - k_indicatorThickness)/2, m_margin+m_offset*totalLength(),
+      k_indicatorThickness, m_visibleLength*totalLength()
+    ),
+    m_indicatorColor
+  );
 }
 
 void ScrollViewIndicator::update(KDCoordinate totalContentLength, KDCoordinate contentOffset, KDCoordinate visibleContentLength) {

--- a/escher/src/scroll_view_indicator.cpp
+++ b/escher/src/scroll_view_indicator.cpp
@@ -7,8 +7,8 @@ extern "C" {
 ScrollViewIndicator::ScrollViewIndicator(ScrollViewIndicator::Direction direction) :
   View(),
   m_direction(direction),
-  m_start(0),
-  m_end(0),
+  m_offset(0),
+  m_visibleLength(0),
   m_indicatorColor(Palette::GreyDark),
   m_backgroundColor(Palette::GreyMiddle),
   m_margin(14)
@@ -19,52 +19,37 @@ void ScrollViewIndicator::drawRect(KDContext * ctx, KDRect rect) const {
   KDRect frame = KDRectZero;
   if (m_direction == Direction::Horizontal) {
     frame = KDRect(m_margin, (m_frame.height() - k_indicatorThickness)/2,
-        m_frame.width() - 2*m_margin, k_indicatorThickness);
+        totalLength(), k_indicatorThickness);
   } else {
     assert(m_direction == Direction::Vertical);
     frame = KDRect((m_frame.width() - k_indicatorThickness)/2, m_margin,
-        k_indicatorThickness, m_frame.height() - 2*m_margin);
+        k_indicatorThickness, totalLength());
   }
   ctx->fillRect(frame, m_backgroundColor);
   KDRect indicatorFrame = KDRectZero;
   if (m_direction == Direction::Horizontal) {
-    KDCoordinate indicatorWidth = m_frame.width() - 2*m_margin;
-    indicatorFrame = KDRect(m_margin+m_start*indicatorWidth, (m_frame.height() - k_indicatorThickness)/2,
-        (m_end-m_start)*indicatorWidth, k_indicatorThickness);
+    indicatorFrame = KDRect(m_margin+m_offset*totalLength(), (m_frame.height() - k_indicatorThickness)/2,
+        m_visibleLength*totalLength(), k_indicatorThickness);
   } else {
     assert(m_direction == Direction::Vertical);
-    KDCoordinate indicatorHeight = m_frame.height() - 2*m_margin;
-    indicatorFrame = KDRect((m_frame.width() - k_indicatorThickness)/2, m_margin+m_start*indicatorHeight,
-        k_indicatorThickness, (m_end-m_start)*indicatorHeight);
+    indicatorFrame = KDRect((m_frame.width() - k_indicatorThickness)/2, m_margin+m_offset*totalLength(),
+        k_indicatorThickness, m_visibleLength*totalLength());
   }
   ctx->fillRect(indicatorFrame, m_indicatorColor);
 }
 
-float ScrollViewIndicator::start() const {
-  return m_start;
-}
-
-void ScrollViewIndicator::setStart(float start) {
-  if (m_start != start) {
-    m_start = start;
+void ScrollViewIndicator::update(KDCoordinate totalContentLength, KDCoordinate contentOffset, KDCoordinate visibleContentLength) {
+  float offset = contentOffset;
+  float visibleLength = visibleContentLength;
+  offset = offset / totalContentLength;
+  visibleLength = visibleLength / totalContentLength;
+  if (m_offset != offset || m_visibleLength != visibleLength) {
+    m_offset = offset;
+    m_visibleLength = visibleLength;
     markRectAsDirty(bounds());
   }
 }
 
-float ScrollViewIndicator::end() const {
-  return m_end;
-}
-
-void ScrollViewIndicator::setEnd(float end) {
-  if (m_end != end) {
-    m_end = end;
-    markRectAsDirty(bounds());
-  }
-}
-
-KDRect ScrollViewIndicator::frame() {
-  return m_frame;
-}
 #if ESCHER_VIEW_LOGGING
 const char * ScrollViewIndicator::className() const {
   return "ScrollViewIndicator";
@@ -72,7 +57,7 @@ const char * ScrollViewIndicator::className() const {
 
 void ScrollViewIndicator::logAttributes(std::ostream &os) const {
   View::logAttributes(os);
-  os << " start=\"" << m_start << "\"";
-  os << " end=\"" << m_end << "\"";
+  os << " offset=\"" << m_offset << "\"";
+  os << " visibleLength=\"" << m_visibleLength << "\"";
 }
 #endif

--- a/escher/src/scroll_view_indicator.cpp
+++ b/escher/src/scroll_view_indicator.cpp
@@ -72,6 +72,30 @@ void ScrollViewVerticalBar::drawRect(KDContext * ctx, KDRect rect) const {
   );
 }
 
+ScrollViewArrow::ScrollViewArrow(Side side) :
+  m_visible(false),
+  m_arrow(side)
+{
+}
+
+bool ScrollViewArrow::update(bool visible) {
+  if (m_visible != visible) {
+    markRectAsDirty(bounds());
+  }
+  m_visible = visible;
+  return visible;
+}
+
+void ScrollViewArrow::drawRect(KDContext * ctx, KDRect rect) const {
+  ctx->fillRect(bounds(), m_backgroundColor);
+  KDSize arrowSize = KDFont::LargeFont->glyphSize();
+  const KDPoint arrowAlign = KDPoint(
+    (m_arrow == Top || m_arrow == Bottom) * (m_frame.width() - arrowSize.width()) / 2,
+    (m_arrow == Left || m_arrow == Right) * (m_frame.height() - arrowSize.height()) / 2
+  );
+  ctx->drawString(&m_arrow, arrowAlign, KDFont::LargeFont, m_color, m_backgroundColor, m_visible);
+}
+
 #if ESCHER_VIEW_LOGGING
 const char * ScrollViewIndicator::className() const {
   return "ScrollViewIndicator";

--- a/escher/src/scroll_view_indicator.cpp
+++ b/escher/src/scroll_view_indicator.cpp
@@ -19,7 +19,7 @@ ScrollViewBar::ScrollViewBar() :
 {
 }
 
-void ScrollViewBar::update(KDCoordinate totalContentLength, KDCoordinate contentOffset, KDCoordinate visibleContentLength) {
+bool ScrollViewBar::update(KDCoordinate totalContentLength, KDCoordinate contentOffset, KDCoordinate visibleContentLength) {
   float offset = contentOffset;
   float visibleLength = visibleContentLength;
   offset = offset / totalContentLength;
@@ -29,6 +29,7 @@ void ScrollViewBar::update(KDCoordinate totalContentLength, KDCoordinate content
     m_visibleLength = visibleLength;
     markRectAsDirty(bounds());
   }
+  return visible();
 }
 
 void ScrollViewHorizontalBar::drawRect(KDContext * ctx, KDRect rect) const {

--- a/escher/src/scroll_view_indicator.cpp
+++ b/escher/src/scroll_view_indicator.cpp
@@ -3,6 +3,7 @@
 extern "C" {
 #include <assert.h>
 }
+#include <cmath>
 
 ScrollViewIndicator::ScrollViewIndicator() :
   View(),
@@ -46,7 +47,7 @@ void ScrollViewHorizontalBar::drawRect(KDContext * ctx, KDRect rect) const {
   ctx->fillRect(
     KDRect(
       m_margin+m_offset*totalLength(), (m_frame.height() - k_indicatorThickness)/2,
-      m_visibleLength*totalLength(), k_indicatorThickness
+      std::ceil(m_visibleLength*totalLength()), k_indicatorThickness
     ),
     m_color
   );
@@ -66,7 +67,7 @@ void ScrollViewVerticalBar::drawRect(KDContext * ctx, KDRect rect) const {
   ctx->fillRect(
     KDRect(
       (m_frame.width() - k_indicatorThickness)/2, m_margin+m_offset*totalLength(),
-      k_indicatorThickness, m_visibleLength*totalLength()
+      k_indicatorThickness, std::ceil(m_visibleLength*totalLength())
     ),
     m_color
   );

--- a/escher/src/scroll_view_indicator.cpp
+++ b/escher/src/scroll_view_indicator.cpp
@@ -32,6 +32,9 @@ void ScrollViewBar::update(KDCoordinate totalContentLength, KDCoordinate content
 }
 
 void ScrollViewHorizontalBar::drawRect(KDContext * ctx, KDRect rect) const {
+  if (!visible()) {
+    return;
+  }
   ctx->fillRect(
     KDRect(
       m_margin, (m_frame.height() - k_indicatorThickness)/2,
@@ -49,6 +52,9 @@ void ScrollViewHorizontalBar::drawRect(KDContext * ctx, KDRect rect) const {
 }
 
 void ScrollViewVerticalBar::drawRect(KDContext * ctx, KDRect rect) const {
+  if (!visible()) {
+    return;
+  }
   ctx->fillRect(
     KDRect(
       (m_frame.width() - k_indicatorThickness)/2, m_margin,

--- a/escher/src/scrollable_view.cpp
+++ b/escher/src/scrollable_view.cpp
@@ -50,10 +50,9 @@ void ScrollableView::reloadScroll(bool forceReLayout) {
   setContentOffset(m_manualScrollingOffset, forceReLayout);
 }
 
-void ScrollableView::layoutSubviews() {
-  KDSize viewSize = contentSize();
-  KDCoordinate viewWidth = max(viewSize.width(), bounds().width() - leftMargin() - rightMargin());
-  KDCoordinate viewHeight = max(viewSize.height(), bounds().height() - topMargin() - bottomMargin());
-  m_contentView->setSize(KDSize(viewWidth, viewHeight));
-  ScrollView::layoutSubviews();
+KDSize ScrollableView::contentSize() const {
+  KDSize viewSize = ScrollView::contentSize();
+  KDCoordinate viewWidth = max(viewSize.width(), maxContentWidthDisplayableWithoutScrolling());
+  KDCoordinate viewHeight = max(viewSize.height(), maxContentHeightDisplayableWithoutScrolling());
+  return KDSize(viewWidth, viewHeight);
 }

--- a/escher/src/scrollable_view.cpp
+++ b/escher/src/scrollable_view.cpp
@@ -7,7 +7,7 @@ ScrollableView::ScrollableView(Responder * parentResponder, View * view, ScrollV
   ScrollView(view, dataSource),
   m_manualScrollingOffset(KDPointZero)
 {
-  setShowsIndicators(false);
+  setDecoratorType(ScrollView::Decorator::Type::None);
   setColorsBackground(false);
 }
 

--- a/escher/src/scrollable_view.cpp
+++ b/escher/src/scrollable_view.cpp
@@ -8,7 +8,6 @@ ScrollableView::ScrollableView(Responder * parentResponder, View * view, ScrollV
   m_manualScrollingOffset(KDPointZero)
 {
   setDecoratorType(ScrollView::Decorator::Type::None);
-  setColorsBackground(false);
 }
 
 bool ScrollableView::handleEvent(Ion::Events::Event event) {

--- a/escher/src/scrollable_view.cpp
+++ b/escher/src/scrollable_view.cpp
@@ -19,7 +19,7 @@ bool ScrollableView::handleEvent(Ion::Events::Event event) {
     }
   }
   if (event == Ion::Events::Right) {
-    KDCoordinate movementToEdge =  m_contentView->minimalSizeForOptimalDisplay().width() - bounds().width() - m_manualScrollingOffset.x();
+    KDCoordinate movementToEdge = minimalSizeForOptimalDisplay().width() - bounds().width() - m_manualScrollingOffset.x();
     if (movementToEdge > 0) {
       translation = KDPoint(min(Metric::ScrollStep, movementToEdge), 0);
     }
@@ -31,7 +31,7 @@ bool ScrollableView::handleEvent(Ion::Events::Event event) {
     }
   }
   if (event == Ion::Events::Down) {
-    KDCoordinate movementToEdge =  m_contentView->minimalSizeForOptimalDisplay().height() - bounds().height() - m_manualScrollingOffset.y();
+    KDCoordinate movementToEdge = minimalSizeForOptimalDisplay().height() - bounds().height() - m_manualScrollingOffset.y();
     if (movementToEdge > 0) {
       translation = KDPoint(0, min(Metric::ScrollStep, movementToEdge));
     }

--- a/escher/src/selectable_table_view.cpp
+++ b/escher/src/selectable_table_view.cpp
@@ -1,5 +1,6 @@
 #include <escher/selectable_table_view.h>
 #include <escher/clipboard.h>
+#include <escher/metric.h>
 #include <assert.h>
 
 SelectableTableView::SelectableTableView(Responder * parentResponder, TableViewDataSource * dataSource, SelectableTableViewDataSource * selectionDataSource, SelectableTableViewDelegate * delegate) :
@@ -8,8 +9,13 @@ SelectableTableView::SelectableTableView(Responder * parentResponder, TableViewD
   m_selectionDataSource(selectionDataSource),
   m_delegate(delegate)
 {
-  setCommonMargins();
   assert(m_selectionDataSource != nullptr);
+  setMargins(
+    Metric::CommonTopMargin,
+    Metric::CommonRightMargin,
+    Metric::CommonBottomMargin,
+    Metric::CommonLeftMargin
+  );
 }
 
 int SelectableTableView::selectedRow() {

--- a/escher/src/stack_view_controller.cpp
+++ b/escher/src/stack_view_controller.cpp
@@ -96,6 +96,7 @@ void StackViewController::push(ViewController * vc, KDColor textColor, KDColor b
   Frame frame = Frame(vc, textColor, backgroundColor, separatorColor);
   /* Add the frame to the model */
   pushModel(frame);
+  frame.viewController()->initView();
   if (!m_isVisible) {
     return;
   }
@@ -154,6 +155,10 @@ bool StackViewController::handleEvent(Ion::Events::Event event) {
 
 View * StackViewController::view() {
   return &m_view;
+}
+
+void StackViewController::initView() {
+  m_childrenFrame[0].viewController()->initView();
 }
 
 void StackViewController::viewWillAppear() {

--- a/escher/src/tab_view_controller.cpp
+++ b/escher/src/tab_view_controller.cpp
@@ -156,12 +156,14 @@ const char * TabViewController::tabName(uint8_t index) {
   return m_children[index]->title();
 }
 
-void TabViewController::viewWillAppear() {
-  if (m_view.m_tabView.numberOfTabs() != m_numberOfChildren) {
-    for (int i=0; i<m_numberOfChildren; i++) {
-      m_view.m_tabView.addTab(m_children[i]);
-    }
+void TabViewController::initView() {
+  for (int i=0; i<m_numberOfChildren; i++) {
+    m_view.m_tabView.addTab(m_children[i]);
+    m_children[i]->initView();
   }
+}
+
+void TabViewController::viewWillAppear() {
   if (m_dataSource->activeTab() < 0) {
     m_dataSource->setActiveTab(0);
   }

--- a/escher/src/table_view.cpp
+++ b/escher/src/table_view.cpp
@@ -38,12 +38,20 @@ const char * TableView::className() const {
 #endif
 
 void TableView::layoutSubviews() {
-  // We only have to layout our contentView.
-  // We will size it here, and ScrollView::layoutSubviews will position it.
-
-  m_contentView.resizeToFitContent();
-
   ScrollView::layoutSubviews();
+  m_contentView.layoutSubviews();
+  /* FIXME:
+   * On the one hand, ScrollView::layoutSubviews()
+   * calls setFrame(...) over m_contentView,
+   * which typically calls layoutSubviews() over m_contentView.
+   * However, if the frame happens to be unchanged,
+   * setFrame(...) does not call layoutSubviews.
+   * On the other hand, calling only m_contentView.layoutSubviews()
+   * does not relayout ScrollView when the offset
+   * or the content's size changes.
+   * For those reasons, we call both of them explicitly.
+   * Finally, this solution is not optimal at all since
+   * layoutSubviews is called twice over m_contentView. */
 }
 
 void TableView::reloadCellAtLocation(int i, int j) {
@@ -73,13 +81,6 @@ KDCoordinate TableView::ContentView::columnWidth(int i) const {
   int columnWidth = m_dataSource->columnWidth(i);
   columnWidth = columnWidth ? columnWidth : m_tableView->maxContentWidthDisplayableWithoutScrolling();
   return columnWidth;
-}
-
-void TableView::ContentView::resizeToFitContent() {
-  if (!(m_tableView->bounds() == KDRectZero)) {
-    layoutSubviews();
-    setSize(KDSize(width(), height()));
-  }
 }
 
 KDCoordinate TableView::ContentView::height() const {

--- a/escher/src/table_view.cpp
+++ b/escher/src/table_view.cpp
@@ -13,10 +13,6 @@ TableView::TableView(TableViewDataSource * dataSource, ScrollViewDataSource * sc
 {
 }
 
-KDSize TableView::minimalSizeForOptimalDisplay() const {
-  return m_contentView.minimalSizeForOptimalDisplay();
-}
-
 TableViewDataSource * TableView::dataSource() {
   return m_contentView.dataSource();
 }

--- a/escher/src/table_view.cpp
+++ b/escher/src/table_view.cpp
@@ -73,10 +73,14 @@ TableViewDataSource * TableView::ContentView::dataSource() {
   return m_dataSource;
 }
 
-KDCoordinate TableView::ContentView::columnWidth(int i) const {
-  int columnWidth = m_dataSource->columnWidth(i);
+KDRect TableView::ContentView::cellFrame(int i, int j) const {
+  KDCoordinate columnWidth = m_dataSource->columnWidth(i);
   columnWidth = columnWidth ? columnWidth : m_tableView->maxContentWidthDisplayableWithoutScrolling();
-  return columnWidth;
+  return KDRect(
+    m_dataSource->cumulatedWidthFromIndex(i), m_dataSource->cumulatedHeightFromIndex(j),
+    columnWidth + m_horizontalCellOverlap,
+    m_dataSource->rowHeight(j) + m_verticalCellOverlap
+  );
 }
 
 KDCoordinate TableView::ContentView::height() const {
@@ -90,8 +94,7 @@ KDCoordinate TableView::ContentView::width() const {
 }
 
 void TableView::ContentView::scrollToCell(int x, int y) const {
-  KDRect cellRect = KDRect(m_dataSource->cumulatedWidthFromIndex(x), m_dataSource->cumulatedHeightFromIndex(y), columnWidth(x), m_dataSource->rowHeight(y));
-  m_tableView->scrollToContentRect(cellRect, true);
+  m_tableView->scrollToContentRect(cellFrame(x, y), true);
 }
 
 void TableView::ContentView::reloadCellAtLocation(int i, int j) {
@@ -172,14 +175,7 @@ void TableView::ContentView::layoutSubviews() {
     int i = absoluteColumnNumberFromSubviewIndex(index);
     int j = absoluteRowNumberFromSubviewIndex(index);
     m_dataSource->willDisplayCellAtLocation((HighlightCell *)cell, i, j);
-
-    KDCoordinate rowHeight = m_dataSource->rowHeight(j);
-    KDCoordinate columnWidth = this->columnWidth(i);
-    KDCoordinate verticalOffset = m_dataSource->cumulatedHeightFromIndex(j);
-    KDCoordinate horizontalOffset = m_dataSource->cumulatedWidthFromIndex(i);
-    KDRect cellFrame(horizontalOffset, verticalOffset,
-      columnWidth+m_horizontalCellOverlap, rowHeight+m_verticalCellOverlap);
-    cell->setFrame(cellFrame);
+    cell->setFrame(cellFrame(i,j));
   }
 }
 

--- a/escher/src/table_view.cpp
+++ b/escher/src/table_view.cpp
@@ -34,10 +34,7 @@ const char * TableView::className() const {
 #endif
 
 void TableView::layoutSubviews() {
-  ScrollView::layoutSubviews();
-  m_contentView.layoutSubviews();
-  /* FIXME:
-   * On the one hand, ScrollView::layoutSubviews()
+  /* On the one hand, ScrollView::layoutSubviews()
    * calls setFrame(...) over m_contentView,
    * which typically calls layoutSubviews() over m_contentView.
    * However, if the frame happens to be unchanged,
@@ -46,8 +43,14 @@ void TableView::layoutSubviews() {
    * does not relayout ScrollView when the offset
    * or the content's size changes.
    * For those reasons, we call both of them explicitly.
+   * Besides, one must call layoutSubviews() over
+   * m_contentView first, in order to reload the table's data,
+   * otherwise the table's size might be miscomputed...
+   * FIXME:
    * Finally, this solution is not optimal at all since
    * layoutSubviews is called twice over m_contentView. */
+  m_contentView.layoutSubviews();
+  ScrollView::layoutSubviews();
 }
 
 void TableView::reloadCellAtLocation(int i, int j) {

--- a/escher/src/text_field.cpp
+++ b/escher/src/text_field.cpp
@@ -312,10 +312,6 @@ bool TextField::privateHandleEvent(Ion::Events::Event event) {
   return false;
 }
 
-KDSize TextField::minimalSizeForOptimalDisplay() const {
-  return m_contentView.minimalSizeForOptimalDisplay();
-}
-
 char TextField::XNTChar(char defaultXNTChar) {
   static constexpr struct { const char *name; char xnt; } sFunctions[] = {
     { "diff", 'x' }, { "int", 'x' },

--- a/ion/src/blackbox/compare.cpp
+++ b/ion/src/blackbox/compare.cpp
@@ -13,7 +13,7 @@
  *
  * To compare the versions on a given scenario:
  *      make -j8 PLATFORM=blackbox compare
- *      ./compare path/to/scenario
+ *      ./compare < path/to/scenario
  * To fuzz over scenarios that are in a folder named "tests":
  *      make -j8 PLATFORM=blackbox TOOLCHAIN=afl compare_fuzz
  */


### PR DESCRIPTION
Add arrow indicators to ScrollView, in addition to bar indicators.
Arrow indicators are used in
- ScrollableExpressionView
- ScrollableExactApproximateExpressionsView