### PR TITLE
Increase the max number of iterations to approximate an integral

### DIFF
--- a/poincare/include/poincare/integral.h
+++ b/poincare/include/poincare/integral.h
@@ -41,7 +41,7 @@ private:
     T integral;
     T absoluteError;
   };
-  constexpr static int k_maxNumberOfIterations = 10;
+  constexpr static int k_maxNumberOfIterations = 20;
 #ifdef LAGRANGE_METHOD
   template<typename T> T lagrangeGaussQuadrature(T a, T b, Context Context & context, Preferences::AngleUnit angleUnit context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
 #else


### PR DESCRIPTION
Fix #987

The `Poincare::IntegralNode::adaptiveQuadrature` method approximates recursively the integral of a given function, more and more accurately. It stops when
* either the approximation error is smaller than a given tolerance
* or the number of iterations reaches a given maximum, where it returns `NaN`.

At each iteration, if the approximation error is not satisfactory, it divides the integration interval in two equal pieces and calls itself on each subinterval, expecting that their respective errors will both be smaller than the initial tolerance.
If the bounds of the integral are X and Y and the maximal number of iterations is N, the smallest subinterval size looks like (X - Y) / 2^N.

The more a function varies quickly (such as x -> x^a with a in (0,1) in the neighborhood of 0), the smaller the subinterval must be.