### PR TITLE
[python/port] Increase stack limit on emscripten, simulator...

### DIFF
--- a/python/port/port.cpp
+++ b/python/port/port.cpp
@@ -105,7 +105,7 @@ void MicroPython::init(void * heapStart, void * heapEnd) {
 #else
   volatile int stackTop;
   mp_stack_set_top((void *)(&stackTop));
-  mp_stack_set_limit(4000);
+  mp_stack_set_limit(8192);
 #endif
   gc_init(heapStart, heapEnd);
   mp_init();


### PR DESCRIPTION
The value is quite arbitrary, we just do not want to outperfom the
device but still provide more recursion depth.