### PR TITLE
[escher/text_area] Fix text indentation handling

### DIFF
--- a/escher/include/escher/text_input_helpers.h
+++ b/escher/include/escher/text_input_helpers.h
@@ -6,7 +6,7 @@
 
 namespace TextInputHelpers {
 
-const char * CursorPositionInCommand(const char * text);
+const char * CursorPositionInCommand(const char * text, const char * stoppingPosition = nullptr);
 /* Returns the pointer to the char that should be right of the cursor, which is
  * the first char between :
  *   - The first EmptyChar (which is the position of the first argument)

--- a/escher/src/text_input_helpers.cpp
+++ b/escher/src/text_input_helpers.cpp
@@ -4,11 +4,12 @@
 
 namespace TextInputHelpers {
 
-const char * CursorPositionInCommand(const char * text) {
+const char * CursorPositionInCommand(const char * text, const char * stoppingPosition) {
+  assert(stoppingPosition == nullptr || text <= stoppingPosition);
   UTF8Decoder decoder(text);
   const char * currentPointer = text;
   CodePoint codePoint = decoder.nextCodePoint();
-  while (codePoint != UCodePointNull) {
+  while ((stoppingPosition == nullptr || currentPointer < stoppingPosition) && codePoint != UCodePointNull) {
     if (codePoint == UCodePointEmpty) {
       return currentPointer;
     }

--- a/ion/include/ion/unicode/utf8_helper.h
+++ b/ion/include/ion/unicode/utf8_helper.h
@@ -24,7 +24,7 @@ void CopyAndRemoveCodePoint(char * dst, size_t dstSize, const char * src, CodePo
 
 /* Remove all code points c. and update an index that should be lower if code
  * points where removed before it. Ensure null-termination of dst. */
-void RemoveCodePoint(char * buffer, CodePoint c, const char * * indexToDUpdate = nullptr);
+void RemoveCodePoint(char * buffer, CodePoint c, const char * * indexToDUpdate = nullptr, const char * stoppingPosition = nullptr);
 
 /* Copy src into dst until end of dst or code point c, with null termination. Return the length of the copy */
 size_t CopyUntilCodePoint(char * dst, size_t dstSize, const char * src, CodePoint c);
@@ -50,8 +50,19 @@ size_t CopyUntilCodePoint(char * dst, size_t dstSize, const char * src, CodePoin
  *    ^start of string  ^r             ^initialPosition
  *
  * */
-typedef void (*CodePointAction)(int codePointOffset, void * contextPointer, int contextInt);
-const char * PerformAtCodePoints(const char * string, CodePoint c, CodePointAction actionCodePoint, CodePointAction actionOtherCodePoint, void * contextPointer, int contextInt, CodePoint stoppingCodePoint = UCodePointNull, bool goingRight = true, const char * initialPosition = nullptr);
+typedef void (*CodePointAction)(int codePointOffset, void * contextPointer, int contextInt1, int contextInt2);
+const char * PerformAtCodePoints(
+    const char * string,
+    CodePoint c,
+    CodePointAction actionCodePoint,
+    CodePointAction actionOtherCodePoint,
+    void * contextPointer,
+    int contextInt1,
+    int contextInt2 = -1,
+    CodePoint stoppingCodePoint = UCodePointNull,
+    bool goingRight = true,
+    const char * initialPosition = nullptr,
+    const char * stoppingPosition = nullptr);
 
 bool PreviousCodePointIs(const char * buffer, const char * location, CodePoint c);
 bool CodePointIs(const char * location, CodePoint c);

--- a/ion/src/shared/unicode/utf8_helper.cpp
+++ b/ion/src/shared/unicode/utf8_helper.cpp
@@ -110,7 +110,7 @@ void CopyAndRemoveCodePoint(char * dst, size_t dstSize, const char * src, CodePo
   *(dst + minInt(bufferIndex, dstSize - 1)) = 0;
 }
 
-void RemoveCodePoint(char * buffer, CodePoint c, const char * * pointerToUpdate) {
+void RemoveCodePoint(char * buffer, CodePoint c, const char * * pointerToUpdate, const char * stoppingPosition) {
   UTF8Decoder decoder(buffer);
   const char * currentPointer = buffer;
   CodePoint codePoint = decoder.nextCodePoint();
@@ -118,7 +118,7 @@ void RemoveCodePoint(char * buffer, CodePoint c, const char * * pointerToUpdate)
   size_t bufferIndex = 0;
   size_t codePointCharSize = UTF8Decoder::CharSizeOfCodePoint(c);
 
-  while (codePoint != UCodePointNull) {
+  while (codePoint != UCodePointNull && (stoppingPosition == nullptr || currentPointer < stoppingPosition)) {
     if (codePoint != c) {
       int copySize = nextPointer - currentPointer;
       memmove(buffer + bufferIndex, currentPointer, copySize);
@@ -131,7 +131,16 @@ void RemoveCodePoint(char * buffer, CodePoint c, const char * * pointerToUpdate)
     codePoint = decoder.nextCodePoint();
     nextPointer = decoder.stringPosition();
   }
-  *(buffer + bufferIndex) = 0;
+  if (codePoint == UCodePointNull) {
+    *(buffer + bufferIndex) = 0;
+  } else {
+    assert(stoppingPosition != nullptr);
+    // Find the null-terminating code point
+    const char * nullTermination = CodePointSearch(currentPointer, UCodePointNull);
+    /* Copy what remains of the buffer after the stopping position for code
+     * point removal */
+    memmove(buffer + bufferIndex, stoppingPosition, nullTermination - stoppingPosition + 1);
+  }
 }
 
 size_t CopyUntilCodePoint(char * dst, size_t dstSize, const char * src, CodePoint c) {
@@ -150,7 +159,7 @@ size_t CopyUntilCodePoint(char * dst, size_t dstSize, const char * src, CodePoin
   return copySize;
 }
 
-const char * PerformAtCodePoints(const char * s, CodePoint c, CodePointAction actionCodePoint, CodePointAction actionOtherCodePoint, void * contextPointer, int contextInt, CodePoint stoppingCodePoint, bool goingRight, const char * initialPosition) {
+const char * PerformAtCodePoints(const char * s, CodePoint c, CodePointAction actionCodePoint, CodePointAction actionOtherCodePoint, void * contextPointer, int contextInt1, int contextInt2, CodePoint stoppingCodePoint, bool goingRight, const char * initialPosition, const char * stoppingPosition) {
   /* If we are decoding towards the left, we must have a starting position. If
    * we are decoding towards the right, the starting position is the start of
    * string. */
@@ -162,22 +171,22 @@ const char * PerformAtCodePoints(const char * s, CodePoint c, CodePointAction ac
      * translations. We can do a classic char search. */
     if (goingRight) {
       const char * i = s;
-      while (*i != stoppingCodePoint && *i != 0) {
+      while (*i != stoppingCodePoint && *i != 0 && i != stoppingPosition) {
         if (*i == c) {
-          actionCodePoint(i - s, contextPointer, contextInt);
+          actionCodePoint(i - s, contextPointer, contextInt1, contextInt2);
         } else {
-          actionOtherCodePoint(i - s, contextPointer, contextInt);
+          actionOtherCodePoint(i - s, contextPointer, contextInt1, contextInt2);
         }
         i++;
       }
       return i;
     }
     const char * i = initialPosition - 1;
-    while (i >= s && *i != stoppingCodePoint) {
+    while (i >= s && *i != stoppingCodePoint && i != stoppingPosition) {
       if (*i == c) {
-        actionCodePoint(i - s, contextPointer, contextInt);
+        actionCodePoint(i - s, contextPointer, contextInt1, contextInt2);
       } else {
-        actionOtherCodePoint(i - s, contextPointer, contextInt);
+        actionOtherCodePoint(i - s, contextPointer, contextInt1, contextInt2);
       }
       i--;
     }
@@ -188,11 +197,11 @@ const char * PerformAtCodePoints(const char * s, CodePoint c, CodePointAction ac
     UTF8Decoder decoder(s);
     const char * codePointPointer = decoder.stringPosition();
     CodePoint codePoint = decoder.nextCodePoint();
-    while (codePoint != stoppingCodePoint && codePoint != UCodePointNull) {
+    while (codePoint != stoppingCodePoint && codePoint != UCodePointNull && codePointPointer != stoppingPosition) {
       if (codePoint == c) {
-        actionCodePoint(codePointPointer - s, contextPointer, contextInt);
+        actionCodePoint(codePointPointer - s, contextPointer, contextInt1, contextInt2);
       } else {
-        actionOtherCodePoint(codePointPointer - s, contextPointer, contextInt);
+        actionOtherCodePoint(codePointPointer - s, contextPointer, contextInt1, contextInt2);
       }
       codePointPointer = decoder.stringPosition();
       codePoint = decoder.nextCodePoint();
@@ -206,11 +215,11 @@ const char * PerformAtCodePoints(const char * s, CodePoint c, CodePointAction ac
   UTF8Decoder decoder(s, initialPosition);
   CodePoint codePoint = decoder.previousCodePoint();
   const char * codePointPointer = decoder.stringPosition();
-  while (codePointPointer >= s && codePoint != stoppingCodePoint) {
+  while (codePointPointer >= s && codePoint != stoppingCodePoint && codePointPointer != stoppingPosition) {
     if (codePoint == c) {
-      actionCodePoint(codePointPointer - s, contextPointer, contextInt);
+      actionCodePoint(codePointPointer - s, contextPointer, contextInt1, contextInt2);
     } else {
-      actionOtherCodePoint(codePointPointer - s, contextPointer, contextInt);
+      actionOtherCodePoint(codePointPointer - s, contextPointer, contextInt1, contextInt2);
     }
     if (codePointPointer > s) {
       codePoint = decoder.previousCodePoint();


### PR DESCRIPTION
We used a small buffer to preprocess a text to insert in text area (add
indentation, remove empty code points, compute the next cursor location),
but the size of this buffer was sometimes too small and caused a crash.
Now we do all the text modification in place in the text area buffer.