### PR TITLE
Explicit exponential regression

### DIFF
--- a/apps/regression/Makefile
+++ b/apps/regression/Makefile
@@ -13,6 +13,7 @@ app_src += $(addprefix apps/regression/,\
   graph_options_controller.cpp \
   graph_view.cpp \
   initialisation_parameter_controller.cpp \
+  linear_model_helper.cpp \
   regression_context.cpp \
   regression_controller.cpp \
   store.cpp \

--- a/apps/regression/linear_model_helper.cpp
+++ b/apps/regression/linear_model_helper.cpp
@@ -1,0 +1,17 @@
+#include "linear_model_helper.h"
+
+namespace Regression {
+
+namespace LinearModelHelper {
+
+double Slope(double covariance, double variance) {
+  return covariance / variance;
+}
+
+double YIntercept(double meanOfY, double meanOfX, double slope) {
+  return meanOfY - slope * meanOfX;
+}
+
+}
+
+}

--- a/apps/regression/linear_model_helper.h
+++ b/apps/regression/linear_model_helper.h
@@ -1,0 +1,15 @@
+#ifndef REGRESSION_LINEAR_MODEL_HELPER
+#define REGRESSION_LINEAR_MODEL_HELPER
+
+namespace Regression {
+
+namespace LinearModelHelper {
+
+double Slope(double covariance, double variance);
+double YIntercept(double meanOfY, double meanOfX, double slope);
+
+}
+
+}
+
+#endif

--- a/apps/regression/model/exponential_model.cpp
+++ b/apps/regression/model/exponential_model.cpp
@@ -1,4 +1,5 @@
 #include "exponential_model.h"
+#include "../store.h"
 #include <math.h>
 #include <assert.h>
 #include <poincare/code_point_layout.h>
@@ -44,6 +45,44 @@ double ExponentialModel::levelSet(double * modelCoefficients, double xMin, doubl
     return NAN;
   }
   return log(y/a)/b;
+}
+
+void ExponentialModel::fit(Store * store, int series, double * modelCoefficients, Poincare::Context * context) {
+  /* By the change of variable z=ln(y), the equation y=a*exp(b*x) becomes
+   * z=c*x+d with c=b and d=ln(a). Although that change of variable does not
+   * preserve the regression error function, it turns an exponential regression
+   * problem into a linear one and we consider that the solution of the latter
+   * is good enough for our purpose.
+   * That being said, one should check that the y values are all positive. (If
+   * the y values are all negative, one may replace each of them by its
+   * opposite. In the case where y values happen to be zero or of opposite
+   * sign, we call the base class method as a fallback. */
+  double sumOfX = 0;
+  double sumOfY = 0;
+  double sumOfXX = 0;
+  double sumOfXY = 0;
+  const int numberOfPoints = store->numberOfPairsOfSeries(series);
+  const int sign = store->get(series, 1, 0) > 0 ? 1 : -1;
+  for (int p = 0; p < numberOfPoints; p++) {
+    const double x = store->get(series, 0, p);
+    const double z = store->get(series, 1, p) * sign;
+    if (z <= 0) {
+      return Model::fit(store, series, modelCoefficients, context);
+    }
+    const double y = log(z);
+    sumOfX += x;
+    sumOfY += y;
+    sumOfXX += x*x;
+    sumOfXY += x*y;
+  }
+  const double meanOfX = sumOfX / numberOfPoints;
+  const double meanOfY = sumOfY / numberOfPoints;
+  const double meanOfXX = sumOfXX / numberOfPoints;
+  const double meanOfXY = sumOfXY / numberOfPoints;
+  const double variance = meanOfXX - meanOfX * meanOfX;
+  const double covariance = meanOfXY - meanOfX * meanOfY;
+  modelCoefficients[1] = covariance / variance;
+  modelCoefficients[0] = sign * exp(meanOfY - modelCoefficients[1] * meanOfX);
 }
 
 double ExponentialModel::partialDerivate(double * modelCoefficients, int derivateCoefficientIndex, double x) const {

--- a/apps/regression/model/exponential_model.cpp
+++ b/apps/regression/model/exponential_model.cpp
@@ -1,5 +1,6 @@
 #include "exponential_model.h"
 #include "../store.h"
+#include "../linear_model_helper.h"
 #include <math.h>
 #include <assert.h>
 #include <poincare/code_point_layout.h>
@@ -81,8 +82,9 @@ void ExponentialModel::fit(Store * store, int series, double * modelCoefficients
   const double meanOfXY = sumOfXY / numberOfPoints;
   const double variance = meanOfXX - meanOfX * meanOfX;
   const double covariance = meanOfXY - meanOfX * meanOfY;
-  modelCoefficients[1] = covariance / variance;
-  modelCoefficients[0] = sign * exp(meanOfY - modelCoefficients[1] * meanOfX);
+  modelCoefficients[1] = LinearModelHelper::Slope(covariance, variance);
+  modelCoefficients[0] =
+    sign * exp(LinearModelHelper::YIntercept(meanOfY, meanOfX, modelCoefficients[1]));
 }
 
 double ExponentialModel::partialDerivate(double * modelCoefficients, int derivateCoefficientIndex, double x) const {

--- a/apps/regression/model/exponential_model.h
+++ b/apps/regression/model/exponential_model.h
@@ -12,6 +12,7 @@ public:
   I18n::Message formulaMessage() const override { return I18n::Message::ExponentialRegressionFormula; }
   double evaluate(double * modelCoefficients, double x) const override;
   double levelSet(double * modelCoefficients, double xMin, double step, double xMax, double y, Poincare::Context * context) override;
+  void fit(Store * store, int series, double * modelCoefficients, Poincare::Context * context) override;
   double partialDerivate(double * modelCoefficients, int derivateCoefficientIndex, double x) const override;
   int numberOfCoefficients() const override { return 2; }
   int bannerLinesCount() const override { return 2; }

--- a/apps/regression/store.cpp
+++ b/apps/regression/store.cpp
@@ -1,4 +1,5 @@
 #include "store.h"
+#include "linear_model_helper.h"
 #include "apps/apps_container.h"
 #include <poincare/preferences.h>
 #include <assert.h>
@@ -238,11 +239,11 @@ double Store::covariance(int series) const {
 }
 
 double Store::slope(int series) const {
-  return covariance(series)/varianceOfColumn(series, 0);
+  return LinearModelHelper::Slope(covariance(series), varianceOfColumn(series, 0));
 }
 
 double Store::yIntercept(int series) const {
-  return meanOfColumn(series, 1) - slope(series)*meanOfColumn(series, 0);
+  return LinearModelHelper::YIntercept(meanOfColumn(series, 1), meanOfColumn(series, 0), slope(series));
 }
 
 double Store::yValueForXValue(int series, double x, Poincare::Context * globalContext) {

--- a/apps/regression/test/model.cpp
+++ b/apps/regression/test/model.cpp
@@ -76,6 +76,20 @@ QUIZ_CASE(exponential_regression) {
   assert_regression_is(x, y, 6, Model::Type::Exponential, coefficients);
 }
 
+QUIZ_CASE(exponential_regression2) {
+  double x[] = {0, 1, 2, 3};
+  double y[] = {3000, 3315.513, 3664.208, 4049.576};
+  double coefficients[] = {3000, .1};
+  assert_regression_is(x, y, 4, Model::Type::Exponential, coefficients);
+}
+
+QUIZ_CASE(exponential_regression3) {
+  double x[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  double y[] = {-1, -.3678794, -.1353353, -.04978707, -.01831564, -.006737947, -.002478752, -.000911882, -.0003354626, -.0001234098, -.00004539993};
+  double coefficients[] = {-1, -1};
+  assert_regression_is(x, y, 11, Model::Type::Exponential, coefficients);
+}
+
 QUIZ_CASE(power_regression) {
   double x[] = {1.0, 50.0, 34.0, 67.0, 20.0};
   double y[] = {71.860, 2775514, 979755.1, 6116830, 233832.9};


### PR DESCRIPTION
Fix #969

Epsilon's implementation of Levenberg-Marquardt regression algorithm cannot find the optimal parameters of an exponential regression for samples (added to the test suite) which actually admit an exact fit.

In fact, for the sample generated by y=e^(-x) with x ranging from 0 to 10, we observed that this implementation finds a pretty reasonable solution in that the error function is quite small (0.15...) and that the gradient of the error function is smaller than the precision of Poincare, so that the algorithm stops there, although the estimated parameters (1, -182) are far from the optimal ones. Indeed, the error function is small in a wide region in which its variation are imperceptible.

In any case, it is more satisfactory for our purpose to find the optimal solution for samples that admit an exact fit.