### PR TITLE
[build/macOS] Fix macOS SDL build errors

### DIFF
--- a/ion/src/sdl/macos/Makefile
+++ b/ion/src/sdl/macos/Makefile
@@ -1,3 +1,5 @@
 src += $(addprefix ion/src/sdl/macos/, \
   images.m \
+  language.m \
+  telemetry.m \
 )

--- a/ion/src/sdl/macos/language.m
+++ b/ion/src/sdl/macos/language.m
@@ -1,0 +1,17 @@
+#include "../shared/platform.h"
+
+#include <Foundation/Foundation.h>
+
+char * IonSDLPlatformGetLanguageCode() {
+  static char buffer[4] = {0};
+  if (buffer[0] == 0) {
+    NSString * preferredLanguage = [[NSLocale preferredLanguages] firstObject];
+    NSString * languageName = [[NSLocale componentsFromLocaleIdentifier:preferredLanguage] objectForKey:@"kCFLocaleLanguageCodeKey"];
+    const char * name = [languageName UTF8String];
+    if (strlen(name) > 3) {
+      return NULL;
+    }
+    strlcpy(buffer, name, sizeof(buffer));
+  }
+  return buffer;
+}

--- a/ion/src/sdl/macos/telemetry.m
+++ b/ion/src/sdl/macos/telemetry.m
@@ -1,0 +1,10 @@
+#include "../shared/platform.h"
+
+void IonSDLPlatformTelemetryInit() {
+}
+
+void IonSDLPlatformTelemetryEvent(const char * eventName) {
+}
+
+void IonSDLPlatformTelemetryDeinit() {
+}


### PR DESCRIPTION
Hello!
Relative to the announced deprecation of FLTK (#992), I tried to build the SDL version of the emulator on macOS.
Unfortunately, the build failed due to the absence of some classes. So, I took the classes from the iOS version and (slightly) adapted them for macOS.

_Documentation time!_
To build the SDL version of the simulator on macOS:
```
make PLATFORM=sdl MODEL=macos epsilon.ipa -j
open ./build/sdl/macos/app/Epsilon.app 
```

To clean the build files:
```
make PLATFORM=sdl MODEL=macos clean
```