### PR TITLE
Fix cursor navigation on utf8

### DIFF
--- a/apps/code/editor_controller.cpp
+++ b/apps/code/editor_controller.cpp
@@ -84,7 +84,7 @@ bool EditorController::textAreaDidReceiveEvent(TextArea * textArea, Ion::Events:
     numberOfSpaces = numberOfSpaces / UTF8Decoder::CharSizeOfCodePoint(' ');
     if (cursorIsPrecededOnTheLineBySpacesOnly && numberOfSpaces >= k_indentationSpacesNumber) {
       for (int i = 0; i < k_indentationSpacesNumber; i++) {
-        textArea->removeCodePoint();
+        textArea->removePreviousGlyph();
       }
       return true;
     }

--- a/escher/include/escher/text_area.h
+++ b/escher/include/escher/text_area.h
@@ -77,7 +77,7 @@ protected:
     void insertText(const char * s, int textLength, char * location);
     void insertSpacesAtLocation(int numberOfSpaces, char * location);
 
-    CodePoint removeCodePoint(char * * position);
+    CodePoint removePreviousGlyph(char * * position);
     size_t removeRemainingLine(const char * position, int direction);
     char operator[](size_t index) {
       assert(index < m_bufferSize);
@@ -114,7 +114,7 @@ protected:
     const Text * getText() const { return &m_text; }
     bool insertTextAtLocation(const char * text, const char * location) override;
     void moveCursorGeo(int deltaX, int deltaY);
-    bool removeCodePoint() override;
+    bool removePreviousGlyph() override;
     bool removeEndOfLine() override;
     bool removeStartOfLine();
   protected:

--- a/escher/include/escher/text_field.h
+++ b/escher/include/escher/text_field.h
@@ -55,7 +55,7 @@ protected:
      * the maximum buffer capacity) and false is returned. */
     bool insertTextAtLocation(const char * text, const char * location) override; // TODO
     KDSize minimalSizeForOptimalDisplay() const override;
-    bool removeCodePoint() override;
+    bool removePreviousGlyph() override;
     bool removeEndOfLine() override;
     void willModifyTextBuffer();
     void didModifyTextBuffer();

--- a/escher/include/escher/text_input.h
+++ b/escher/include/escher/text_input.h
@@ -50,7 +50,7 @@ protected:
     virtual const char * editedText() const = 0;
     virtual size_t editedTextLength() const = 0;
   };
-protected:
+
   /* If the text to be appended is too long to be added without overflowing the
    * buffer, nothing is done (not even adding few letters from the text to reach
    * the maximum buffer capacity) and false is returned. */
@@ -60,6 +60,8 @@ protected:
     return const_cast<ContentView *>(nonEditableContentView());
   }
   virtual const ContentView * nonEditableContentView() const = 0;
+  bool moveCursorLeft();
+  bool moveCursorRight();
 private:
   virtual void willSetCursorLocation(const char * * location) {}
   virtual bool privateRemoveEndOfLine();

--- a/escher/include/escher/text_input.h
+++ b/escher/include/escher/text_input.h
@@ -11,7 +11,7 @@ public:
   TextInput(Responder * parentResponder, View * contentView) : ScrollableView(parentResponder, contentView, this) {}
   void setFont(const KDFont * font) { contentView()->setFont(font); }
   const char * text() const { return nonEditableContentView()->text(); }
-  bool removeCodePoint();
+  bool removePreviousGlyph();
   const char * cursorLocation() const { return nonEditableContentView()->cursorLocation(); }
   bool setCursorLocation(const char * location);
   virtual void scrollToCursor();
@@ -30,7 +30,7 @@ protected:
     void setCursorLocation(const char * cursorLocation);
     virtual const char * text() const = 0;
     virtual bool insertTextAtLocation(const char * text, const char * location) = 0;
-    virtual bool removeCodePoint() = 0;
+    virtual bool removePreviousGlyph() = 0;
     virtual bool removeEndOfLine() = 0;
     KDRect cursorRect();
   protected:

