### PR TITLE
[apps] Force packing classes of objects contained in the Storage

### DIFF
--- a/apps/sequence/sequence.h
+++ b/apps/sequence/sequence.h
@@ -70,7 +70,9 @@ private:
   constexpr static double k_maxNumberOfTermsInSum = 100000.0;
 
   /* SequenceRecordDataBuffer is the layout of the data buffer of Record
-   * representing a Sequence. */
+   * representing a Sequence. See comment on
+   * Shared::Function::FunctionRecordDataBuffer about packing. */
+#pragma pack(push,1)
   class SequenceRecordDataBuffer : public FunctionRecordDataBuffer {
   public:
     SequenceRecordDataBuffer(KDColor color) :
@@ -91,13 +93,13 @@ private:
       assert(conditionIndex >= 0 && conditionIndex < 2);
       m_initialConditionSizes[conditionIndex] = size;
     }
-
   private:
     static_assert((1 << 8*sizeof(uint16_t)) > Ion::Storage::k_storageSize, "Potential overflows of Sequence initial condition sizes");
     Type m_type;
     uint8_t m_initialRank;
     uint16_t m_initialConditionSizes[2];
   };
+#pragma pack(pop)
 
   class SequenceModel : public Shared::ExpressionModel {
   public:

--- a/apps/sequence/sequence.h
+++ b/apps/sequence/sequence.h
@@ -5,6 +5,10 @@
 #include "sequence_context.h"
 #include <assert.h>
 
+#if __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+
 namespace Sequence {
 
 /* WARNING: after calling setType, setInitialRank, setContent, setFirstInitialConditionContent
@@ -70,7 +74,7 @@ private:
   constexpr static double k_maxNumberOfTermsInSum = 100000.0;
 
   /* SequenceRecordDataBuffer is the layout of the data buffer of Record
-   * representing a Sequence. See comment on
+   * representing a Sequence. See comment in
    * Shared::Function::FunctionRecordDataBuffer about packing. */
 #pragma pack(push,1)
   class SequenceRecordDataBuffer : public FunctionRecordDataBuffer {
@@ -97,7 +101,13 @@ private:
     static_assert((1 << 8*sizeof(uint16_t)) > Ion::Storage::k_storageSize, "Potential overflows of Sequence initial condition sizes");
     Type m_type;
     uint8_t m_initialRank;
+#if __EMSCRIPTEN__
+    // See comment about emscripten alignement in Shared::Function::FunctionRecordDataBuffer
+    static_assert(sizeof(emscripten_align1_short) == sizeof(uint16_t), "emscripten_align1_short should have the same size as uint16_t");
+    emscripten_align1_short m_initialConditionSizes[2];
+#else
     uint16_t m_initialConditionSizes[2];
+#endif
   };
 #pragma pack(pop)
 

--- a/apps/shared/cartesian_function.h
+++ b/apps/shared/cartesian_function.h
@@ -32,7 +32,9 @@ public:
   Poincare::Expression::Coordinate2D nextIntersectionFrom(double start, double step, double max, Poincare::Context * context, Poincare::Expression expression) const;
 private:
   /* CartesianFunctionRecordDataBuffer is the layout of the data buffer of Record
-   * representing a CartesianFunction. */
+   * representing a CartesianFunction. See comment on
+   * Shared::Function::FunctionRecordDataBuffer about packing. */
+#pragma pack(push,1)
   class CartesianFunctionRecordDataBuffer : public FunctionRecordDataBuffer {
   public:
     CartesianFunctionRecordDataBuffer(KDColor color) :
@@ -47,6 +49,7 @@ private:
      * the expression of the function, directly copied from the pool. */
     //char m_expression[0];
   };
+#pragma pack(pop)
   class Model : public ExpressionModel {
   public:
     void * expressionAddress(const Ion::Storage::Record * record) const override;

--- a/apps/shared/function.h
+++ b/apps/shared/function.h
@@ -41,7 +41,11 @@ public:
   virtual double sumBetweenBounds(double start, double end, Poincare::Context * context) const = 0;
 protected:
   /* FunctionRecordDataBuffer is the layout of the data buffer of Record
-   * representing a Function. */
+   * representing a Function. We want to avoid padding which would:
+   * - increase the size of the storage file
+   * - introduce junk memory zone which are then crc-ed in Storage::checksum
+   *   creating dependency on uninitialized values. */
+#pragma pack(push,1)
   class FunctionRecordDataBuffer {
   public:
     FunctionRecordDataBuffer(KDColor color) : m_color(color), m_active(true) {}
@@ -59,6 +63,7 @@ protected:
     KDColor m_color;
     bool m_active;
   };
+#pragma pack(pop)
 private:
   template<typename T> T templatedApproximateAtAbscissa(T x, Poincare::Context * context, CodePoint unknownSymbol) const;
   FunctionRecordDataBuffer * recordData() const;

--- a/apps/shared/function.h
+++ b/apps/shared/function.h
@@ -5,6 +5,10 @@
 #include <poincare/symbol.h>
 #include "expression_model_handle.h"
 
+#if __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+
 namespace Shared {
 
 class Function : public ExpressionModelHandle {
@@ -50,17 +54,24 @@ protected:
   public:
     FunctionRecordDataBuffer(KDColor color) : m_color(color), m_active(true) {}
     KDColor color() const {
-      /* Record::value() is a pointer to an address inside
-       * Ion::Storage::sharedStorage(), and it might be unaligned. In the method
-       * recordData(), we cast Record::value() to the type FunctionRecordDataBuffer.
-       * We must thus do some convolutions to read KDColor, which is a uint16_t
-       * and might produce an alignment error on the emscripten platform. */
-      return KDColor::RGB16(Ion::StorageHelper::unalignedShort(reinterpret_cast<char *>(const_cast<KDColor *>(&m_color))));
+      return KDColor::RGB16(m_color);
     }
     bool isActive() const { return m_active; }
     void setActive(bool active) { m_active = active; }
   private:
-    KDColor m_color;
+#if __EMSCRIPTEN__
+    /* Record::value() is a pointer to an address inside
+     * Ion::Storage::sharedStorage(), and it might be unaligned. However, for
+     * emscripten memory representation, loads and stores must be aligned;
+     * performing a normal load or store on an unaligned address can fail
+     * silently. We thus use 'emscripten_align1_short' type, the unaligned
+     * version of uint16_t type to avoid producing an alignment error on the
+     * emscripten platform. */
+    static_assert(sizeof(emscripten_align1_short) == sizeof(uint16_t), "emscripten_align1_short should have the same size as uint16_t");
+    emscripten_align1_short m_color;
+#else
+    uint16_t m_color;
+#endif
     bool m_active;
   };
 #pragma pack(pop)


### PR DESCRIPTION
If these classes are padded, we lose space in the Storage and the
Storage::checksum is computed on uninitialized values (corresponding to
the padding memory spaces)