### PR TITLE
Glyph length

### DIFF
--- a/apps/statistics/histogram_controller.cpp
+++ b/apps/statistics/histogram_controller.cpp
@@ -90,6 +90,20 @@ Responder * HistogramController::tabController() const {
   return (parentResponder()->parentResponder()->parentResponder()->parentResponder());
 }
 
+void pad(char * buffer, int bufferSize, int * currentNumberOfChar, int maxGlyphLengthWithPadding) {
+  assert(*currentNumberOfChar <= bufferSize);
+  size_t currentGlyphLength = UTF8Helper::StringGlyphLength(buffer, *currentNumberOfChar);
+  bool addedPadding = false;
+  while (currentGlyphLength < maxGlyphLengthWithPadding && *currentNumberOfChar < bufferSize) {
+    *currentNumberOfChar = *currentNumberOfChar + UTF8Decoder::CodePointToChars(' ', buffer + *currentNumberOfChar, bufferSize - *currentNumberOfChar);
+    addedPadding = true;
+    currentGlyphLength++;
+  }
+  if (addedPadding) {
+    buffer[*currentNumberOfChar-1] = 0;
+  }
+}
+
 void HistogramController::reloadBannerView() {
   if (selectedSeriesIndex() < 0) {
     return;
@@ -107,7 +121,7 @@ void HistogramController::reloadBannerView() {
   // Add lower bound
   if (selectedSeriesIndex() >= 0) {
     double lowerBound = m_store->startOfBarAtIndex(selectedSeriesIndex(), *m_selectedBarIndex);
-    numberOfChar += PoincareHelpers::ConvertFloatToText<double>(lowerBound, buffer+numberOfChar, PrintFloat::bufferSizeForFloatsWithPrecision(Constant::LargeNumberOfSignificantDigits), Constant::LargeNumberOfSignificantDigits);
+    numberOfChar += PoincareHelpers::ConvertFloatToText<double>(lowerBound, buffer+numberOfChar, bufferSize-numberOfChar, Constant::LargeNumberOfSignificantDigits);
   }
 
   numberOfChar+= UTF8Decoder::CodePointToChars(';', buffer + numberOfChar, bufferSize - numberOfChar);
@@ -115,15 +129,12 @@ void HistogramController::reloadBannerView() {
   // Add upper bound
   if (selectedSeriesIndex() >= 0) {
     double upperBound = m_store->endOfBarAtIndex(selectedSeriesIndex(), *m_selectedBarIndex);
-    numberOfChar += PoincareHelpers::ConvertFloatToText<double>(upperBound, buffer+numberOfChar, PrintFloat::bufferSizeForFloatsWithPrecision(Constant::LargeNumberOfSignificantDigits), Constant::LargeNumberOfSignificantDigits);
+    numberOfChar += PoincareHelpers::ConvertFloatToText<double>(upperBound, buffer+numberOfChar, bufferSize-numberOfChar, Constant::LargeNumberOfSignificantDigits);
   }
   numberOfChar+= UTF8Decoder::CodePointToChars('[', buffer + numberOfChar, bufferSize - numberOfChar);
 
   // Padding
-  for (int i = numberOfChar; i < k_maxIntervalLegendLength; i++) {
-    numberOfChar+= UTF8Decoder::CodePointToChars(' ', buffer + numberOfChar, bufferSize - numberOfChar);
-  }
-  buffer[k_maxIntervalLegendLength] = 0;
+  pad(buffer, bufferSize, &numberOfChar, k_maxIntervalLegendLength);
   m_view.bannerView()->intervalView()->setText(buffer);
 
   // Add Size Data
@@ -135,13 +146,10 @@ void HistogramController::reloadBannerView() {
   double size = 0;
   if (selectedSeriesIndex() >= 0) {
     size = m_store->heightOfBarAtIndex(selectedSeriesIndex(), *m_selectedBarIndex);
-    numberOfChar += PoincareHelpers::ConvertFloatToText<double>(size, buffer+numberOfChar, PrintFloat::bufferSizeForFloatsWithPrecision(Constant::LargeNumberOfSignificantDigits), Constant::LargeNumberOfSignificantDigits);
+    numberOfChar += PoincareHelpers::ConvertFloatToText<double>(size, buffer+numberOfChar, bufferSize-numberOfChar, Constant::LargeNumberOfSignificantDigits);
   }
   // Padding
-  for (int i = numberOfChar; i < k_maxLegendLength; i++) {
-    numberOfChar+= UTF8Decoder::CodePointToChars(' ', buffer + numberOfChar, bufferSize - numberOfChar);
-  }
-  buffer[k_maxLegendLength] = 0;
+  pad(buffer, bufferSize, &numberOfChar, k_maxLegendLength);
   m_view.bannerView()->sizeView()->setText(buffer);
 
   // Add Frequency Data
@@ -152,13 +160,10 @@ void HistogramController::reloadBannerView() {
   numberOfChar += legendLength;
   if (selectedSeriesIndex() >= 0) {
     double frequency = size/m_store->sumOfOccurrences(selectedSeriesIndex());
-    numberOfChar += PoincareHelpers::ConvertFloatToText<double>(frequency, buffer+numberOfChar, PrintFloat::bufferSizeForFloatsWithPrecision(Constant::LargeNumberOfSignificantDigits), Constant::LargeNumberOfSignificantDigits);
+    numberOfChar += PoincareHelpers::ConvertFloatToText<double>(frequency, buffer+numberOfChar, bufferSize - numberOfChar, Constant::LargeNumberOfSignificantDigits);
   }
   // Padding
-  for (int i = numberOfChar; i < k_maxLegendLength; i++) {
-    numberOfChar+= UTF8Decoder::CodePointToChars(' ', buffer + numberOfChar, bufferSize - numberOfChar);
-  }
-  buffer[k_maxLegendLength] = 0;
+  pad(buffer, bufferSize, &numberOfChar, k_maxLegendLength);
   m_view.bannerView()->frequencyView()->setText(buffer);
 
   m_view.bannerView()->reload();

--- a/ion/Makefile
+++ b/ion/Makefile
@@ -34,6 +34,7 @@ tests += $(addprefix ion/test/,\
   keyboard.cpp\
   storage.cpp\
   utf8_decoder.cpp\
+  utf8_helper.cpp\
 )
 
 ifdef ION_STORAGE_LOG

--- a/ion/include/ion/unicode/utf8_helper.h
+++ b/ion/include/ion/unicode/utf8_helper.h
@@ -68,6 +68,10 @@ int RemovePreviousCodePoint(const char * text, char * location, CodePoint * c);
 const char * CodePointAtGlyphOffset(const char * buffer, int position);
 size_t GlyphOffsetAtCodePoint(const char * buffer, const char * position);
 
+/* Return the number of glyphs in a string.
+ * For instance, strlen("∑") = 3 but StringGlyphLength("∑") = 1 */
+size_t StringGlyphLength(const char * s, int maxSize = -1);
+
 };
 
 #endif

--- a/ion/src/shared/unicode/utf8_helper.cpp
+++ b/ion/src/shared/unicode/utf8_helper.cpp
@@ -326,5 +326,20 @@ size_t GlyphOffsetAtCodePoint(const char * buffer, const char * position) {
   return glyphIndex;
 }
 
+size_t StringGlyphLength(const char * s, int maxSize) {
+  if (maxSize == 0) {
+    return 0;
+  }
+  UTF8Decoder decoder(s);
+  CodePoint codePoint = decoder.nextCodePoint();
+  size_t glyphIndex = 0;
+  while (codePoint != UCodePointNull && (maxSize < 0 || ((decoder.stringPosition() - s) <= maxSize))) {
+    if (!codePoint.isCombining()) {
+      glyphIndex++;
+    }
+    codePoint = decoder.nextCodePoint();
+  }
+  return glyphIndex;
+}
 
-};
+}

--- a/ion/test/utf8_helper.cpp
+++ b/ion/test/utf8_helper.cpp
@@ -1,0 +1,14 @@
+#include <quiz.h>
+#include <ion/unicode/utf8_helper.h>
+
+void assert_string_glyph_length_is(const char * string, int maxSize, size_t result) {
+  quiz_assert(UTF8Helper::StringGlyphLength(string, maxSize) == result);
+}
+
+QUIZ_CASE(ion_utf8_helper_glyph_length) {
+  assert_string_glyph_length_is("123", -1, 3);
+  assert_string_glyph_length_is("1ᴇ3", -1, 3);
+  assert_string_glyph_length_is("∑∫𝐢", -1, 3);
+  assert_string_glyph_length_is("123", 2, 2);
+  assert_string_glyph_length_is("1ᴇ3", 2, 1);
+}


### PR DESCRIPTION
Fix a display bug in the banner view of statistics

Scenario:
Scientific mode, statistics app with data:
10 - 1
20 - 5
30 - 4
40 - 3
50 - 1
Display the histogram, there are problems in the banner view