### PR TITLE
[apps/shared] Fix ExpressionFieldDelegateApp::layoutFieldDidReceiveEvent

### DIFF
--- a/apps/shared/expression_field_delegate_app.cpp
+++ b/apps/shared/expression_field_delegate_app.cpp
@@ -23,8 +23,14 @@ bool ExpressionFieldDelegateApp::layoutFieldDidReceiveEvent(LayoutField * layout
       layoutField->app()->displayWarning(I18n::Message::SyntaxError);
       return true;
     }
-    char buffer[TextField::maxBufferSize()];
-    int bufferSize = TextField::maxBufferSize();
+    /* An acceptable layout has to be parsable and serialized in a fixed-size
+     * buffer. We check all that here. */
+    /* Step 1: Simple layout serialisation. Resulting texts can be parsed but
+     * not displayed, like:
+     * - 2a
+     * - log_{2}(x) */
+    constexpr int bufferSize = TextField::maxBufferSize();
+    char buffer[bufferSize];
     int length = layoutField->layout().serializeForParsing(buffer, bufferSize);
     if (length >= bufferSize-1) {
       /* If the buffer is totally full, it is VERY likely that writeTextInBuffer
@@ -32,7 +38,24 @@ bool ExpressionFieldDelegateApp::layoutFieldDidReceiveEvent(LayoutField * layout
       displayWarning(I18n::Message::SyntaxError);
       return true;
     }
-    if (!isAcceptableText(buffer)) {
+    // Step 2: Parsing
+    Poincare::Expression e = Poincare::Expression::Parse(buffer);
+    if (e.isUninitialized()) {
+      // Unparsable expression
+      displayWarning(I18n::Message::SyntaxError);
+      return true;
+    }
+    /* Step 3: Expression serialization. Tesulting texts are parseable and
+     * displayable, like:
+     * - 2*a
+     * - log(x,2) */
+    length = e.serialize(buffer, bufferSize, Poincare::Preferences::sharedPreferences()->displayMode());
+    if (length >= bufferSize-1) {
+      // Same comment as before
+      displayWarning(I18n::Message::SyntaxError);
+      return true;
+    }
+    if (!isAcceptableExpression(e)) {
       displayWarning(I18n::Message::SyntaxError);
       return true;
     }


### PR DESCRIPTION
Layouts have two potential serializations. For example,
HorizontalLayout(CharLayout(2), CharLayout(a)) can be serialized as:
"2a" and "2*a". In layoutFieldDidReceiveEvent, we want to check that the
longest serialisation is bounded by maxBufferSize. (We could have used
Layout::serializeParsedExpression but we don't to avoid parsing the
expression twice)