### PR TITLE
[build] Update targets.device.mak to flash ./build/device/epsilon.elf

### DIFF
--- a/scripts/targets.device.mak
+++ b/scripts/targets.device.mak
@@ -34,7 +34,7 @@
 	@echo "==============================="
 
 .PHONY: %_flash
-%_flash: %.bin
+%_flash: ./build/device/%.bin
 	@echo "DFU     $@"
 	@echo "INFO    About to flash your device. Please plug your device to your computer"
 	@echo "        using an USB cable and press the RESET button the back of your device."


### PR DESCRIPTION
Currently, when building the firmware for the device, epsilon.elf is created in ./build/device/epsilon.elf. If we want to flash this firmware on a real device, the user have to move the epsilon.elf file to the root project folder, which can lead to some confusions, as this step is undocumented on  [the Numworks documentation](https://www.numworks.com/resources/engineering/software/sdk/).
This pull request makes the `make epsilon_flash` command get the epsilon.elf directly in the ./build/device/ folder, so the user can use the command straight away, without any additional step.