### PR TITLE
Fix layout field cursor position

### DIFF
--- a/escher/include/escher/layout_field.h
+++ b/escher/include/escher/layout_field.h
@@ -53,7 +53,7 @@ private:
   static_assert(k_maxNumberOfLayouts == TextField::maxBufferSize(), "Maximal number of layouts in a layout field should be equal to max number of char in text field");
   void scrollRightOfLayout(Poincare::Layout layoutR);
   void scrollToBaselinedRect(KDRect rect, KDCoordinate baseline);
-  void insertLayoutAtCursor(Poincare::Layout layoutR, Poincare::Layout pointedLayout, bool forceCursorRightOfLayout = false);
+  void insertLayoutAtCursor(Poincare::Layout layoutR, Poincare::Expression correspondingExpression, bool forceCursorRightOfLayout = false);
 
   class ContentView : public View {
   public:

--- a/poincare/Makefile
+++ b/poincare/Makefile
@@ -158,6 +158,7 @@ tests += $(addprefix poincare/test/,\
   infinity.cpp\
   integer.cpp\
   layouts.cpp\
+  layout_cursor.cpp\
   logarithm.cpp\
   matrix.cpp\
   multiplication.cpp\

--- a/poincare/include/poincare/condensed_sum_layout.h
+++ b/poincare/include/poincare/condensed_sum_layout.h
@@ -26,9 +26,9 @@ public:
     return SerializationHelper::Prefix(this, buffer, bufferSize, floatDisplayMode, numberOfSignificantDigits, Sum::s_functionHelper.name());
   }
 
-  LayoutNode * layoutToPointWhenInserting() override {
+  LayoutNode * layoutToPointWhenInserting(Expression * correspondingExpression) override {
     assert(false);
-    return nullptr;
+    return this;
   }
 
   // TreeNode

--- a/poincare/include/poincare/fraction_layout.h
+++ b/poincare/include/poincare/fraction_layout.h
@@ -27,7 +27,7 @@ public:
   int leftCollapsingAbsorbingChildIndex() const override { return 0; }
   int rightCollapsingAbsorbingChildIndex() const override { return 1; }
   void didCollapseSiblings(LayoutCursor * cursor) override;
-  LayoutNode * layoutToPointWhenInserting() override;
+  LayoutNode * layoutToPointWhenInserting(Expression * correspondingExpression) override;
   bool canBeOmittedMultiplicationRightFactor() const override { return false; }
   /* WARNING: We need to override this function, else 1/2 3/4 would be
    * serialized as 1/2**3/4, as the two Fraction layouts think their sibling is

--- a/poincare/include/poincare/horizontal_layout.h
+++ b/poincare/include/poincare/horizontal_layout.h
@@ -26,6 +26,7 @@ public:
   void moveCursorRight(LayoutCursor * cursor, bool * shouldRecomputeLayout) override;
   LayoutCursor equivalentCursor(LayoutCursor * cursor) override;
   void deleteBeforeCursor(LayoutCursor * cursor) override;
+  LayoutNode * layoutToPointWhenInserting(Expression * correspondingExpression) override;
   int serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const override;
 
   bool isEmpty() const override { return m_numberOfChildren == 1 && const_cast<HorizontalLayoutNode *>(this)->childAtIndex(0)->isEmpty(); }

--- a/poincare/include/poincare/integral_layout.h
+++ b/poincare/include/poincare/integral_layout.h
@@ -24,7 +24,7 @@ public:
   void moveCursorDown(LayoutCursor * cursor, bool * shouldRecomputeLayout, bool equivalentPositionVisited = false) override;
   void deleteBeforeCursor(LayoutCursor * cursor) override;
   int serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const override;
-  LayoutNode * layoutToPointWhenInserting() override { return lowerBoundLayout(); }
+  LayoutNode * layoutToPointWhenInserting(Expression * correspondingExpression) override { return lowerBoundLayout(); }
   CodePoint XNTCodePoint() const override { return 'x'; }
 
   // TreeNode

--- a/poincare/include/poincare/layout.h
+++ b/poincare/include/poincare/layout.h
@@ -8,6 +8,7 @@
 namespace Poincare {
 
 class LayoutCursor;
+class Expression;
 
 class Layout : public TreeHandle {
   friend class GridLayoutNode;
@@ -59,7 +60,11 @@ public:
   void deleteBeforeCursor(LayoutCursor * cursor) { return node()->deleteBeforeCursor(cursor); }
   bool removeGreySquaresFromAllMatrixAncestors() { return node()->removeGreySquaresFromAllMatrixAncestors(); }
   bool addGreySquaresToAllMatrixAncestors() { return node()->addGreySquaresToAllMatrixAncestors(); }
-  Layout layoutToPointWhenInserting() { return Layout(node()->layoutToPointWhenInserting()); }
+  Layout layoutToPointWhenInserting(Expression * correspondingExpression) {
+    // Pointer to correspondingExpr because expression.h includes layout.h
+    assert(correspondingExpression != nullptr);
+    return Layout(node()->layoutToPointWhenInserting(correspondingExpression));
+  }
 
   // Cursor
   LayoutCursor cursor() const;

--- a/poincare/include/poincare/layout_node.h
+++ b/poincare/include/poincare/layout_node.h
@@ -6,6 +6,7 @@
 
 namespace Poincare {
 
+class Expression;
 class LayoutCursor;
 class Layout;
 
@@ -102,9 +103,7 @@ public:
   virtual void deleteBeforeCursor(LayoutCursor * cursor);
 
   // Other
-  virtual LayoutNode * layoutToPointWhenInserting() {
-    return numberOfChildren() > 0 ? childAtIndex(0) : this;
-  }
+  virtual LayoutNode * layoutToPointWhenInserting(Expression * correspondingExpression);
   bool removeGreySquaresFromAllMatrixAncestors() { return changeGreySquaresOfAllMatrixAncestors(false); }
   bool addGreySquaresToAllMatrixAncestors() { return changeGreySquaresOfAllMatrixAncestors(true); }
   /* A layout has text if it is not empty and it is not an horizontal layout

--- a/poincare/include/poincare/sequence_layout.h
+++ b/poincare/include/poincare/sequence_layout.h
@@ -19,7 +19,7 @@ public:
   void moveCursorUp(LayoutCursor * cursor, bool * shouldRecomputeLayout, bool equivalentPositionVisited = false) override;
   void moveCursorDown(LayoutCursor * cursor, bool * shouldRecomputeLayout, bool equivalentPositionVisited = false) override;
   void deleteBeforeCursor(LayoutCursor * cursor) override;
-  LayoutNode * layoutToPointWhenInserting() override { return lowerBoundLayout(); }
+  LayoutNode * layoutToPointWhenInserting(Expression * correspondingExpression) override { return lowerBoundLayout(); }
   CodePoint XNTCodePoint() const override { return 'n'; }
 
   // TreeNode

--- a/poincare/src/fraction_layout.cpp
+++ b/poincare/src/fraction_layout.cpp
@@ -166,7 +166,7 @@ int FractionLayoutNode::serialize(char * buffer, int bufferSize, Preferences::Pr
   return numberOfChar;
 }
 
-LayoutNode * FractionLayoutNode::layoutToPointWhenInserting() {
+LayoutNode * FractionLayoutNode::layoutToPointWhenInserting(Expression * correspondingExpression) {
   if (numeratorLayout()->isEmpty()){
     return numeratorLayout();
   }

--- a/poincare/src/horizontal_layout.cpp
+++ b/poincare/src/horizontal_layout.cpp
@@ -164,6 +164,21 @@ void HorizontalLayoutNode::deleteBeforeCursor(LayoutCursor * cursor) {
   LayoutNode::deleteBeforeCursor(cursor);
 }
 
+LayoutNode * HorizontalLayoutNode::layoutToPointWhenInserting(Expression * correspondingExpression) {
+  assert(correspondingExpression != nullptr);
+  if (correspondingExpression->numberOfChildren() > 0) {
+    Layout layoutToPointTo = Layout(this).recursivelyMatches(
+      [](Poincare::Layout layout) {
+        return layout.type() == LayoutNode::Type::LeftParenthesisLayout || layout.isEmpty();
+      }
+    );
+    if (!layoutToPointTo.isUninitialized()) {
+      return layoutToPointTo.node();
+    }
+  }
+  return this;
+}
+
 int HorizontalLayoutNode::serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const {
   if (numberOfChildren() == 0) {
     if (bufferSize == 0) {

--- a/poincare/src/layout_node.cpp
+++ b/poincare/src/layout_node.cpp
@@ -110,6 +110,11 @@ void LayoutNode::deleteBeforeCursor(LayoutCursor * cursor) {
   // WARNING: Do no use "this" afterwards
 }
 
+LayoutNode * LayoutNode::layoutToPointWhenInserting(Expression * correspondingExpression) {
+  assert(correspondingExpression != nullptr);
+  return numberOfChildren() > 0 ? childAtIndex(0) : this;
+}
+
 bool LayoutNode::willRemoveChild(LayoutNode * l, LayoutCursor * cursor, bool force) {
   if (!force) {
     Layout(this).replaceChildWithEmpty(Layout(l), cursor);

--- a/poincare/test/helper.cpp
+++ b/poincare/test/helper.cpp
@@ -193,6 +193,11 @@ void assert_parsed_expression_layout_serialize_to_self(const char * expressionLa
   quiz_assert(strcmp(expressionLayout, buffer) == 0);
 }
 
+void assert_expression_layouts_as(Poincare::Expression expression, Poincare::Layout layout) {
+  Layout l = expression.createLayout(DecimalMode, PrintFloat::k_numberOfStoredSignificantDigits);
+  quiz_assert(l.isIdenticalTo(layout));
+}
+
 void assert_expression_layout_serialize_to(Poincare::Layout layout, const char * serialization) {
   constexpr int bufferSize = 255;
   char buffer[bufferSize];

--- a/poincare/test/helper.h
+++ b/poincare/test/helper.h
@@ -39,6 +39,7 @@ void assert_parsed_expression_approximates_with_value_for_symbol(Poincare::Expre
 
 void assert_parsed_expression_simplify_to(const char * expression, const char * simplifiedExpression, Poincare::ExpressionNode::ReductionTarget target = Poincare::ExpressionNode::ReductionTarget::User, Poincare::Preferences::AngleUnit angleUnit = Poincare::Preferences::AngleUnit::Radian, Poincare::Preferences::ComplexFormat complexFormat = Poincare::Preferences::ComplexFormat::Cartesian);
 void assert_parsed_expression_serialize_to(Poincare::Expression expression, const char * serializedExpression, Poincare::Preferences::PrintFloatMode mode = DecimalMode, int numberOfSignifiantDigits = 7);
+void assert_expression_layouts_as(Poincare::Expression expression, Poincare::Layout layout);
 
 
 // Layouts

--- a/poincare/test/layout_cursor.cpp
+++ b/poincare/test/layout_cursor.cpp
@@ -1,0 +1,74 @@
+#include <quiz.h>
+#include <poincare_layouts.h>
+#include "helper.h"
+
+using namespace Poincare;
+
+void assert_inserted_layout_points_to(Layout layoutToInsert, Expression * correspondingExpression, Layout layoutToPoint) {
+  quiz_assert(correspondingExpression != nullptr);
+  assert_expression_layouts_as(*correspondingExpression, layoutToInsert);
+  Layout layoutToPointComputed = layoutToInsert.layoutToPointWhenInserting(correspondingExpression);
+  quiz_assert(layoutToPointComputed.identifier() == layoutToPoint.identifier());
+}
+
+QUIZ_CASE(poincare_layout_cursor_computation) {
+  Layout l;
+  Expression e;
+
+  // 1+2
+  l = HorizontalLayout::Builder(
+      CodePointLayout::Builder('1'),
+      CodePointLayout::Builder('+'),
+      CodePointLayout::Builder('2'));
+  e = Addition::Builder(Rational::Builder(1), Rational::Builder(2));
+  assert_inserted_layout_points_to(l, &e, l);
+
+  // random()
+  HorizontalLayout hl = HorizontalLayout::Builder();
+  hl.addChildAtIndex(CodePointLayout::Builder('r'), hl.numberOfChildren(),  hl.numberOfChildren(), nullptr);
+  hl.addChildAtIndex(CodePointLayout::Builder('a'), hl.numberOfChildren(),  hl.numberOfChildren(), nullptr);
+  hl.addChildAtIndex(CodePointLayout::Builder('n'), hl.numberOfChildren(),  hl.numberOfChildren(), nullptr);
+  hl.addChildAtIndex(CodePointLayout::Builder('d'), hl.numberOfChildren(),  hl.numberOfChildren(), nullptr);
+  hl.addChildAtIndex(CodePointLayout::Builder('o'), hl.numberOfChildren(),  hl.numberOfChildren(), nullptr);
+  hl.addChildAtIndex(CodePointLayout::Builder('m'), hl.numberOfChildren(),  hl.numberOfChildren(), nullptr);
+  hl.addChildAtIndex(LeftParenthesisLayout::Builder(), hl.numberOfChildren(), hl.numberOfChildren(), nullptr);
+  hl.addChildAtIndex(RightParenthesisLayout::Builder(), hl.numberOfChildren(), hl.numberOfChildren(), nullptr);
+  l = hl;
+  e = Random::Builder();
+  assert_inserted_layout_points_to(l, &e, l);
+
+  // cos(\x11)
+  hl = HorizontalLayout::Builder();
+  hl.addChildAtIndex(CodePointLayout::Builder('c'), hl.numberOfChildren(),  hl.numberOfChildren(), nullptr);
+  hl.addChildAtIndex(CodePointLayout::Builder('o'), hl.numberOfChildren(),  hl.numberOfChildren(), nullptr);
+  hl.addChildAtIndex(CodePointLayout::Builder('s'), hl.numberOfChildren(),  hl.numberOfChildren(), nullptr);
+  hl.addChildAtIndex(LeftParenthesisLayout::Builder(), hl.numberOfChildren(), hl.numberOfChildren(), nullptr);
+  hl.addChildAtIndex(RightParenthesisLayout::Builder(), hl.numberOfChildren(), hl.numberOfChildren(), nullptr);
+  l = hl;
+  e = Cosine::Builder(EmptyExpression::Builder());
+  assert_inserted_layout_points_to(l, &e, l.childAtIndex(3));
+
+  // •^•
+  l = HorizontalLayout::Builder(
+      EmptyLayout::Builder(),
+      VerticalOffsetLayout::Builder(
+        EmptyLayout::Builder(),
+        VerticalOffsetLayoutNode::Position::Superscript)
+      );
+  e = Power::Builder(EmptyExpression::Builder(), EmptyExpression::Builder());
+  assert_inserted_layout_points_to(l, &e, l.childAtIndex(0));
+
+  // int(•, x, •, •)
+  l = IntegralLayout::Builder(
+      EmptyLayout::Builder(),
+      HorizontalLayout::Builder(
+        CodePointLayout::Builder('x')),
+      EmptyLayout::Builder(),
+      EmptyLayout::Builder());
+  e = Integral::Builder(
+      EmptyExpression::Builder(),
+      Symbol::Builder('x'),
+      EmptyExpression::Builder(),
+      EmptyExpression::Builder());
+  assert_inserted_layout_points_to(l, &e, l.childAtIndex(2));
+}


### PR DESCRIPTION
Clean the code to position the cursor when inserting a layout. This removes a dirty inclusion of apps/i18n.h in Escher