### PR TITLE
[apps/regression] Increase the iterations limit to compute a regression

### DIFF
--- a/apps/regression/model/model.h
+++ b/apps/regression/model/model.h
@@ -47,7 +47,7 @@ private:
   virtual double partialDerivate(double * modelCoefficients, int derivateCoefficientIndex, double x) const = 0;
 
   // Levenberg-Marquardt
-  static constexpr double k_maxIterations = 100;
+  static constexpr double k_maxIterations = 300;
   static constexpr double k_maxMatrixInversionFixIterations = 10;
   static constexpr double k_initialLambda = 0.001;
   static constexpr double k_lambdaFactor = 10;


### PR DESCRIPTION
The exponential regression on the following data now works:
1 120000
3 130000
6 150000
8 160000