--- a/escher/src/text_area.cpp
+++ b/escher/src/text_area.cpp
@@ -120,7 +120,7 @@ bool TextArea::handleEvent(Ion::Events::Event event) {
   } else if (event == Ion::Events::ShiftRight) {
     contentView()->moveCursorGeo(INT_MAX/2, 0);
   } else if (event == Ion::Events::Backspace) {
-    return removeCodePoint();
+    return removePreviousGlyph();
   } else if (event.hasText()) {
     return handleEventWithText(event.text());
   } else if (event == Ion::Events::EXE) {
@@ -219,12 +219,12 @@ void TextArea::Text::insertSpacesAtLocation(int numberOfSpaces, char * location)
   }
 }
 
-CodePoint TextArea::Text::removeCodePoint(char * * position) {
+CodePoint TextArea::Text::removePreviousGlyph(char * * position) {
   assert(m_buffer != nullptr);
   assert(m_buffer <= *position && *position < m_buffer + m_bufferSize);
 
   CodePoint removedCodePoint = 0;
-  int removedSize = UTF8Helper::RemovePreviousCodePoint(m_buffer, *position, &removedCodePoint);
+  int removedSize = UTF8Helper::RemovePreviousGlyph(m_buffer, *position, &removedCodePoint);
   assert(removedSize > 0);
 
   // Set the new cursor position
@@ -405,14 +405,14 @@ bool TextArea::TextArea::ContentView::insertTextAtLocation(const char * text, co
   return true;
 }
 
-bool TextArea::TextArea::ContentView::removeCodePoint() {
+bool TextArea::TextArea::ContentView::removePreviousGlyph() {
   if (cursorLocation() <= text()) {
     assert(cursorLocation() == text());
     return false;
   }
   bool lineBreak = false;
   char * cursorLoc = const_cast<char *>(cursorLocation());
-  lineBreak = m_text.removeCodePoint(&cursorLoc) == '\n';
+  lineBreak = m_text.removePreviousGlyph(&cursorLoc) == '\n';
   setCursorLocation(cursorLoc); // Update the cursor
   layoutSubviews(); // Reposition the cursor
   reloadRectFromPosition(cursorLocation(), lineBreak);

--- a/escher/src/text_area.cpp
+++ b/escher/src/text_area.cpp
@@ -99,18 +99,9 @@ bool TextArea::handleEvent(Ion::Events::Event event) {
   } else if (handleBoxEvent(app(), event)) {
     return true;
   } else if (event == Ion::Events::Left) {
-    if (cursorLocation() <= text()) {
-      assert(cursorLocation() == text());
-      return false;
-    }
-    UTF8Decoder decoder(text(), cursorLocation());
-    return setCursorLocation(decoder.previousGlyphPosition());
+    return TextInput::moveCursorLeft();
   } else if (event == Ion::Events::Right) {
-    if (UTF8Helper::CodePointIs(cursorLocation(), UCodePointNull)) {
-      return false;
-    }
-    UTF8Decoder decoder(cursorLocation());
-    return setCursorLocation(decoder.nextGlyphPosition());
+    return TextInput::moveCursorRight();
   } else if (event == Ion::Events::Up) {
     contentView()->moveCursorGeo(0, -1);
   } else if (event == Ion::Events::Down) {

--- a/escher/src/text_area.cpp
+++ b/escher/src/text_area.cpp
@@ -104,15 +104,13 @@ bool TextArea::handleEvent(Ion::Events::Event event) {
       return false;
     }
     UTF8Decoder decoder(text(), cursorLocation());
-    decoder.previousCodePoint();
-    return setCursorLocation(decoder.stringPosition());
+    return setCursorLocation(decoder.previousGlyphPosition());
   } else if (event == Ion::Events::Right) {
     if (UTF8Helper::CodePointIs(cursorLocation(), UCodePointNull)) {
       return false;
     }
     UTF8Decoder decoder(cursorLocation());
-    decoder.nextCodePoint();
-    return setCursorLocation(decoder.stringPosition());
+    return setCursorLocation(decoder.nextGlyphPosition());
   } else if (event == Ion::Events::Up) {
     contentView()->moveCursorGeo(0, -1);
   } else if (event == Ion::Events::Down) {

--- a/escher/src/text_field.cpp
+++ b/escher/src/text_field.cpp
@@ -432,23 +432,21 @@ void TextField::scrollToCursor() {
 }
 
 bool TextField::privateHandleMoveEvent(Ion::Events::Event event) {
-  if (event == Ion::Events::Left && isEditing() && cursorLocation() > m_contentView.draftTextBuffer()) {
-    assert(isEditing());
-    UTF8Decoder decoder(m_contentView.draftTextBuffer(), cursorLocation());
-    return setCursorLocation(decoder.previousGlyphPosition());
+  if (!isEditing()) {
+    return false;
   }
-  if (event == Ion::Events::ShiftLeft && isEditing()) {
-    assert(isEditing());
-    return setCursorLocation(m_contentView.draftTextBuffer());
+  const char * draftBuffer = m_contentView.draftTextBuffer();
+  if (event == Ion::Events::Left && cursorLocation() > draftBuffer) {
+    return TextInput::moveCursorLeft();
   }
-  if (event == Ion::Events::Right && isEditing() && cursorLocation() < m_contentView.draftTextBuffer() + draftTextLength()) {
-    assert(isEditing());
-    UTF8Decoder decoder(cursorLocation());
-    return setCursorLocation(decoder.nextGlyphPosition());
+  if (event == Ion::Events::Right && cursorLocation() < draftBuffer + draftTextLength()) {
+    return TextInput::moveCursorRight();
   }
-  if (event == Ion::Events::ShiftRight && isEditing()) {
-    assert(isEditing());
-    return setCursorLocation(m_contentView.draftTextBuffer() + draftTextLength());
+  if (event == Ion::Events::ShiftLeft) {
+    return setCursorLocation(draftBuffer);
+  }
+  if (event == Ion::Events::ShiftRight) {
+    return setCursorLocation(draftBuffer + draftTextLength());
   }
   return false;
 }

--- a/escher/src/text_field.cpp
+++ b/escher/src/text_field.cpp
@@ -149,12 +149,11 @@ bool TextField::ContentView::removePreviousGlyph() {
 
   if (m_horizontalAlignment > 0.0f) {
     /* Reload the view. If we do it later, the text beins supposedly shorter, we
-     *  will not clean the first char. */
+     * will not clean the first char. */
     reloadRectFromPosition(m_draftTextBuffer);
   }
   // Remove the glyph if possible
-  CodePoint removedCodePoint = 0;
-  int removedSize = UTF8Helper::RemovePreviousGlyph(m_draftTextBuffer, const_cast<char *>(cursorLocation()), &removedCodePoint);
+  int removedSize = UTF8Helper::RemovePreviousGlyph(m_draftTextBuffer, const_cast<char *>(cursorLocation()));
   if (removedSize == 0) {
     assert(cursorLocation() == m_draftTextBuffer);
     return false;

--- a/escher/src/text_field.cpp
+++ b/escher/src/text_field.cpp
@@ -436,8 +436,7 @@ bool TextField::privateHandleMoveEvent(Ion::Events::Event event) {
   if (event == Ion::Events::Left && isEditing() && cursorLocation() > m_contentView.draftTextBuffer()) {
     assert(isEditing());
     UTF8Decoder decoder(m_contentView.draftTextBuffer(), cursorLocation());
-    decoder.previousCodePoint();
-    return setCursorLocation(decoder.stringPosition());
+    return setCursorLocation(decoder.previousGlyphPosition());
   }
   if (event == Ion::Events::ShiftLeft && isEditing()) {
     assert(isEditing());
@@ -446,8 +445,7 @@ bool TextField::privateHandleMoveEvent(Ion::Events::Event event) {
   if (event == Ion::Events::Right && isEditing() && cursorLocation() < m_contentView.draftTextBuffer() + draftTextLength()) {
     assert(isEditing());
     UTF8Decoder decoder(cursorLocation());
-    decoder.nextCodePoint();
-    return setCursorLocation(decoder.stringPosition());
+    return setCursorLocation(decoder.nextGlyphPosition());
   }
   if (event == Ion::Events::ShiftRight && isEditing()) {
     assert(isEditing());

--- a/escher/src/text_field.cpp
+++ b/escher/src/text_field.cpp
@@ -144,7 +144,7 @@ KDSize TextField::ContentView::minimalSizeForOptimalDisplay() const {
   return stringSize;
 }
 
-bool TextField::ContentView::removeCodePoint() {
+bool TextField::ContentView::removePreviousGlyph() {
   assert(m_isEditing);
 
   if (m_horizontalAlignment > 0.0f) {
@@ -152,9 +152,9 @@ bool TextField::ContentView::removeCodePoint() {
      *  will not clean the first char. */
     reloadRectFromPosition(m_draftTextBuffer);
   }
-  // Remove the code point if possible
+  // Remove the glyph if possible
   CodePoint removedCodePoint = 0;
-  int removedSize = UTF8Helper::RemovePreviousCodePoint(m_draftTextBuffer, const_cast<char *>(cursorLocation()), &removedCodePoint);
+  int removedSize = UTF8Helper::RemovePreviousGlyph(m_draftTextBuffer, const_cast<char *>(cursorLocation()), &removedCodePoint);
   if (removedSize == 0) {
     assert(cursorLocation() == m_draftTextBuffer);
     return false;
@@ -325,7 +325,7 @@ bool TextField::privateHandleEvent(Ion::Events::Event event) {
     return true;
   }
   if (event == Ion::Events::Backspace && isEditing()) {
-    return removeCodePoint();
+    return removePreviousGlyph();
   }
   if (event == Ion::Events::Back && isEditing()) {
     setEditing(false, m_hasTwoBuffers);

--- a/escher/src/text_input.cpp
+++ b/escher/src/text_input.cpp
@@ -96,6 +96,23 @@ bool TextInput::removeEndOfLine() {
   return false;
 }
 
+bool TextInput::moveCursorLeft() {
+  if (cursorLocation() <= text()) {
+    assert(cursorLocation() == text());
+    return false;
+  }
+  UTF8Decoder decoder(text(), cursorLocation());
+  return setCursorLocation(decoder.previousGlyphPosition());
+}
+
+bool TextInput::moveCursorRight() {
+  if (UTF8Helper::CodePointIs(cursorLocation(), UCodePointNull)) {
+    return false;
+  }
+  UTF8Decoder decoder(cursorLocation());
+  return setCursorLocation(decoder.nextGlyphPosition());
+}
+
 bool TextInput::privateRemoveEndOfLine() {
   return contentView()->removeEndOfLine();
 }

--- a/escher/src/text_input.cpp
+++ b/escher/src/text_input.cpp
@@ -50,8 +50,8 @@ KDRect TextInput::ContentView::dirtyRectFromPosition(const char * position, bool
 
 /* TextInput */
 
-bool TextInput::removeCodePoint() {
-  contentView()->removeCodePoint();
+bool TextInput::removePreviousGlyph() {
+  contentView()->removePreviousGlyph();
   scrollToCursor();
   return true;
 }

--- a/ion/include/ion/unicode/utf8_decoder.h
+++ b/ion/include/ion/unicode/utf8_decoder.h
@@ -38,6 +38,8 @@ public:
   }
   CodePoint nextCodePoint();
   CodePoint previousCodePoint();
+  const char * nextGlyphPosition();
+  const char * previousGlyphPosition();
   const char * stringPosition() const { return m_stringPosition; }
   static size_t CharSizeOfCodePoint(CodePoint c);
   static size_t CodePointToChars(CodePoint c, char * buffer, size_t bufferSize);

--- a/ion/include/ion/unicode/utf8_helper.h
+++ b/ion/include/ion/unicode/utf8_helper.h
@@ -72,7 +72,7 @@ bool CodePointIsUpperCaseLetter(CodePoint c);
 bool CodePointIsNumber(CodePoint c);
 
 // Shift the buffer and return the number of bytes removed.
-int RemovePreviousGlyph(const char * text, char * location, CodePoint * c);
+int RemovePreviousGlyph(const char * text, char * location, CodePoint * c = nullptr);
 
 /* Return the pointer to the (non combining) code point whose glyph is displayed
  * at the given position, and vice-versa */

--- a/ion/include/ion/unicode/utf8_helper.h
+++ b/ion/include/ion/unicode/utf8_helper.h
@@ -72,7 +72,7 @@ bool CodePointIsUpperCaseLetter(CodePoint c);
 bool CodePointIsNumber(CodePoint c);
 
 // Shift the buffer and return the number of bytes removed.
-int RemovePreviousCodePoint(const char * text, char * location, CodePoint * c);
+int RemovePreviousGlyph(const char * text, char * location, CodePoint * c);
 
 /* Return the pointer to the (non combining) code point whose glyph is displayed
  * at the given position, and vice-versa */

--- a/ion/src/shared/unicode/utf8_decoder.cpp
+++ b/ion/src/shared/unicode/utf8_decoder.cpp
@@ -63,6 +63,30 @@ CodePoint UTF8Decoder::previousCodePoint() {
   return CodePoint(result);
 }
 
+const char * UTF8Decoder::nextGlyphPosition() {
+  assert(*m_stringPosition != 0 && (m_stringPosition == m_string || *(m_stringPosition - 1) != 0));
+  CodePoint followingCodePoint = nextCodePoint();
+  const char * resultGlyphPosition = m_stringPosition;
+  followingCodePoint = nextCodePoint();
+  while (followingCodePoint != UCodePointNull && followingCodePoint.isCombining()) {
+    resultGlyphPosition = m_stringPosition;
+    followingCodePoint = nextCodePoint();
+  }
+  m_stringPosition = resultGlyphPosition;
+  return resultGlyphPosition;
+}
+
+const char * UTF8Decoder::previousGlyphPosition() {
+  assert(m_stringPosition > m_string);
+  CodePoint previousCP = previousCodePoint();
+  const char * resultGlyphPosition = m_stringPosition;
+  while (m_stringPosition > m_string && previousCP.isCombining()) {
+    previousCP = previousCodePoint();
+    resultGlyphPosition = m_stringPosition;
+  }
+  return resultGlyphPosition;
+}
+
 size_t UTF8Decoder::CharSizeOfCodePoint(CodePoint c) {
   if (c <= 0x7F) {
     return 1;

--- a/ion/src/shared/unicode/utf8_helper.cpp
+++ b/ion/src/shared/unicode/utf8_helper.cpp
@@ -267,7 +267,6 @@ bool CodePointIsNumber(CodePoint c) {
 }
 
 int RemovePreviousGlyph(const char * text, char * location, CodePoint * c) {
-  assert(c != nullptr);
   if (location <= text) {
     assert(location == text);
     return 0;
@@ -276,7 +275,9 @@ int RemovePreviousGlyph(const char * text, char * location, CodePoint * c) {
   // Find the previous glyph
   UTF8Decoder decoder(text, location);
   const char * previousGlyphPos = decoder.previousGlyphPosition();
-  *c = decoder.nextCodePoint();
+  if (c != nullptr) {
+    *c = decoder.nextCodePoint();
+  }
 
   // Shift the buffer
   int shiftedSize = location - previousGlyphPos;

--- a/ion/src/shared/unicode/utf8_helper.cpp
+++ b/ion/src/shared/unicode/utf8_helper.cpp
@@ -266,29 +266,29 @@ bool CodePointIsNumber(CodePoint c) {
   return c >= '0' && c <= '9';
 }
 
-int RemovePreviousCodePoint(const char * text, char * location, CodePoint * c) {
+int RemovePreviousGlyph(const char * text, char * location, CodePoint * c) {
   assert(c != nullptr);
   if (location <= text) {
     assert(location == text);
     return 0;
   }
 
-  // Find the previous code point
+  // Find the previous glyph
   UTF8Decoder decoder(text, location);
-  *c = decoder.previousCodePoint();
+  const char * previousGlyphPos = decoder.previousGlyphPosition();
+  *c = decoder.nextCodePoint();
 
   // Shift the buffer
-  int codePointSize = UTF8Decoder::CharSizeOfCodePoint(*c);
-  char * iterator = location - codePointSize;
+  int shiftedSize = location - previousGlyphPos;
+  char * iterator = const_cast<char *>(previousGlyphPos);
   assert(iterator >= text);
   do {
-    *iterator = *(iterator + codePointSize);
+    *iterator = *(iterator + shiftedSize);
     iterator++;
   } while (*(iterator - 1) != 0); // Stop shifting after writing a null terminating char.
 
-  return codePointSize;
+  return shiftedSize;
 }
-
 
 const char * CodePointAtGlyphOffset(const char * buffer, int position) {
   assert(buffer != nullptr);

--- a/ion/test/utf8_decoder.cpp
+++ b/ion/test/utf8_decoder.cpp
@@ -1,5 +1,6 @@
 #include <quiz.h>
 #include <ion/unicode/utf8_decoder.h>
+#include <ion/unicode/utf8_helper.h>
 
 void assert_decodes_to(const char * string, CodePoint c) {
   UTF8Decoder d(string);
@@ -10,6 +11,18 @@ void assert_decodes_to(const char * string, CodePoint c) {
 void assert_previous_code_point_is_to(const char * string, const char * stringPosition, CodePoint c) {
   UTF8Decoder d(string, stringPosition);
   quiz_assert(d.previousCodePoint() == c);
+}
+
+void assert_code_point_at_next_glyph_position_is(const char * string, CodePoint c) {
+  UTF8Decoder d(string);
+  d.nextGlyphPosition();
+  quiz_assert(d.nextCodePoint() == c);
+}
+
+void assert_code_point_at_previous_glyph_position_is(const char * string, const char * stringPosition, CodePoint c) {
+  UTF8Decoder d(string, stringPosition);
+  d.previousGlyphPosition();
+  quiz_assert(d.nextCodePoint() == c);
 }
 
 QUIZ_CASE(ion_utf8_decode_forward) {
@@ -24,4 +37,17 @@ QUIZ_CASE(ion_utf8_decode_backwards) {
   assert_previous_code_point_is_to(a, a+1, *a);
   assert_previous_code_point_is_to(a, a+4, *(a+3));
   assert_previous_code_point_is_to(a, a+6, *(a+5));
+}
+
+QUIZ_CASE(ion_utf8_decoder_next_glyph) {
+  const char * string = u8"a\u0065\u0301i";
+  assert_code_point_at_next_glyph_position_is(string, 'e');
+  assert_code_point_at_next_glyph_position_is(string+1, 'i');
+}
+
+QUIZ_CASE(ion_utf8_decoder_previous_glyph) {
+  const char * string = u8"a\u0065\u0301i";
+  const char * iPosition = UTF8Helper::CodePointSearch(string, 'i');
+  assert_code_point_at_previous_glyph_position_is(string, iPosition, 'e');
+  assert_code_point_at_previous_glyph_position_is(string,string+1, 'a');
 }


### PR DESCRIPTION
Fix Left/Right/Backspace on special UTF8 glyphs ('é' for instance)