### PR TITLE
Secure manual flash

### DIFF
--- a/build/targets.device.mak
+++ b/build/targets.device.mak
@@ -42,9 +42,9 @@ products += $(patsubst %.$(EXE),%.map,$(filter %.$(EXE),$(products)))
 	@echo "DFU     $@"
 	@echo "INFO    About to flash your device. Please plug your device to your computer"
 	@echo "        using an USB cable and press the RESET button the back of your device."
-	@until dfu-util -l | grep "Flash" > /dev/null 2>&1; do sleep 1;done
+	@until dfu-util -l | grep "0483:a291" > /dev/null 2>&1; do sleep 1;done
 	@echo "DFU     $@"
-	$(Q) dfu-util -i 0 -a 0 -s 0x08000000:leave -D $<
+	$(Q) dfu-util -d 0483:a291 -s 0x08000000:leave -D $<
 
 .PHONY: openocd
 openocd:


### PR DESCRIPTION
Detect device using the vendorID:productID description instead of
name "Flash" which may be used by others devices.

Flash using the same descriptor instead of the default interface which can be
already used by an other device.

See issue #974 