### PR TITLE
Global access to app

### DIFF
--- a/apps/Makefile
+++ b/apps/Makefile
@@ -38,7 +38,7 @@ snapshots_count = $(words $(apps))
 snapshot_includes = $(foreach i,$(app_headers),-include $(i) )
 epsilon_app_names = '$(foreach i,${EPSILON_APPS},"$(i)", )'
 
-$(call object_for,apps/apps_container_storage.cpp apps/main.cpp): CXXFLAGS += $(snapshot_includes) -DAPPS_CONTAINER_APPS_DECLARATION="$(apps_declaration)" -DAPPS_CONTAINER_SNAPSHOT_DECLARATIONS="$(snapshots_declaration)" -DAPPS_CONTAINER_SNAPSHOT_CONSTRUCTORS="$(snapshots_construction)" -DAPPS_CONTAINER_SNAPSHOT_LIST="$(snapshots_list)" -DAPPS_CONTAINER_SNAPSHOT_COUNT=$(snapshots_count) -DEPSILON_APPS_NAMES=$(epsilon_app_names)
+$(call object_for,apps/apps_container_storage.cpp apps/apps_container.cpp): CXXFLAGS += $(snapshot_includes) -DAPPS_CONTAINER_APPS_DECLARATION="$(apps_declaration)" -DAPPS_CONTAINER_SNAPSHOT_DECLARATIONS="$(snapshots_declaration)" -DAPPS_CONTAINER_SNAPSHOT_CONSTRUCTORS="$(snapshots_construction)" -DAPPS_CONTAINER_SNAPSHOT_LIST="$(snapshots_list)" -DAPPS_CONTAINER_SNAPSHOT_COUNT=$(snapshots_count) -DEPSILON_APPS_NAMES=$(epsilon_app_names)
 
 # I18n file generation
 

--- a/apps/apps_container.cpp
+++ b/apps/apps_container.cpp
@@ -1,4 +1,5 @@
 #include "apps_container.h"
+#include "apps_container_storage.h"
 #include "global_preferences.h"
 #include <ion.h>
 #include <poincare/init.h>
@@ -51,6 +52,11 @@ static KDColor sPromptColors[] = {
   Palette::YellowDark};
 
 #endif
+
+AppsContainer * AppsContainer::sharedAppsContainer() {
+  static AppsContainerStorage appsContainerStorage;
+  return &appsContainerStorage;
+}
 
 AppsContainer::AppsContainer() :
   Container(),

--- a/apps/apps_container.cpp
+++ b/apps/apps_container.cpp
@@ -241,6 +241,7 @@ bool AppsContainer::switchTo(App::Snapshot * snapshot) {
 }
 
 void AppsContainer::run() {
+  setSharedContainer(this);
   window()->setFrame(KDRect(0, 0, Ion::Display::Width, Ion::Display::Height));
   refreshPreferences();
 

--- a/apps/apps_container.cpp
+++ b/apps/apps_container.cpp
@@ -247,7 +247,6 @@ bool AppsContainer::switchTo(App::Snapshot * snapshot) {
 }
 
 void AppsContainer::run() {
-  setSharedContainer(this);
   window()->setFrame(KDRect(0, 0, Ion::Display::Width, Ion::Display::Height));
   refreshPreferences();
 

--- a/apps/apps_container.cpp
+++ b/apps/apps_container.cpp
@@ -64,8 +64,8 @@ AppsContainer::AppsContainer() :
 #elif EPSILON_BOOT_PROMPT == EPSILON_UPDATE_PROMPT
   m_promptController(sPromptMessages, sPromptColors, 6),
 #endif
-  m_batteryTimer(BatteryTimer(this)),
-  m_suspendTimer(SuspendTimer(this)),
+  m_batteryTimer(),
+  m_suspendTimer(),
   m_backlightDimmingTimer(),
   m_homeSnapshot(),
   m_onBoardingSnapshot(),

--- a/apps/apps_container.h
+++ b/apps/apps_container.h
@@ -24,6 +24,9 @@
 
 class AppsContainer : public Container, ExamPopUpControllerDelegate, Ion::StorageDelegate {
 public:
+  static AppsContainer * sharedAppsContainer() {
+    return static_cast<AppsContainer *>(Container::sharedContainer());
+  }
   AppsContainer();
   static bool poincareCircuitBreaker();
   virtual int numberOfApps() = 0;

--- a/apps/apps_container.h
+++ b/apps/apps_container.h
@@ -24,9 +24,7 @@
 
 class AppsContainer : public Container, ExamPopUpControllerDelegate, Ion::StorageDelegate {
 public:
-  static AppsContainer * sharedAppsContainer() {
-    return static_cast<AppsContainer *>(Container::sharedContainer());
-  }
+  static AppsContainer * sharedAppsContainer();
   AppsContainer();
   static bool poincareCircuitBreaker();
   virtual int numberOfApps() = 0;

--- a/apps/apps_container_storage.cpp
+++ b/apps/apps_container_storage.cpp
@@ -14,11 +14,6 @@
 
 constexpr int k_numberOfCommonApps = 1+APPS_CONTAINER_SNAPSHOT_COUNT; // Take the Home app into account
 
-AppsContainerStorage * AppsContainerStorage::sharedContainer() {
-  static AppsContainerStorage appsContainerStorage;
-  return &appsContainerStorage;
-}
-
 AppsContainerStorage::AppsContainerStorage() :
   AppsContainer()
   APPS_CONTAINER_SNAPSHOT_CONSTRUCTORS

--- a/apps/apps_container_storage.h
+++ b/apps/apps_container_storage.h
@@ -9,7 +9,6 @@
 
 class AppsContainerStorage : public AppsContainer {
 public:
-  static AppsContainerStorage * sharedContainer();
   AppsContainerStorage();
   int numberOfApps() override;
   App::Snapshot * appSnapshotAtIndex(int index) override;

--- a/apps/battery_timer.cpp
+++ b/apps/battery_timer.cpp
@@ -1,16 +1,16 @@
 #include "battery_timer.h"
 #include "apps_container.h"
 
-BatteryTimer::BatteryTimer(AppsContainer * container) :
-  Timer(1),
-  m_container(container)
+BatteryTimer::BatteryTimer() :
+  Timer(1)
 {
 }
 
 bool BatteryTimer::fire() {
-  bool needRedrawing = m_container->updateBatteryState();
+  AppsContainer * container = AppsContainer::sharedAppsContainer();
+  bool needRedrawing = container->updateBatteryState();
   if (Ion::Battery::level() == Ion::Battery::Charge::EMPTY) {
-    m_container->shutdownDueToLowBattery();
+    container->shutdownDueToLowBattery();
   }
   return needRedrawing;
 }

--- a/apps/battery_timer.h
+++ b/apps/battery_timer.h
@@ -3,14 +3,11 @@
 
 #include <escher.h>
 
-class AppsContainer;
-
 class BatteryTimer : public Timer {
 public:
-  BatteryTimer(AppsContainer * container);
+  BatteryTimer();
 private:
   bool fire() override;
-  AppsContainer * m_container;
 };
 
 #endif

--- a/apps/calculation/app.cpp
+++ b/apps/calculation/app.cpp
@@ -23,7 +23,7 @@ const Image * App::Descriptor::icon() {
 }
 
 App * App::Snapshot::unpack(Container * container) {
-  return new (container->currentAppBuffer()) App(container, this);
+  return new (container->currentAppBuffer()) App(this);
 }
 
 void App::Snapshot::reset() {
@@ -39,8 +39,8 @@ void App::Snapshot::tidy() {
   m_calculationStore.tidy();
 }
 
-App::App(Container * container, Snapshot * snapshot) :
-  ExpressionFieldDelegateApp(container, snapshot, &m_editExpressionController),
+App::App(Snapshot * snapshot) :
+  ExpressionFieldDelegateApp(snapshot, &m_editExpressionController),
   m_historyController(&m_editExpressionController, snapshot->calculationStore()),
   m_editExpressionController(&m_modalViewController, this, &m_historyController, snapshot->calculationStore())
 {

--- a/apps/calculation/app.cpp
+++ b/apps/calculation/app.cpp
@@ -1,5 +1,4 @@
 #include "app.h"
-#include "../apps_container.h"
 #include "calculation_icon.h"
 #include <apps/i18n.h>
 #include <poincare/symbol.h>

--- a/apps/calculation/app.h
+++ b/apps/calculation/app.h
@@ -34,7 +34,7 @@ public:
   bool storeExpressionAllowed() const override { return true; }
   char XNT() override;
 private:
-  App(Container * container, Snapshot * snapshot);
+  App(Snapshot * snapshot);
   HistoryController m_historyController;
   EditExpressionController m_editExpressionController;
 };

--- a/apps/calculation/app.h
+++ b/apps/calculation/app.h
@@ -27,6 +27,9 @@ public:
     void tidy() override;
     CalculationStore m_calculationStore;
   };
+  static App * app() {
+    return static_cast<App *>(Container::activeApp());
+  }
   bool textFieldDidReceiveEvent(::TextField * textField, Ion::Events::Event event) override;
   bool layoutFieldDidReceiveEvent(::LayoutField * layoutField, Ion::Events::Event event) override;
   // TextFieldDelegateApp
@@ -38,10 +41,6 @@ private:
   HistoryController m_historyController;
   EditExpressionController m_editExpressionController;
 };
-
-inline App * app() {
-  return static_cast<App *>(Container::activeApp());
-}
 
 }
 

--- a/apps/calculation/app.h
+++ b/apps/calculation/app.h
@@ -39,6 +39,10 @@ private:
   EditExpressionController m_editExpressionController;
 };
 
+inline App * app() {
+  return static_cast<App *>(::app());
+}
+
 }
 
 #endif

--- a/apps/calculation/app.h
+++ b/apps/calculation/app.h
@@ -40,7 +40,7 @@ private:
 };
 
 inline App * app() {
-  return static_cast<App *>(::app());
+  return static_cast<App *>(Container::activeApp());
 }
 
 }

--- a/apps/calculation/edit_expression_controller.cpp
+++ b/apps/calculation/edit_expression_controller.cpp
@@ -69,7 +69,7 @@ bool EditExpressionController::textFieldDidReceiveEvent(::TextField * textField,
   if (inputViewDidReceiveEvent(event, shouldDuplicateLastCalculation)) {
     return true;
   }
-  return textFieldDelegateApp()->textFieldDidReceiveEvent(textField, event);
+  return app()->textFieldDidReceiveEvent(textField, event);
 }
 
 bool EditExpressionController::textFieldDidFinishEditing(::TextField * textField, const char * text, Ion::Events::Event event) {
@@ -85,7 +85,7 @@ bool EditExpressionController::layoutFieldDidReceiveEvent(::LayoutField * layout
   if (inputViewDidReceiveEvent(event, shouldDuplicateLastCalculation)) {
     return true;
   }
-  return expressionFieldDelegateApp()->layoutFieldDidReceiveEvent(layoutField, event);
+  return app()->layoutFieldDidReceiveEvent(layoutField, event);
 }
 
 bool EditExpressionController::layoutFieldDidFinishEditing(::LayoutField * layoutField, Layout layoutR, Ion::Events::Event event) {

--- a/apps/calculation/edit_expression_controller.cpp
+++ b/apps/calculation/edit_expression_controller.cpp
@@ -61,7 +61,7 @@ void EditExpressionController::didBecomeFirstResponder() {
   int lastRow = m_calculationStore->numberOfCalculations() > 0 ? m_calculationStore->numberOfCalculations()-1 : 0;
   m_historyController->scrollToCell(0, lastRow);
   ((ContentView *)view())->expressionField()->setEditing(true, false);
-  app()->setFirstResponder(((ContentView *)view())->expressionField());
+  Container::activeApp()->setFirstResponder(((ContentView *)view())->expressionField());
 }
 
 bool EditExpressionController::textFieldDidReceiveEvent(::TextField * textField, Ion::Events::Event event) {
@@ -133,7 +133,7 @@ bool EditExpressionController::inputViewDidReceiveEvent(Ion::Events::Event event
     if (m_calculationStore->numberOfCalculations() > 0) {
       m_cacheBuffer[0] = 0;
       ((ContentView *)view())->expressionField()->setEditing(false, false);
-      app()->setFirstResponder(m_historyController);
+      Container::activeApp()->setFirstResponder(m_historyController);
     }
     return true;
   }

--- a/apps/calculation/edit_expression_controller.cpp
+++ b/apps/calculation/edit_expression_controller.cpp
@@ -121,7 +121,6 @@ bool EditExpressionController::inputViewDidReceiveEvent(Ion::Events::Event event
     /* The input text store in m_cacheBuffer might have beed correct the first
      * time but then be too long when replacing ans in another context */
     if (!app()->isAcceptableText(m_cacheBuffer)) {
-      app()->displayWarning(I18n::Message::SyntaxError);
       return true;
     }
     m_calculationStore->push(m_cacheBuffer, app()->localContext());

--- a/apps/calculation/edit_expression_controller.cpp
+++ b/apps/calculation/edit_expression_controller.cpp
@@ -109,11 +109,11 @@ void EditExpressionController::layoutFieldDidChangeSize(::LayoutField * layoutFi
 }
 
 TextFieldDelegateApp * EditExpressionController::textFieldDelegateApp() {
-  return (App *)app();
+  return app();
 }
 
 ExpressionFieldDelegateApp * EditExpressionController::expressionFieldDelegateApp() {
-  return (App *)app();
+  return app();
 }
 
 void EditExpressionController::reloadView() {
@@ -126,14 +126,13 @@ void EditExpressionController::reloadView() {
 
 bool EditExpressionController::inputViewDidReceiveEvent(Ion::Events::Event event, bool shouldDuplicateLastCalculation) {
   if (shouldDuplicateLastCalculation && m_cacheBuffer[0] != 0) {
-    App * calculationApp = (App *)app();
     /* The input text store in m_cacheBuffer might have beed correct the first
      * time but then be too long when replacing ans in another context */
-    if (!calculationApp->isAcceptableText(m_cacheBuffer)) {
-      calculationApp->displayWarning(I18n::Message::SyntaxError);
+    if (!app()->isAcceptableText(m_cacheBuffer)) {
+      app()->displayWarning(I18n::Message::SyntaxError);
       return true;
     }
-    m_calculationStore->push(m_cacheBuffer, calculationApp->localContext());
+    m_calculationStore->push(m_cacheBuffer, app()->localContext());
     m_historyController->reload();
     ((ContentView *)view())->mainView()->scrollToCell(0, m_historyController->numberOfRows()-1);
     return true;
@@ -151,14 +150,13 @@ bool EditExpressionController::inputViewDidReceiveEvent(Ion::Events::Event event
 
 
 bool EditExpressionController::inputViewDidFinishEditing(const char * text, Layout layoutR) {
-  App * calculationApp = (App *)app();
   if (layoutR.isUninitialized()) {
     assert(text);
     strlcpy(m_cacheBuffer, text, k_cacheBufferSize);
   } else {
     layoutR.serializeParsedExpression(m_cacheBuffer, k_cacheBufferSize);
   }
-  m_calculationStore->push(m_cacheBuffer, calculationApp->localContext());
+  m_calculationStore->push(m_cacheBuffer, app()->localContext());
   m_historyController->reload();
   ((ContentView *)view())->mainView()->scrollToCell(0, m_historyController->numberOfRows()-1);
   ((ContentView *)view())->expressionField()->setEditing(true, true);

--- a/apps/calculation/edit_expression_controller.cpp
+++ b/apps/calculation/edit_expression_controller.cpp
@@ -108,10 +108,6 @@ void EditExpressionController::layoutFieldDidChangeSize(::LayoutField * layoutFi
   }
 }
 
-TextFieldDelegateApp * EditExpressionController::textFieldDelegateApp() {
-  return app();
-}
-
 void EditExpressionController::reloadView() {
   ((ContentView *)view())->reload();
   m_historyController->reload();

--- a/apps/calculation/edit_expression_controller.cpp
+++ b/apps/calculation/edit_expression_controller.cpp
@@ -112,10 +112,6 @@ TextFieldDelegateApp * EditExpressionController::textFieldDelegateApp() {
   return app();
 }
 
-ExpressionFieldDelegateApp * EditExpressionController::expressionFieldDelegateApp() {
-  return app();
-}
-
 void EditExpressionController::reloadView() {
   ((ContentView *)view())->reload();
   m_historyController->reload();

--- a/apps/calculation/edit_expression_controller.cpp
+++ b/apps/calculation/edit_expression_controller.cpp
@@ -69,7 +69,7 @@ bool EditExpressionController::textFieldDidReceiveEvent(::TextField * textField,
   if (inputViewDidReceiveEvent(event, shouldDuplicateLastCalculation)) {
     return true;
   }
-  return app()->textFieldDidReceiveEvent(textField, event);
+  return textFieldDelegateApp()->textFieldDidReceiveEvent(textField, event);
 }
 
 bool EditExpressionController::textFieldDidFinishEditing(::TextField * textField, const char * text, Ion::Events::Event event) {
@@ -120,10 +120,11 @@ bool EditExpressionController::inputViewDidReceiveEvent(Ion::Events::Event event
   if (shouldDuplicateLastCalculation && m_cacheBuffer[0] != 0) {
     /* The input text store in m_cacheBuffer might have beed correct the first
      * time but then be too long when replacing ans in another context */
-    if (!app()->isAcceptableText(m_cacheBuffer)) {
+    Shared::TextFieldDelegateApp * myApp = textFieldDelegateApp();
+    if (!myApp->isAcceptableText(m_cacheBuffer)) {
       return true;
     }
-    m_calculationStore->push(m_cacheBuffer, app()->localContext());
+    m_calculationStore->push(m_cacheBuffer, myApp->localContext());
     m_historyController->reload();
     ((ContentView *)view())->mainView()->scrollToCell(0, m_historyController->numberOfRows()-1);
     return true;
@@ -147,7 +148,7 @@ bool EditExpressionController::inputViewDidFinishEditing(const char * text, Layo
   } else {
     layoutR.serializeParsedExpression(m_cacheBuffer, k_cacheBufferSize);
   }
-  m_calculationStore->push(m_cacheBuffer, app()->localContext());
+  m_calculationStore->push(m_cacheBuffer, textFieldDelegateApp()->localContext());
   m_historyController->reload();
   ((ContentView *)view())->mainView()->scrollToCell(0, m_historyController->numberOfRows()-1);
   ((ContentView *)view())->expressionField()->setEditing(true, true);

--- a/apps/calculation/edit_expression_controller.cpp
+++ b/apps/calculation/edit_expression_controller.cpp
@@ -1,6 +1,5 @@
 #include "edit_expression_controller.h"
 #include "app.h"
-#include "../apps_container.h"
 #include <ion/display.h>
 #include <poincare/preferences.h>
 #include <assert.h>

--- a/apps/calculation/edit_expression_controller.cpp
+++ b/apps/calculation/edit_expression_controller.cpp
@@ -85,7 +85,7 @@ bool EditExpressionController::layoutFieldDidReceiveEvent(::LayoutField * layout
   if (inputViewDidReceiveEvent(event, shouldDuplicateLastCalculation)) {
     return true;
   }
-  return app()->layoutFieldDidReceiveEvent(layoutField, event);
+  return expressionFieldDelegateApp()->layoutFieldDidReceiveEvent(layoutField, event);
 }
 
 bool EditExpressionController::layoutFieldDidFinishEditing(::LayoutField * layoutField, Layout layoutR, Ion::Events::Event event) {

--- a/apps/calculation/edit_expression_controller.h
+++ b/apps/calculation/edit_expression_controller.h
@@ -54,7 +54,6 @@ private:
   bool inputViewDidFinishEditing(const char * text, Poincare::Layout layoutR);
   bool inputViewDidAbortEditing(const char * text);
   Shared::TextFieldDelegateApp * textFieldDelegateApp() override;
-  Shared::ExpressionFieldDelegateApp * expressionFieldDelegateApp() override;
   static constexpr int k_cacheBufferSize = Constant::MaxSerializedExpressionSize;
   char m_cacheBuffer[k_cacheBufferSize];
   HistoryController * m_historyController;

--- a/apps/calculation/edit_expression_controller.h
+++ b/apps/calculation/edit_expression_controller.h
@@ -53,7 +53,6 @@ private:
   bool inputViewDidReceiveEvent(Ion::Events::Event event, bool shouldDuplicateLastCalculation);
   bool inputViewDidFinishEditing(const char * text, Poincare::Layout layoutR);
   bool inputViewDidAbortEditing(const char * text);
-  Shared::TextFieldDelegateApp * textFieldDelegateApp() override;
   static constexpr int k_cacheBufferSize = Constant::MaxSerializedExpressionSize;
   char m_cacheBuffer[k_cacheBufferSize];
   HistoryController * m_historyController;

--- a/apps/calculation/history_controller.cpp
+++ b/apps/calculation/history_controller.cpp
@@ -24,7 +24,7 @@ void HistoryController::reload() {
 
 void HistoryController::didBecomeFirstResponder() {
   selectCellAtLocation(0, numberOfRows()-1);
-  app()->setFirstResponder(&m_selectableTableView);
+  Container::activeApp()->setFirstResponder(&m_selectableTableView);
 }
 
 void HistoryController::willExitResponderChain(Responder * nextFirstResponder) {
@@ -36,7 +36,7 @@ void HistoryController::willExitResponderChain(Responder * nextFirstResponder) {
 bool HistoryController::handleEvent(Ion::Events::Event event) {
   if (event == Ion::Events::Down) {
     m_selectableTableView.deselectTable();
-    app()->setFirstResponder(parentResponder());
+    Container::activeApp()->setFirstResponder(parentResponder());
     return true;
   }
   if (event == Ion::Events::Up) {
@@ -48,7 +48,7 @@ bool HistoryController::handleEvent(Ion::Events::Event event) {
     SubviewType subviewType = selectedSubviewType();
     EditExpressionController * editController = (EditExpressionController *)parentResponder();
     m_selectableTableView.deselectTable();
-    app()->setFirstResponder(editController);
+    Container::activeApp()->setFirstResponder(editController);
     Calculation * calculation = m_calculationStore->calculationAtIndex(focusRow);
     if (subviewType == SubviewType::Input) {
       editController->insertTextBody(calculation->inputText());
@@ -72,7 +72,7 @@ bool HistoryController::handleEvent(Ion::Events::Event event) {
     m_calculationStore->deleteCalculationAtIndex(focusRow);
     reload();
     if (numberOfRows()== 0) {
-      app()->setFirstResponder(editController);
+      Container::activeApp()->setFirstResponder(editController);
       return true;
     }
     if (focusRow > 0) {
@@ -92,13 +92,13 @@ bool HistoryController::handleEvent(Ion::Events::Event event) {
     m_selectableTableView.deselectTable();
     m_calculationStore->deleteAll();
     reload();
-    app()->setFirstResponder(parentResponder());
+    Container::activeApp()->setFirstResponder(parentResponder());
     return true;
   }
   if (event == Ion::Events::Back) {
     EditExpressionController * editController = (EditExpressionController *)parentResponder();
     m_selectableTableView.deselectTable();
-    app()->setFirstResponder(editController);
+    Container::activeApp()->setFirstResponder(editController);
     return true;
   }
   return false;
@@ -120,7 +120,7 @@ void HistoryController::tableViewDidChangeSelection(SelectableTableView * t, int
   if (selectedCell == nullptr) {
     return;
   }
-  app()->setFirstResponder(selectedCell);
+  Container::activeApp()->setFirstResponder(selectedCell);
 }
 
 int HistoryController::numberOfRows() {

--- a/apps/calculation/history_controller.cpp
+++ b/apps/calculation/history_controller.cpp
@@ -1,6 +1,5 @@
 #include "history_controller.h"
 #include "app.h"
-#include "../apps_container.h"
 #include <assert.h>
 
 using namespace Shared;

--- a/apps/calculation/history_controller.cpp
+++ b/apps/calculation/history_controller.cpp
@@ -151,8 +151,7 @@ KDCoordinate HistoryController::rowHeight(int j) {
     return 0;
   }
   Calculation * calculation = m_calculationStore->calculationAtIndex(j);
-  App * calculationApp = (App *)app();
-  return calculation->height(calculationApp->localContext(), j == selectedRow() && selectedSubviewType() == SubviewType::Output) + 4 * Metric::CommonSmallMargin;
+  return calculation->height(app()->localContext(), j == selectedRow() && selectedSubviewType() == SubviewType::Output) + 4 * Metric::CommonSmallMargin;
 }
 
 int HistoryController::typeAtLocation(int i, int j) {

--- a/apps/calculation/history_controller.cpp
+++ b/apps/calculation/history_controller.cpp
@@ -151,7 +151,7 @@ KDCoordinate HistoryController::rowHeight(int j) {
     return 0;
   }
   Calculation * calculation = m_calculationStore->calculationAtIndex(j);
-  return calculation->height(app()->localContext(), j == selectedRow() && selectedSubviewType() == SubviewType::Output) + 4 * Metric::CommonSmallMargin;
+  return calculation->height(App::app()->localContext(), j == selectedRow() && selectedSubviewType() == SubviewType::Output) + 4 * Metric::CommonSmallMargin;
 }
 
 int HistoryController::typeAtLocation(int i, int j) {

--- a/apps/calculation/history_view_cell.cpp
+++ b/apps/calculation/history_view_cell.cpp
@@ -167,9 +167,9 @@ void HistoryViewCell::setCalculation(Calculation * calculation, bool expanded) {
 void HistoryViewCell::didBecomeFirstResponder() {
   assert(m_dataSource);
   if (m_dataSource->selectedSubviewType() == HistoryViewCellDataSource::SubviewType::Input) {
-    app()->setFirstResponder(&m_inputView);
+    Container::activeApp()->setFirstResponder(&m_inputView);
   } else {
-    app()->setFirstResponder(&m_scrollableOutputView);
+    Container::activeApp()->setFirstResponder(&m_scrollableOutputView);
   }
 }
 
@@ -181,7 +181,7 @@ bool HistoryViewCell::handleEvent(Ion::Events::Event event) {
     m_dataSource->setSelectedSubviewType(otherSubviewType, this);
     CalculationSelectableTableView * tableView = (CalculationSelectableTableView *)parentResponder();
     tableView->scrollToSubviewOfTypeOfCellAtLocation(otherSubviewType, tableView->selectedColumn(), tableView->selectedRow());
-    app()->setFirstResponder(this);
+    Container::activeApp()->setFirstResponder(this);
     return true;
   }
   return false;

--- a/apps/calculation/history_view_cell.cpp
+++ b/apps/calculation/history_view_cell.cpp
@@ -75,8 +75,7 @@ void HistoryViewCell::reloadScroll() {
 }
 
 void HistoryViewCell::reloadOutputSelection() {
-  App * calculationApp = (App *)app();
-  Calculation::DisplayOutput display = m_calculation.displayOutput(calculationApp->localContext());
+  Calculation::DisplayOutput display = m_calculation.displayOutput(app()->localContext());
   /* Select the right output according to the calculation display output. This
    * will reload the scroll to display the selected output. */
   if (display == Calculation::DisplayOutput::ExactAndApproximate) {
@@ -140,8 +139,7 @@ void HistoryViewCell::setCalculation(Calculation * calculation, bool expanded) {
   // Memoization
   m_calculation = *calculation;
   m_calculationExpanded = expanded;
-  App * calculationApp = (App *)app();
-  Calculation::DisplayOutput display = calculation->displayOutput(calculationApp->localContext());
+  Calculation::DisplayOutput display = calculation->displayOutput(app()->localContext());
   m_inputView.setLayout(calculation->createInputLayout());
   /* Both output expressions have to be updated at the same time. Otherwise,
    * when updating one layout, if the second one still points to a deleted
@@ -151,13 +149,13 @@ void HistoryViewCell::setCalculation(Calculation * calculation, bool expanded) {
   if (display == Calculation::DisplayOutput::ExactOnly) {
     rightOutputLayout = calculation->createExactOutputLayout();
   } else {
-    rightOutputLayout = calculation->createApproximateOutputLayout(calculationApp->localContext());
+    rightOutputLayout = calculation->createApproximateOutputLayout(app()->localContext());
     if (display == Calculation::DisplayOutput::ExactAndApproximate || (display == Calculation::DisplayOutput::ExactAndApproximateToggle && expanded)) {
       leftOutputLayout = calculation->createExactOutputLayout();
     }
   }
   m_scrollableOutputView.setLayouts(rightOutputLayout, leftOutputLayout);
-  I18n::Message equalMessage = calculation->exactAndApproximateDisplayedOutputsAreEqual(calculationApp->localContext()) == Calculation::EqualSign::Equal ? I18n::Message::Equal : I18n::Message::AlmostEqual;
+  I18n::Message equalMessage = calculation->exactAndApproximateDisplayedOutputsAreEqual(app()->localContext()) == Calculation::EqualSign::Equal ? I18n::Message::Equal : I18n::Message::AlmostEqual;
   m_scrollableOutputView.setEqualMessage(equalMessage);
 
   /* The displayed input and outputs have changed. We need to re-layout the cell

--- a/apps/calculation/history_view_cell.cpp
+++ b/apps/calculation/history_view_cell.cpp
@@ -75,7 +75,7 @@ void HistoryViewCell::reloadScroll() {
 }
 
 void HistoryViewCell::reloadOutputSelection() {
-  Calculation::DisplayOutput display = m_calculation.displayOutput(app()->localContext());
+  Calculation::DisplayOutput display = m_calculation.displayOutput(App::app()->localContext());
   /* Select the right output according to the calculation display output. This
    * will reload the scroll to display the selected output. */
   if (display == Calculation::DisplayOutput::ExactAndApproximate) {
@@ -136,10 +136,11 @@ void HistoryViewCell::setCalculation(Calculation * calculation, bool expanded) {
   if (m_calculationExpanded == expanded && *calculation == m_calculation) {
     return;
   }
+  Poincare::Context * context = App::app()->localContext();
   // Memoization
   m_calculation = *calculation;
   m_calculationExpanded = expanded;
-  Calculation::DisplayOutput display = calculation->displayOutput(app()->localContext());
+  Calculation::DisplayOutput display = calculation->displayOutput(context);
   m_inputView.setLayout(calculation->createInputLayout());
   /* Both output expressions have to be updated at the same time. Otherwise,
    * when updating one layout, if the second one still points to a deleted
@@ -149,13 +150,13 @@ void HistoryViewCell::setCalculation(Calculation * calculation, bool expanded) {
   if (display == Calculation::DisplayOutput::ExactOnly) {
     rightOutputLayout = calculation->createExactOutputLayout();
   } else {
-    rightOutputLayout = calculation->createApproximateOutputLayout(app()->localContext());
+    rightOutputLayout = calculation->createApproximateOutputLayout(context);
     if (display == Calculation::DisplayOutput::ExactAndApproximate || (display == Calculation::DisplayOutput::ExactAndApproximateToggle && expanded)) {
       leftOutputLayout = calculation->createExactOutputLayout();
     }
   }
   m_scrollableOutputView.setLayouts(rightOutputLayout, leftOutputLayout);
-  I18n::Message equalMessage = calculation->exactAndApproximateDisplayedOutputsAreEqual(app()->localContext()) == Calculation::EqualSign::Equal ? I18n::Message::Equal : I18n::Message::AlmostEqual;
+  I18n::Message equalMessage = calculation->exactAndApproximateDisplayedOutputsAreEqual(context) == Calculation::EqualSign::Equal ? I18n::Message::Equal : I18n::Message::AlmostEqual;
   m_scrollableOutputView.setEqualMessage(equalMessage);
 
   /* The displayed input and outputs have changed. We need to re-layout the cell

--- a/apps/code/app.cpp
+++ b/apps/code/app.cpp
@@ -1,5 +1,4 @@
 #include "app.h"
-#include "../apps_container.h"
 #include "code_icon.h"
 #include <apps/i18n.h>
 #include "helpers.h"

--- a/apps/code/app.cpp
+++ b/apps/code/app.cpp
@@ -28,7 +28,7 @@ App::Snapshot::Snapshot() :
 }
 
 App * App::Snapshot::unpack(Container * container) {
-  return new (container->currentAppBuffer()) App(container, this);
+  return new (container->currentAppBuffer()) App(this);
 }
 
 App::Descriptor * App::Snapshot::descriptor() {
@@ -72,8 +72,8 @@ void App::Snapshot::setOpt(const char * name, char * value) {
 }
 #endif
 
-App::App(Container * container, Snapshot * snapshot) :
-  Shared::InputEventHandlerDelegateApp(container, snapshot, &m_codeStackViewController),
+App::App(Snapshot * snapshot) :
+  Shared::InputEventHandlerDelegateApp(snapshot, &m_codeStackViewController),
   m_pythonHeap{},
   m_pythonUser(nullptr),
   m_consoleController(nullptr, this, snapshot->scriptStore()

--- a/apps/code/app.h
+++ b/apps/code/app.h
@@ -85,7 +85,7 @@ private:
 };
 
 inline App * app() {
-  return static_cast<App *>(::app());
+  return static_cast<App *>(Container::activeApp());
 }
 
 }

--- a/apps/code/app.h
+++ b/apps/code/app.h
@@ -84,6 +84,10 @@ private:
   VariableBoxController m_variableBoxController;
 };
 
+inline App * app() {
+  return static_cast<App *>(::app());
+}
+
 }
 
 #endif

--- a/apps/code/app.h
+++ b/apps/code/app.h
@@ -75,7 +75,7 @@ private:
   char m_pythonHeap[k_pythonHeapSize];
   const void * m_pythonUser;
 
-  App(Container * container, Snapshot * snapshot);
+  App(Snapshot * snapshot);
   ConsoleController m_consoleController;
   ButtonRowController m_listFooter;
   MenuController m_menuController;

--- a/apps/code/app.h
+++ b/apps/code/app.h
@@ -36,6 +36,9 @@ public:
 #endif
     ScriptStore m_scriptStore;
   };
+  static App * app() {
+    return static_cast<App *>(Container::activeApp());
+  }
   ~App();
   bool prepareForExit() override {
     if (m_consoleController.inputRunLoopActive()) {
@@ -83,10 +86,6 @@ private:
   PythonToolbox m_toolbox;
   VariableBoxController m_variableBoxController;
 };
-
-inline App * app() {
-  return static_cast<App *>(Container::activeApp());
-}
 
 }
 

--- a/apps/code/console_controller.cpp
+++ b/apps/code/console_controller.cpp
@@ -153,7 +153,7 @@ void ConsoleController::viewWillAppear() {
 }
 
 void ConsoleController::didBecomeFirstResponder() {
-  app()->setFirstResponder(&m_editCell);
+  Container::activeApp()->setFirstResponder(&m_editCell);
 }
 
 bool ConsoleController::handleEvent(Ion::Events::Event event) {
@@ -162,7 +162,7 @@ bool ConsoleController::handleEvent(Ion::Events::Event event) {
       const char * text = m_consoleStore.lineAtIndex(m_selectableTableView.selectedRow()).text();
       m_editCell.setEditing(true);
       m_selectableTableView.selectCellAtLocation(0, m_consoleStore.numberOfLines());
-      app()->setFirstResponder(&m_editCell);
+      Container::activeApp()->setFirstResponder(&m_editCell);
       return m_editCell.insertText(text);
     }
   } else if (event == Ion::Events::Clear) {

--- a/apps/code/console_controller.cpp
+++ b/apps/code/console_controller.cpp
@@ -57,7 +57,7 @@ bool ConsoleController::loadPythonEnvironment() {
   /* We load functions and variables names in the variable box before running
    * any other python code to avoid failling to load functions and variables
    * due to memory exhaustion. */
-  static_cast<App *>(app())->variableBoxController()->loadFunctionsAndVariables();
+  app()->variableBoxController()->loadFunctionsAndVariables();
   return true;
 }
 
@@ -290,7 +290,7 @@ bool ConsoleController::textFieldDidReceiveEvent(TextField * textField, Ion::Eve
       return true;
     }
   }
-  return static_cast<App *>(app())->textInputDidReceiveEvent(textField, event);
+  return app()->textInputDidReceiveEvent(textField, event);
 }
 
 bool ConsoleController::textFieldDidFinishEditing(TextField * textField, const char * text, Ion::Events::Event event) {

--- a/apps/code/console_controller.cpp
+++ b/apps/code/console_controller.cpp
@@ -290,7 +290,7 @@ bool ConsoleController::textFieldDidReceiveEvent(TextField * textField, Ion::Eve
       return true;
     }
   }
-  return static_cast<App *>(textField->app())->textInputDidReceiveEvent(textField, event);
+  return static_cast<App *>(app())->textInputDidReceiveEvent(textField, event);
 }
 
 bool ConsoleController::textFieldDidFinishEditing(TextField * textField, const char * text, Ion::Events::Event event) {

--- a/apps/code/console_controller.cpp
+++ b/apps/code/console_controller.cpp
@@ -57,7 +57,7 @@ bool ConsoleController::loadPythonEnvironment() {
   /* We load functions and variables names in the variable box before running
    * any other python code to avoid failling to load functions and variables
    * due to memory exhaustion. */
-  app()->variableBoxController()->loadFunctionsAndVariables();
+  App::app()->variableBoxController()->loadFunctionsAndVariables();
   return true;
 }
 
@@ -290,7 +290,7 @@ bool ConsoleController::textFieldDidReceiveEvent(TextField * textField, Ion::Eve
       return true;
     }
   }
-  return app()->textInputDidReceiveEvent(textField, event);
+  return App::app()->textInputDidReceiveEvent(textField, event);
 }
 
 bool ConsoleController::textFieldDidFinishEditing(TextField * textField, const char * text, Ion::Events::Event event) {

--- a/apps/code/console_controller.cpp
+++ b/apps/code/console_controller.cpp
@@ -90,7 +90,7 @@ void ConsoleController::terminateInputLoop() {
 }
 
 const char * ConsoleController::inputText(const char * prompt) {
-  AppsContainer * a = (AppsContainer *)(app()->container());
+  AppsContainer * appsContainer = AppsContainer::sharedAppsContainer();
   m_inputRunLoopActive = true;
 
   const char * promptText = prompt;
@@ -119,10 +119,10 @@ const char * ConsoleController::inputText(const char * prompt) {
   // Reload the history
   m_selectableTableView.reloadData();
   m_selectableTableView.selectCellAtLocation(0, m_consoleStore.numberOfLines());
-  a->redrawWindow();
+  appsContainer->redrawWindow();
 
   // Launch a new input loop
-  a->runWhile([](void * a){
+  appsContainer->runWhile([](void * a){
       ConsoleController * c = static_cast<ConsoleController *>(a);
       return c->inputRunLoopActive();
   }, this);

--- a/apps/code/console_edit_cell.cpp
+++ b/apps/code/console_edit_cell.cpp
@@ -35,7 +35,7 @@ void ConsoleEditCell::layoutSubviews() {
 }
 
 void ConsoleEditCell::didBecomeFirstResponder() {
-  app()->setFirstResponder(&m_textField);
+  Container::activeApp()->setFirstResponder(&m_textField);
 }
 
 void ConsoleEditCell::setEditing(bool isEditing,  bool reinitDraftBuffer) {

--- a/apps/code/console_line_cell.cpp
+++ b/apps/code/console_line_cell.cpp
@@ -90,7 +90,7 @@ void ConsoleLineCell::layoutSubviews() {
 }
 
 void ConsoleLineCell::didBecomeFirstResponder() {
-  app()->setFirstResponder(&m_scrollableView);
+  Container::activeApp()->setFirstResponder(&m_scrollableView);
 }
 
 }

--- a/apps/code/editor_controller.cpp
+++ b/apps/code/editor_controller.cpp
@@ -114,10 +114,6 @@ VariableBoxController * EditorController::variableBoxForInputEventHandler(InputE
   return varBox;
 }
 
-InputEventHandlerDelegateApp * EditorController::inputEventHandlerDelegateApp() {
-  return app();
-}
-
 StackViewController * EditorController::stackController() {
   return static_cast<StackViewController *>(parentResponder());
 }

--- a/apps/code/editor_controller.cpp
+++ b/apps/code/editor_controller.cpp
@@ -39,7 +39,7 @@ bool EditorController::handleEvent(Ion::Events::Event event) {
 }
 
 void EditorController::didBecomeFirstResponder() {
-  app()->setFirstResponder(&m_editorView);
+  Container::activeApp()->setFirstResponder(&m_editorView);
 }
 
 void EditorController::viewWillAppear() {

--- a/apps/code/editor_controller.cpp
+++ b/apps/code/editor_controller.cpp
@@ -58,7 +58,7 @@ bool EditorController::textAreaDidReceiveEvent(TextArea * textArea, Ion::Events:
     saveScript();
     return false;
   }
-  if (app()->textInputDidReceiveEvent(textArea, event)) {
+  if (App::app()->textInputDidReceiveEvent(textArea, event)) {
     return true;
   }
   if (event == Ion::Events::EXE) {
@@ -109,7 +109,7 @@ bool EditorController::textAreaDidReceiveEvent(TextArea * textArea, Ion::Events:
 }
 
 VariableBoxController * EditorController::variableBoxForInputEventHandler(InputEventHandler * textInput) {
-  VariableBoxController * varBox = app()->variableBoxController();
+  VariableBoxController * varBox = App::app()->variableBoxController();
   varBox->loadFunctionsAndVariables();
   return varBox;
 }

--- a/apps/code/editor_controller.cpp
+++ b/apps/code/editor_controller.cpp
@@ -58,7 +58,7 @@ bool EditorController::textAreaDidReceiveEvent(TextArea * textArea, Ion::Events:
     saveScript();
     return false;
   }
-  if (static_cast<App *>(app())->textInputDidReceiveEvent(textArea, event)) {
+  if (app()->textInputDidReceiveEvent(textArea, event)) {
     return true;
   }
   if (event == Ion::Events::EXE) {
@@ -109,13 +109,13 @@ bool EditorController::textAreaDidReceiveEvent(TextArea * textArea, Ion::Events:
 }
 
 VariableBoxController * EditorController::variableBoxForInputEventHandler(InputEventHandler * textInput) {
-  VariableBoxController * varBox = static_cast<App *>(app())->variableBoxController();
+  VariableBoxController * varBox = app()->variableBoxController();
   varBox->loadFunctionsAndVariables();
   return varBox;
 }
 
 InputEventHandlerDelegateApp * EditorController::inputEventHandlerDelegateApp() {
-  return static_cast<App *>(app());
+  return app();
 }
 
 StackViewController * EditorController::stackController() {

--- a/apps/code/editor_controller.cpp
+++ b/apps/code/editor_controller.cpp
@@ -58,7 +58,7 @@ bool EditorController::textAreaDidReceiveEvent(TextArea * textArea, Ion::Events:
     saveScript();
     return false;
   }
-  if (static_cast<App *>(textArea->app())->textInputDidReceiveEvent(textArea, event)) {
+  if (static_cast<App *>(app())->textInputDidReceiveEvent(textArea, event)) {
     return true;
   }
   if (event == Ion::Events::EXE) {

--- a/apps/code/editor_controller.h
+++ b/apps/code/editor_controller.h
@@ -33,7 +33,6 @@ public:
   VariableBoxController * variableBoxForInputEventHandler(InputEventHandler * textInput) override;
 
 private:
-  Shared::InputEventHandlerDelegateApp * inputEventHandlerDelegateApp() override;
   static constexpr int k_indentationSpacesNumber = 2; //TODO LEA merge with text area k_indentationSpaces
   StackViewController * stackController();
   void saveScript();

--- a/apps/code/editor_view.cpp
+++ b/apps/code/editor_view.cpp
@@ -31,7 +31,7 @@ View * EditorView::subviewAtIndex(int index) {
 }
 
 void EditorView::didBecomeFirstResponder() {
-  app()->setFirstResponder(&m_textArea);
+  Container::activeApp()->setFirstResponder(&m_textArea);
 }
 
 void EditorView::layoutSubviews() {

--- a/apps/code/menu_controller.cpp
+++ b/apps/code/menu_controller.cpp
@@ -36,7 +36,7 @@ MenuController::MenuController(Responder * parentResponder, App * pythonDelegate
 }
 
 ConsoleController * MenuController::consoleController() {
-  return app()->consoleController();
+  return App::app()->consoleController();
 }
 
 StackViewController * MenuController::stackViewController() {

--- a/apps/code/menu_controller.cpp
+++ b/apps/code/menu_controller.cpp
@@ -121,7 +121,7 @@ bool MenuController::handleEvent(Ion::Events::Event event) {
 void MenuController::renameSelectedScript() {
   assert(m_selectableTableView.selectedRow() >= 0);
   assert(m_selectableTableView.selectedRow() < m_scriptStore->numberOfScripts());
-  static_cast<AppsContainer *>(const_cast<Container *>(app()->container()))->setShiftAlphaStatus(Ion::Events::ShiftAlphaStatus::AlphaLock);
+  AppsContainer::sharedAppsContainer()->setShiftAlphaStatus(Ion::Events::ShiftAlphaStatus::AlphaLock);
   m_selectableTableView.selectCellAtLocation(0, (m_selectableTableView.selectedRow()));
   ScriptNameCell * myCell = static_cast<ScriptNameCell *>(m_selectableTableView.selectedCell());
   app()->setFirstResponder(myCell);
@@ -338,7 +338,7 @@ bool MenuController::textFieldDidFinishEditing(TextField * textField, const char
     m_selectableTableView.selectedCell()->setHighlighted(true);
     reloadConsole();
     app()->setFirstResponder(&m_selectableTableView);
-    static_cast<AppsContainer *>(const_cast<Container *>(app()->container()))->setShiftAlphaStatus(Ion::Events::ShiftAlphaStatus::Default);
+    AppsContainer::sharedAppsContainer()->setShiftAlphaStatus(Ion::Events::ShiftAlphaStatus::Default);
     return true;
   } else if (error == Script::ErrorStatus::NameTaken) {
     app()->displayWarning(I18n::Message::NameTaken);
@@ -422,7 +422,7 @@ bool MenuController::privateTextFieldDidAbortEditing(TextField * textField, bool
     m_selectableTableView.selectCellAtLocation(m_selectableTableView.selectedColumn(), m_selectableTableView.selectedRow());
     app()->setFirstResponder(&m_selectableTableView);
   }
-  static_cast<AppsContainer *>(const_cast<Container *>(app()->container()))->setShiftAlphaStatus(Ion::Events::ShiftAlphaStatus::Default);
+  AppsContainer::sharedAppsContainer()->setShiftAlphaStatus(Ion::Events::ShiftAlphaStatus::Default);
   return true;
 }
 

--- a/apps/code/menu_controller.cpp
+++ b/apps/code/menu_controller.cpp
@@ -36,7 +36,7 @@ MenuController::MenuController(Responder * parentResponder, App * pythonDelegate
 }
 
 ConsoleController * MenuController::consoleController() {
-  return static_cast<App *>(app())->consoleController();
+  return app()->consoleController();
 }
 
 StackViewController * MenuController::stackViewController() {

--- a/apps/code/menu_controller.cpp
+++ b/apps/code/menu_controller.cpp
@@ -61,14 +61,14 @@ void MenuController::didBecomeFirstResponder() {
   }
   if (footer()->selectedButton() == 0) {
     assert(m_selectableTableView.selectedRow() < 0);
-    app()->setFirstResponder(&m_consoleButton);
+    Container::activeApp()->setFirstResponder(&m_consoleButton);
     return;
   }
   if (m_selectableTableView.selectedRow() < 0) {
     m_selectableTableView.selectCellAtLocation(0,0);
   }
   assert(m_selectableTableView.selectedRow() < m_scriptStore->numberOfScripts() + 1);
-  app()->setFirstResponder(&m_selectableTableView);
+  Container::activeApp()->setFirstResponder(&m_selectableTableView);
 #if EPSILON_GETOPT
   if (consoleController()->locked()) {
     consoleController()->setAutoImport(true);
@@ -92,7 +92,7 @@ bool MenuController::handleEvent(Ion::Events::Event event) {
     if (footer()->selectedButton() == 0) {
       footer()->setSelectedButton(-1);
       m_selectableTableView.selectCellAtLocation(0, numberOfRows()-1);
-      app()->setFirstResponder(&m_selectableTableView);
+      Container::activeApp()->setFirstResponder(&m_selectableTableView);
       return true;
     }
   }
@@ -124,7 +124,7 @@ void MenuController::renameSelectedScript() {
   AppsContainer::sharedAppsContainer()->setShiftAlphaStatus(Ion::Events::ShiftAlphaStatus::AlphaLock);
   m_selectableTableView.selectCellAtLocation(0, (m_selectableTableView.selectedRow()));
   ScriptNameCell * myCell = static_cast<ScriptNameCell *>(m_selectableTableView.selectedCell());
-  app()->setFirstResponder(myCell);
+  Container::activeApp()->setFirstResponder(myCell);
   myCell->setHighlighted(false);
   myCell->textField()->setEditing(true, false);
   myCell->textField()->setCursorLocation(myCell->textField()->text() + strlen(myCell->textField()->text()));
@@ -337,16 +337,16 @@ bool MenuController::textFieldDidFinishEditing(TextField * textField, const char
     }
     m_selectableTableView.selectedCell()->setHighlighted(true);
     reloadConsole();
-    app()->setFirstResponder(&m_selectableTableView);
+    Container::activeApp()->setFirstResponder(&m_selectableTableView);
     AppsContainer::sharedAppsContainer()->setShiftAlphaStatus(Ion::Events::ShiftAlphaStatus::Default);
     return true;
   } else if (error == Script::ErrorStatus::NameTaken) {
-    app()->displayWarning(I18n::Message::NameTaken);
+    Container::activeApp()->displayWarning(I18n::Message::NameTaken);
   } else if (error == Script::ErrorStatus::NonCompliantName) {
-    app()->displayWarning(I18n::Message::AllowedCharactersaz09, I18n::Message::NameCannotStartWithNumber);
+    Container::activeApp()->displayWarning(I18n::Message::AllowedCharactersaz09, I18n::Message::NameCannotStartWithNumber);
   } else {
     assert(error == Script::ErrorStatus::NotEnoughSpaceAvailable);
-    app()->displayWarning(I18n::Message::NameTooLong);
+    Container::activeApp()->displayWarning(I18n::Message::NameTooLong);
   }
   return false;
 }
@@ -420,7 +420,7 @@ bool MenuController::privateTextFieldDidAbortEditing(TextField * textField, bool
   textField->setText(scriptName);
   if (menuControllerStaysInResponderChain) {
     m_selectableTableView.selectCellAtLocation(m_selectableTableView.selectedColumn(), m_selectableTableView.selectedRow());
-    app()->setFirstResponder(&m_selectableTableView);
+    Container::activeApp()->setFirstResponder(&m_selectableTableView);
   }
   AppsContainer::sharedAppsContainer()->setShiftAlphaStatus(Ion::Events::ShiftAlphaStatus::Default);
   return true;

--- a/apps/code/python_toolbox.cpp
+++ b/apps/code/python_toolbox.cpp
@@ -370,7 +370,7 @@ bool PythonToolbox::selectLeaf(int selectedRow) {
     editedText = strippedEditedText;
   }
   sender()->handleEventWithText(editedText, true);
-  app()->dismissModalViewController();
+  Container::activeApp()->dismissModalViewController();
   return true;
 }
 

--- a/apps/code/sandbox_controller.cpp
+++ b/apps/code/sandbox_controller.cpp
@@ -48,7 +48,7 @@ bool SandboxController::handleEvent(Ion::Events::Event event) {
 }
 
 void SandboxController::redrawWindow() {
-  static_cast<AppsContainer *>(const_cast<Container *>(app()->container()))->redrawWindow();
+  AppsContainer::sharedAppsContainer()->redrawWindow();
 }
 
 }

--- a/apps/code/script_name_cell.cpp
+++ b/apps/code/script_name_cell.cpp
@@ -26,7 +26,7 @@ KDSize ScriptNameCell::minimalSizeForOptimalDisplay() const {
 }
 
 void ScriptNameCell::didBecomeFirstResponder() {
-  app()->setFirstResponder(&m_textField);
+  Container::activeApp()->setFirstResponder(&m_textField);
 }
 
 void ScriptNameCell::layoutSubviews() {

--- a/apps/code/script_parameter_controller.cpp
+++ b/apps/code/script_parameter_controller.cpp
@@ -45,7 +45,7 @@ bool ScriptParameterController::handleEvent(Ion::Events::Event event) {
         m_script.toggleImportationStatus();
         m_selectableTableView.reloadData();
         m_menuController->reloadConsole();
-        app()->setFirstResponder(&m_selectableTableView);
+        Container::activeApp()->setFirstResponder(&m_selectableTableView);
         return true;
       case 3:
         dismissScriptParameterController();
@@ -67,7 +67,7 @@ void ScriptParameterController::viewWillAppear() {
 
 void ScriptParameterController::didBecomeFirstResponder() {
   selectCellAtLocation(0, 0);
-  app()->setFirstResponder(&m_selectableTableView);
+  Container::activeApp()->setFirstResponder(&m_selectableTableView);
 }
 
 HighlightCell * ScriptParameterController::reusableCell(int index) {

--- a/apps/code/variable_box_controller.cpp
+++ b/apps/code/variable_box_controller.cpp
@@ -33,7 +33,7 @@ void VariableBoxController::didEnterResponderChain(Responder * previousFirstResp
    * environment where Python has already been inited. This way, we do not
    * deinit Python when leaving the VariableBoxController, so we do not lose the
    * environment that was loaded when entering the VariableBoxController. */
-  assert(static_cast<App *>(app())->pythonIsInited());
+  assert(app()->pythonIsInited());
 }
 
 static bool shouldAddObject(const char * name, int maxLength) {

--- a/apps/code/variable_box_controller.cpp
+++ b/apps/code/variable_box_controller.cpp
@@ -33,7 +33,7 @@ void VariableBoxController::didEnterResponderChain(Responder * previousFirstResp
    * environment where Python has already been inited. This way, we do not
    * deinit Python when leaving the VariableBoxController, so we do not lose the
    * environment that was loaded when entering the VariableBoxController. */
-  assert(app()->pythonIsInited());
+  assert(App::app()->pythonIsInited());
 }
 
 static bool shouldAddObject(const char * name, int maxLength) {

--- a/apps/code/variable_box_controller.cpp
+++ b/apps/code/variable_box_controller.cpp
@@ -100,7 +100,7 @@ bool VariableBoxController::selectLeaf(int rowIndex) {
   if (selectedScriptNode.type() == ScriptNode::Type::Function) {
     insertTextInCaller(ScriptNodeCell::k_parenthesesWithEmpty);
   }
-  app()->dismissModalViewController();
+  Container::activeApp()->dismissModalViewController();
   return true;
 }
 

--- a/apps/exam_pop_up_controller.cpp
+++ b/apps/exam_pop_up_controller.cpp
@@ -47,8 +47,7 @@ bool ExamPopUpController::handleEvent(Ion::Events::Event event) {
 
 ExamPopUpController::ContentView::ContentView(Responder * parentResponder) :
   m_cancelButton(parentResponder, I18n::Message::Cancel, Invocation([](void * context, void * sender) {
-    AppsContainer * container = AppsContainer::sharedAppsContainer();
-    container->activeApp()->dismissModalViewController();
+    Container::activeApp()->dismissModalViewController();
     return true;
   }, parentResponder), KDFont::SmallFont),
   m_okButton(parentResponder, I18n::Message::Ok, Invocation([](void * context, void * sender) {
@@ -64,7 +63,7 @@ ExamPopUpController::ContentView::ContentView(Responder * parentResponder) :
       Ion::LED::setColor(KDColorBlack);
     }
     container->refreshPreferences();
-    container->activeApp()->dismissModalViewController();
+    Container::activeApp()->dismissModalViewController();
     return true;
   }, parentResponder), KDFont::SmallFont),
   m_warningTextView(KDFont::SmallFont, I18n::Message::Warning, 0.5, 0.5, KDColorWhite, KDColorBlack),
@@ -81,7 +80,7 @@ void ExamPopUpController::ContentView::drawRect(KDContext * ctx, KDRect rect) co
 void ExamPopUpController::ContentView::setSelectedButton(int selectedButton) {
   m_cancelButton.setHighlighted(selectedButton == 0);
   m_okButton.setHighlighted(selectedButton == 1);
-  app()->setFirstResponder(selectedButton == 0 ? &m_cancelButton : &m_okButton);
+  Container::activeApp()->setFirstResponder(selectedButton == 0 ? &m_cancelButton : &m_okButton);
 }
 
 int ExamPopUpController::ContentView::selectedButton() {

--- a/apps/exam_pop_up_controller.cpp
+++ b/apps/exam_pop_up_controller.cpp
@@ -47,8 +47,7 @@ bool ExamPopUpController::handleEvent(Ion::Events::Event event) {
 
 ExamPopUpController::ContentView::ContentView(Responder * parentResponder) :
   m_cancelButton(parentResponder, I18n::Message::Cancel, Invocation([](void * context, void * sender) {
-    ExamPopUpController * controller = (ExamPopUpController *)context;
-    Container * container = (Container *)controller->app()->container();
+    AppsContainer * container = AppsContainer::sharedAppsContainer();
     container->activeApp()->dismissModalViewController();
     return true;
   }, parentResponder), KDFont::SmallFont),
@@ -56,7 +55,7 @@ ExamPopUpController::ContentView::ContentView(Responder * parentResponder) :
     ExamPopUpController * controller = (ExamPopUpController *)context;
     GlobalPreferences::ExamMode nextExamMode = controller->isActivatingExamMode() ? GlobalPreferences::ExamMode::Activate : GlobalPreferences::ExamMode::Deactivate;
     GlobalPreferences::sharedGlobalPreferences()->setExamMode(nextExamMode);
-    AppsContainer * container = (AppsContainer *)controller->app()->container();
+    AppsContainer * container = AppsContainer::sharedAppsContainer();
     if (controller->isActivatingExamMode()) {
       container->reset();
       Ion::LED::setColor(KDColorRed);

--- a/apps/exam_pop_up_controller.cpp
+++ b/apps/exam_pop_up_controller.cpp
@@ -30,16 +30,16 @@ void ExamPopUpController::viewDidDisappear() {
 }
 
 void ExamPopUpController::didBecomeFirstResponder() {
-  m_contentView.setSelectedButton(0, app());
+  m_contentView.setSelectedButton(0);
 }
 
 bool ExamPopUpController::handleEvent(Ion::Events::Event event) {
   if (event == Ion::Events::Left && m_contentView.selectedButton() == 1) {
-    m_contentView.setSelectedButton(0, app());
+    m_contentView.setSelectedButton(0);
     return true;
   }
   if (event == Ion::Events::Right && m_contentView.selectedButton() == 0) {
-    m_contentView.setSelectedButton(1, app());
+    m_contentView.setSelectedButton(1);
     return true;
   }
   return false;
@@ -78,14 +78,10 @@ void ExamPopUpController::ContentView::drawRect(KDContext * ctx, KDRect rect) co
   ctx->fillRect(bounds(), KDColorBlack);
 }
 
-void ExamPopUpController::ContentView::setSelectedButton(int selectedButton, App * app) {
+void ExamPopUpController::ContentView::setSelectedButton(int selectedButton) {
   m_cancelButton.setHighlighted(selectedButton == 0);
   m_okButton.setHighlighted(selectedButton == 1);
-  if (selectedButton == 0) {
-    app->setFirstResponder(&m_cancelButton);
-  } else {
-    app->setFirstResponder(&m_okButton);
-  }
+  app()->setFirstResponder(selectedButton == 0 ? &m_cancelButton : &m_okButton);
 }
 
 int ExamPopUpController::ContentView::selectedButton() {

--- a/apps/exam_pop_up_controller.h
+++ b/apps/exam_pop_up_controller.h
@@ -26,7 +26,7 @@ private:
   public:
     ContentView(Responder * parentResponder);
     void drawRect(KDContext * ctx, KDRect rect) const override;
-    void setSelectedButton(int selectedButton, App * app);
+    void setSelectedButton(int selectedButton);
     int selectedButton();
     void setMessages(bool activingExamMode);
   private:

--- a/apps/graph/app.cpp
+++ b/apps/graph/app.cpp
@@ -28,7 +28,7 @@ App::Snapshot::Snapshot() :
 }
 
 App * App::Snapshot::unpack(Container * container) {
-  return new (container->currentAppBuffer()) App(container, this);
+  return new (container->currentAppBuffer()) App(this);
 }
 
 App::Descriptor * App::Snapshot::descriptor() {
@@ -49,8 +49,8 @@ void App::Snapshot::tidy() {
   m_graphRange.setDelegate(nullptr);
 }
 
-App::App(Container * container, Snapshot * snapshot) :
-  FunctionApp(container, snapshot, &m_inputViewController),
+App::App(Snapshot * snapshot) :
+  FunctionApp(snapshot, &m_inputViewController),
   m_listController(&m_listFooter, &m_listHeader, &m_listFooter),
   m_listFooter(&m_listHeader, &m_listController, &m_listController, ButtonRowController::Position::Bottom, ButtonRowController::Style::EmbossedGrey),
   m_listHeader(&m_listStackViewController, &m_listFooter, &m_listController),

--- a/apps/graph/app.cpp
+++ b/apps/graph/app.cpp
@@ -77,7 +77,7 @@ char App::XNT() {
 }
 
 NestedMenuController * App::variableBoxForInputEventHandler(InputEventHandler * textInput) {
-  VariableBoxController * varBox = container()->variableBoxController();
+  VariableBoxController * varBox = AppsContainer::sharedAppsContainer()->variableBoxController();
   varBox->setSender(textInput);
   varBox->lockDeleteEvent(VariableBoxController::Page::Function);
   return varBox;

--- a/apps/graph/app.h
+++ b/apps/graph/app.h
@@ -52,6 +52,10 @@ private:
   InputViewController m_inputViewController;
 };
 
+inline App * app() {
+  return static_cast<App *>(::app());
+}
+
 }
 
 #endif

--- a/apps/graph/app.h
+++ b/apps/graph/app.h
@@ -53,7 +53,7 @@ private:
 };
 
 inline App * app() {
-  return static_cast<App *>(::app());
+  return static_cast<App *>(Container::activeApp());
 }
 
 }

--- a/apps/graph/app.h
+++ b/apps/graph/app.h
@@ -30,6 +30,9 @@ public:
     CartesianFunctionStore m_functionStore;
     Shared::InteractiveCurveViewRange m_graphRange;
   };
+  static App * app() {
+    return static_cast<App *>(Container::activeApp());
+  }
   InputViewController * inputViewController() override;
   char XNT() override;
   NestedMenuController * variableBoxForInputEventHandler(InputEventHandler * textInput) override;
@@ -51,10 +54,6 @@ private:
   TabViewController m_tabViewController;
   InputViewController m_inputViewController;
 };
-
-inline App * app() {
-  return static_cast<App *>(Container::activeApp());
-}
 
 }
 

--- a/apps/graph/app.h
+++ b/apps/graph/app.h
@@ -35,7 +35,7 @@ public:
   NestedMenuController * variableBoxForInputEventHandler(InputEventHandler * textInput) override;
   CartesianFunctionStore * functionStore() override { return static_cast<CartesianFunctionStore *>(Shared::FunctionApp::functionStore()); }
 private:
-  App(Container * container, Snapshot * snapshot);
+  App(Snapshot * snapshot);
   ListController m_listController;
   ButtonRowController m_listFooter;
   ButtonRowController m_listHeader;

--- a/apps/graph/graph/calculation_graph_controller.cpp
+++ b/apps/graph/graph/calculation_graph_controller.cpp
@@ -52,7 +52,7 @@ Expression::Coordinate2D CalculationGraphController::computeNewPointOfInteresetF
 }
 
 CartesianFunctionStore * CalculationGraphController::functionStore() const {
-  return app()->functionStore();
+  return App::app()->functionStore();
 }
 
 bool CalculationGraphController::handleLeftRightEvent(Ion::Events::Event event) {

--- a/apps/graph/graph/calculation_graph_controller.cpp
+++ b/apps/graph/graph/calculation_graph_controller.cpp
@@ -45,16 +45,14 @@ void CalculationGraphController::reloadBannerView() {
 }
 
 Expression::Coordinate2D CalculationGraphController::computeNewPointOfInteresetFromAbscissa(double start, int direction) {
-  App * myApp = static_cast<App *>(app());
   double step = m_graphRange->xGridUnit()/10.0;
   step = direction < 0 ? -step : step;
   double max = direction > 0 ? m_graphRange->xMax() : m_graphRange->xMin();
-  return computeNewPointOfInterest(start, step, max, myApp->localContext());
+  return computeNewPointOfInterest(start, step, max, app()->localContext());
 }
 
 CartesianFunctionStore * CalculationGraphController::functionStore() const {
-  App * a = static_cast<App *>(app());
-  return a->functionStore();
+  return app()->functionStore();
 }
 
 bool CalculationGraphController::handleLeftRightEvent(Ion::Events::Event event) {

--- a/apps/graph/graph/calculation_graph_controller.cpp
+++ b/apps/graph/graph/calculation_graph_controller.cpp
@@ -48,7 +48,7 @@ Expression::Coordinate2D CalculationGraphController::computeNewPointOfInteresetF
   double step = m_graphRange->xGridUnit()/10.0;
   step = direction < 0 ? -step : step;
   double max = direction > 0 ? m_graphRange->xMax() : m_graphRange->xMin();
-  return computeNewPointOfInterest(start, step, max, app()->localContext());
+  return computeNewPointOfInterest(start, step, max, textFieldDelegateApp()->localContext());
 }
 
 CartesianFunctionStore * CalculationGraphController::functionStore() const {

--- a/apps/graph/graph/calculation_parameter_controller.cpp
+++ b/apps/graph/graph/calculation_parameter_controller.cpp
@@ -33,7 +33,7 @@ View * CalculationParameterController::view() {
 
 void CalculationParameterController::didBecomeFirstResponder() {
   m_selectableTableView.selectCellAtLocation(0, 0);
-  app()->setFirstResponder(&m_selectableTableView);
+  Container::activeApp()->setFirstResponder(&m_selectableTableView);
 }
 
 bool CalculationParameterController::handleEvent(Ion::Events::Event event) {

--- a/apps/graph/graph/graph_controller.cpp
+++ b/apps/graph/graph/graph_controller.cpp
@@ -7,7 +7,7 @@ namespace Graph {
 
 static inline float maxFloat(float x, float y) { return x > y ? x : y; }
 
-GraphController::GraphController(Responder * parentResponder, InputEventHandlerDelegate * inputEventHandlerDelegate, CartesianFunctionStore * functionStore, Shared::InteractiveCurveViewRange * curveViewRange, CurveViewCursor * cursor, int * indexFunctionSelectedByCursor, uint32_t * modelVersion, uint32_t * rangeVersion, Poincare::Preferences::AngleUnit * angleUnitVersion, ButtonRowController * header) :
+GraphController::GraphController(Responder * parentResponder, ::InputEventHandlerDelegate * inputEventHandlerDelegate, CartesianFunctionStore * functionStore, Shared::InteractiveCurveViewRange * curveViewRange, CurveViewCursor * cursor, int * indexFunctionSelectedByCursor, uint32_t * modelVersion, uint32_t * rangeVersion, Poincare::Preferences::AngleUnit * angleUnitVersion, ButtonRowController * header) :
   FunctionGraphController(parentResponder, inputEventHandlerDelegate, header, curveViewRange, &m_view, cursor, indexFunctionSelectedByCursor, modelVersion, rangeVersion, angleUnitVersion),
   m_bannerView(this, inputEventHandlerDelegate, this),
   m_view(functionStore, curveViewRange, m_cursor, &m_bannerView, &m_cursorView),
@@ -43,10 +43,9 @@ void GraphController::setDisplayDerivativeInBanner(bool displayDerivative) {
 
 float GraphController::interestingXHalfRange() const {
   float characteristicRange = 0.0f;
-  TextFieldDelegateApp * myApp = (TextFieldDelegateApp *)app();
   for (int i = 0; i < functionStore()->numberOfActiveFunctions(); i++) {
     ExpiringPointer<CartesianFunction> f = functionStore()->modelForRecord(functionStore()->activeRecordAtIndex(i));
-    float fRange = f->expressionReduced(myApp->localContext()).characteristicXRange(*(myApp->localContext()), Poincare::Preferences::sharedPreferences()->angleUnit());
+    float fRange = f->expressionReduced(app()->localContext()).characteristicXRange(*(app()->localContext()), Poincare::Preferences::sharedPreferences()->angleUnit());
     if (!std::isnan(fRange)) {
       characteristicRange = maxFloat(fRange, characteristicRange);
     }
@@ -74,14 +73,12 @@ void GraphController::reloadBannerView() {
     return;
   }
   Ion::Storage::Record record = functionStore()->activeRecordAtIndex(indexFunctionSelectedByCursor());
-  App * myApp = static_cast<App *>(app());
-  reloadDerivativeInBannerViewForCursorOnFunction(m_cursor, record, myApp);
+  reloadDerivativeInBannerViewForCursorOnFunction(m_cursor, record, app());
 }
 
 bool GraphController::moveCursorHorizontally(int direction) {
   Ion::Storage::Record record = functionStore()->activeRecordAtIndex(indexFunctionSelectedByCursor());
-  App * myApp = static_cast<App *>(app());
-  return privateMoveCursorHorizontally(m_cursor, direction, m_graphRange, k_numberOfCursorStepsInGradUnit, record, myApp);
+  return privateMoveCursorHorizontally(m_cursor, direction, m_graphRange, k_numberOfCursorStepsInGradUnit, record, app());
 }
 
 InteractiveCurveViewRange * GraphController::interactiveCurveViewRange() {

--- a/apps/graph/graph/graph_controller.cpp
+++ b/apps/graph/graph/graph_controller.cpp
@@ -43,9 +43,10 @@ void GraphController::setDisplayDerivativeInBanner(bool displayDerivative) {
 
 float GraphController::interestingXHalfRange() const {
   float characteristicRange = 0.0f;
+  Poincare::Context * context = textFieldDelegateApp()->localContext();
   for (int i = 0; i < functionStore()->numberOfActiveFunctions(); i++) {
     ExpiringPointer<CartesianFunction> f = functionStore()->modelForRecord(functionStore()->activeRecordAtIndex(i));
-    float fRange = f->expressionReduced(app()->localContext()).characteristicXRange(*(app()->localContext()), Poincare::Preferences::sharedPreferences()->angleUnit());
+    float fRange = f->expressionReduced(context).characteristicXRange(*context, Poincare::Preferences::sharedPreferences()->angleUnit());
     if (!std::isnan(fRange)) {
       characteristicRange = maxFloat(fRange, characteristicRange);
     }

--- a/apps/graph/graph/graph_controller.cpp
+++ b/apps/graph/graph/graph_controller.cpp
@@ -73,12 +73,12 @@ void GraphController::reloadBannerView() {
     return;
   }
   Ion::Storage::Record record = functionStore()->activeRecordAtIndex(indexFunctionSelectedByCursor());
-  reloadDerivativeInBannerViewForCursorOnFunction(m_cursor, record, app());
+  reloadDerivativeInBannerViewForCursorOnFunction(m_cursor, record);
 }
 
 bool GraphController::moveCursorHorizontally(int direction) {
   Ion::Storage::Record record = functionStore()->activeRecordAtIndex(indexFunctionSelectedByCursor());
-  return privateMoveCursorHorizontally(m_cursor, direction, m_graphRange, k_numberOfCursorStepsInGradUnit, record, app());
+  return privateMoveCursorHorizontally(m_cursor, direction, m_graphRange, k_numberOfCursorStepsInGradUnit, record);
 }
 
 InteractiveCurveViewRange * GraphController::interactiveCurveViewRange() {

--- a/apps/graph/graph/graph_controller.h
+++ b/apps/graph/graph/graph_controller.h
@@ -15,7 +15,7 @@ namespace Graph {
 
 class GraphController : public Shared::FunctionGraphController, public GraphControllerHelper {
 public:
-  GraphController(Responder * parentResponder, InputEventHandlerDelegate * inputEventHandlerDelegate, CartesianFunctionStore * functionStore, Shared::InteractiveCurveViewRange * curveViewRange, Shared::CurveViewCursor * cursor, int * indexFunctionSelectedByCursor, uint32_t * modelVersion, uint32_t * rangeVersion, Poincare::Preferences::AngleUnit * angleUnitVersion, ButtonRowController * header);
+  GraphController(Responder * parentResponder, ::InputEventHandlerDelegate * inputEventHandlerDelegate, CartesianFunctionStore * functionStore, Shared::InteractiveCurveViewRange * curveViewRange, Shared::CurveViewCursor * cursor, int * indexFunctionSelectedByCursor, uint32_t * modelVersion, uint32_t * rangeVersion, Poincare::Preferences::AngleUnit * angleUnitVersion, ButtonRowController * header);
   I18n::Message emptyMessage() override;
   void viewWillAppear() override;
   bool displayDerivativeInBanner() const;

--- a/apps/graph/graph/graph_controller_helper.cpp
+++ b/apps/graph/graph/graph_controller_helper.cpp
@@ -10,23 +10,23 @@ using namespace Poincare;
 namespace Graph {
 
 bool GraphControllerHelper::privateMoveCursorHorizontally(Shared::CurveViewCursor * cursor, int direction, Shared::InteractiveCurveViewRange * range, int numberOfStepsInGradUnit, Ion::Storage::Record record) {
-  ExpiringPointer<CartesianFunction> function = app()->functionStore()->modelForRecord(record);
+  ExpiringPointer<CartesianFunction> function = App::app()->functionStore()->modelForRecord(record);
   double xCursorPosition = cursor->x();
   double x = direction > 0 ? xCursorPosition + range->xGridUnit()/numberOfStepsInGradUnit : xCursorPosition -  range->xGridUnit()/numberOfStepsInGradUnit;
-  double y = function->evaluateAtAbscissa(x, app()->localContext());
+  double y = function->evaluateAtAbscissa(x, App::app()->localContext());
   cursor->moveTo(x, y);
   return true;
 }
 
 void GraphControllerHelper::reloadDerivativeInBannerViewForCursorOnFunction(Shared::CurveViewCursor * cursor, Ion::Storage::Record record) {
-  ExpiringPointer<CartesianFunction> function = app()->functionStore()->modelForRecord(record);
+  ExpiringPointer<CartesianFunction> function = App::app()->functionStore()->modelForRecord(record);
   constexpr size_t bufferSize = FunctionBannerDelegate::k_maxNumberOfCharacters+PrintFloat::bufferSizeForFloatsWithPrecision(Constant::LargeNumberOfSignificantDigits);
   char buffer[bufferSize];
   const char * space = " ";
   int numberOfChar = function->derivativeNameWithArgument(buffer, bufferSize, CartesianFunction::Symbol());
   const char * legend = "=";
   numberOfChar += strlcpy(buffer+numberOfChar, legend, bufferSize-numberOfChar);
-  double y = function->approximateDerivative(cursor->x(), app()->localContext());
+  double y = function->approximateDerivative(cursor->x(), App::app()->localContext());
   numberOfChar += PoincareHelpers::ConvertFloatToText<double>(y, buffer + numberOfChar, bufferSize-numberOfChar, Constant::ShortNumberOfSignificantDigits);
   strlcpy(buffer+numberOfChar, space, bufferSize-numberOfChar);
   bannerView()->derivativeView()->setText(buffer);

--- a/apps/graph/graph/graph_controller_helper.cpp
+++ b/apps/graph/graph/graph_controller_helper.cpp
@@ -9,24 +9,24 @@ using namespace Poincare;
 
 namespace Graph {
 
-bool GraphControllerHelper::privateMoveCursorHorizontally(Shared::CurveViewCursor * cursor, int direction, Shared::InteractiveCurveViewRange * range, int numberOfStepsInGradUnit, Ion::Storage::Record record, App * app) {
-  ExpiringPointer<CartesianFunction> function = app->functionStore()->modelForRecord(record);
+bool GraphControllerHelper::privateMoveCursorHorizontally(Shared::CurveViewCursor * cursor, int direction, Shared::InteractiveCurveViewRange * range, int numberOfStepsInGradUnit, Ion::Storage::Record record) {
+  ExpiringPointer<CartesianFunction> function = app()->functionStore()->modelForRecord(record);
   double xCursorPosition = cursor->x();
   double x = direction > 0 ? xCursorPosition + range->xGridUnit()/numberOfStepsInGradUnit : xCursorPosition -  range->xGridUnit()/numberOfStepsInGradUnit;
-  double y = function->evaluateAtAbscissa(x, app->localContext());
+  double y = function->evaluateAtAbscissa(x, app()->localContext());
   cursor->moveTo(x, y);
   return true;
 }
 
-void GraphControllerHelper::reloadDerivativeInBannerViewForCursorOnFunction(Shared::CurveViewCursor * cursor, Ion::Storage::Record record, App * app) {
-  ExpiringPointer<CartesianFunction> function = app->functionStore()->modelForRecord(record);
+void GraphControllerHelper::reloadDerivativeInBannerViewForCursorOnFunction(Shared::CurveViewCursor * cursor, Ion::Storage::Record record) {
+  ExpiringPointer<CartesianFunction> function = app()->functionStore()->modelForRecord(record);
   constexpr size_t bufferSize = FunctionBannerDelegate::k_maxNumberOfCharacters+PrintFloat::bufferSizeForFloatsWithPrecision(Constant::LargeNumberOfSignificantDigits);
   char buffer[bufferSize];
   const char * space = " ";
   int numberOfChar = function->derivativeNameWithArgument(buffer, bufferSize, CartesianFunction::Symbol());
   const char * legend = "=";
   numberOfChar += strlcpy(buffer+numberOfChar, legend, bufferSize-numberOfChar);
-  double y = function->approximateDerivative(cursor->x(), app->localContext());
+  double y = function->approximateDerivative(cursor->x(), app()->localContext());
   numberOfChar += PoincareHelpers::ConvertFloatToText<double>(y, buffer + numberOfChar, bufferSize-numberOfChar, Constant::ShortNumberOfSignificantDigits);
   strlcpy(buffer+numberOfChar, space, bufferSize-numberOfChar);
   bannerView()->derivativeView()->setText(buffer);

--- a/apps/graph/graph/graph_controller_helper.h
+++ b/apps/graph/graph/graph_controller_helper.h
@@ -11,8 +11,8 @@ class App;
 
 class GraphControllerHelper {
 protected:
-  bool privateMoveCursorHorizontally(Shared::CurveViewCursor * cursor, int direction, Shared::InteractiveCurveViewRange * range, int numberOfStepsInGradUnit, Ion::Storage::Record record, App * app);
-  void reloadDerivativeInBannerViewForCursorOnFunction(Shared::CurveViewCursor * cursor, Ion::Storage::Record record, App * app);
+  bool privateMoveCursorHorizontally(Shared::CurveViewCursor * cursor, int direction, Shared::InteractiveCurveViewRange * range, int numberOfStepsInGradUnit, Ion::Storage::Record record);
+  void reloadDerivativeInBannerViewForCursorOnFunction(Shared::CurveViewCursor * cursor, Ion::Storage::Record record);
   virtual BannerView * bannerView() = 0;
 };
 

--- a/apps/graph/graph/tangent_graph_controller.cpp
+++ b/apps/graph/graph/tangent_graph_controller.cpp
@@ -61,7 +61,7 @@ void TangentGraphController::reloadBannerView() {
   if (m_record.isNull()) {
     return;
   }
-  FunctionBannerDelegate::reloadBannerViewForCursorOnFunction(m_cursor, m_record, app()->functionStore(), CartesianFunction::Symbol());
+  FunctionBannerDelegate::reloadBannerViewForCursorOnFunction(m_cursor, m_record, Shared::FunctionApp::app()->functionStore(), CartesianFunction::Symbol());
   GraphControllerHelper::reloadDerivativeInBannerViewForCursorOnFunction(m_cursor, m_record);
   constexpr size_t bufferSize = FunctionBannerDelegate::k_maxNumberOfCharacters+PrintFloat::bufferSizeForFloatsWithPrecision(Constant::LargeNumberOfSignificantDigits);
   char buffer[bufferSize];

--- a/apps/graph/graph/tangent_graph_controller.cpp
+++ b/apps/graph/graph/tangent_graph_controller.cpp
@@ -33,18 +33,18 @@ void TangentGraphController::viewWillAppear() {
 void TangentGraphController::didBecomeFirstResponder() {
   if (curveView()->isMainViewSelected()) {
     m_bannerView->abscissaValue()->setParentResponder(this);
-    m_bannerView->abscissaValue()->setDelegates(textFieldDelegateApp(), this);
+    m_bannerView->abscissaValue()->setDelegates(app(), this);
     app()->setFirstResponder(m_bannerView->abscissaValue());
   }
 }
 
 bool TangentGraphController::textFieldDidFinishEditing(TextField * textField, const char * text, Ion::Events::Event event) {
   double floatBody;
-  if (textFieldDelegateApp()->hasUndefinedValue(text, floatBody)) {
+  if (app()->hasUndefinedValue(text, floatBody)) {
     return false;
   }
   ExpiringPointer<CartesianFunction> function = app()->functionStore()->modelForRecord(m_record);
-  double y = function->evaluateAtAbscissa(floatBody, textFieldDelegateApp()->localContext());
+  double y = function->evaluateAtAbscissa(floatBody, app()->localContext());
   m_cursor->moveTo(floatBody, y);
   interactiveCurveViewRange()->panToMakePointVisible(m_cursor->x(), m_cursor->y(), cursorTopMarginRatio(), k_cursorRightMarginRatio, cursorBottomMarginRatio(), k_cursorLeftMarginRatio);
   reloadBannerView();

--- a/apps/graph/graph/tangent_graph_controller.cpp
+++ b/apps/graph/graph/tangent_graph_controller.cpp
@@ -34,7 +34,7 @@ void TangentGraphController::didBecomeFirstResponder() {
   if (curveView()->isMainViewSelected()) {
     m_bannerView->abscissaValue()->setParentResponder(this);
     m_bannerView->abscissaValue()->setDelegates(textFieldDelegateApp(), this);
-    app()->setFirstResponder(m_bannerView->abscissaValue());
+    Container::activeApp()->setFirstResponder(m_bannerView->abscissaValue());
   }
 }
 

--- a/apps/graph/graph/tangent_graph_controller.cpp
+++ b/apps/graph/graph/tangent_graph_controller.cpp
@@ -43,8 +43,7 @@ bool TangentGraphController::textFieldDidFinishEditing(TextField * textField, co
   if (textFieldDelegateApp()->hasUndefinedValue(text, floatBody)) {
     return false;
   }
-  App * myApp = static_cast<App *>(app());
-  ExpiringPointer<CartesianFunction> function = myApp->functionStore()->modelForRecord(m_record);
+  ExpiringPointer<CartesianFunction> function = app()->functionStore()->modelForRecord(m_record);
   double y = function->evaluateAtAbscissa(floatBody, textFieldDelegateApp()->localContext());
   m_cursor->moveTo(floatBody, y);
   interactiveCurveViewRange()->panToMakePointVisible(m_cursor->x(), m_cursor->y(), cursorTopMarginRatio(), k_cursorRightMarginRatio, cursorBottomMarginRatio(), k_cursorLeftMarginRatio);
@@ -62,29 +61,27 @@ void TangentGraphController::reloadBannerView() {
   if (m_record.isNull()) {
     return;
   }
-  App * myApp = static_cast<App *>(app());
-  FunctionBannerDelegate::reloadBannerViewForCursorOnFunction(m_cursor, m_record, myApp->functionStore(), CartesianFunction::Symbol());
-  GraphControllerHelper::reloadDerivativeInBannerViewForCursorOnFunction(m_cursor, m_record, myApp);
+  FunctionBannerDelegate::reloadBannerViewForCursorOnFunction(m_cursor, m_record, app()->functionStore(), CartesianFunction::Symbol());
+  GraphControllerHelper::reloadDerivativeInBannerViewForCursorOnFunction(m_cursor, m_record, app());
   constexpr size_t bufferSize = FunctionBannerDelegate::k_maxNumberOfCharacters+PrintFloat::bufferSizeForFloatsWithPrecision(Constant::LargeNumberOfSignificantDigits);
   char buffer[bufferSize];
   const char * legend = "a=";
   int legendLength = strlcpy(buffer, legend, bufferSize);
-  ExpiringPointer<CartesianFunction> function = myApp->functionStore()->modelForRecord(m_record);
-  double y = function->approximateDerivative(m_cursor->x(), myApp->localContext());
+  ExpiringPointer<CartesianFunction> function = app()->functionStore()->modelForRecord(m_record);
+  double y = function->approximateDerivative(m_cursor->x(), app()->localContext());
   PoincareHelpers::ConvertFloatToText<double>(y, buffer + legendLength, PrintFloat::bufferSizeForFloatsWithPrecision(Constant::MediumNumberOfSignificantDigits), Constant::MediumNumberOfSignificantDigits);
   m_bannerView->aView()->setText(buffer);
 
   legend = "b=";
   legendLength = strlcpy(buffer, legend, bufferSize);
-  y = -y*m_cursor->x()+function->evaluateAtAbscissa(m_cursor->x(), myApp->localContext());
+  y = -y*m_cursor->x()+function->evaluateAtAbscissa(m_cursor->x(), app()->localContext());
   PoincareHelpers::ConvertFloatToText<double>(y, buffer + legendLength, PrintFloat::bufferSizeForFloatsWithPrecision(Constant::MediumNumberOfSignificantDigits), Constant::MediumNumberOfSignificantDigits);
   m_bannerView->bView()->setText(buffer);
   m_bannerView->reload();
 }
 
 bool TangentGraphController::moveCursorHorizontally(int direction) {
-  App * myApp = static_cast<App *>(app());
-  return privateMoveCursorHorizontally(m_cursor, direction, m_graphRange, k_numberOfCursorStepsInGradUnit, m_record, myApp);
+  return privateMoveCursorHorizontally(m_cursor, direction, m_graphRange, k_numberOfCursorStepsInGradUnit, m_record, app());
 }
 
 bool TangentGraphController::handleEnter() {

--- a/apps/graph/graph/tangent_graph_controller.cpp
+++ b/apps/graph/graph/tangent_graph_controller.cpp
@@ -44,7 +44,7 @@ bool TangentGraphController::textFieldDidFinishEditing(TextField * textField, co
   if (myApp->hasUndefinedValue(text, floatBody)) {
     return false;
   }
-  ExpiringPointer<CartesianFunction> function = app()->functionStore()->modelForRecord(m_record);
+  ExpiringPointer<CartesianFunction> function = App::app()->functionStore()->modelForRecord(m_record);
   double y = function->evaluateAtAbscissa(floatBody, myApp->localContext());
   m_cursor->moveTo(floatBody, y);
   interactiveCurveViewRange()->panToMakePointVisible(m_cursor->x(), m_cursor->y(), cursorTopMarginRatio(), k_cursorRightMarginRatio, cursorBottomMarginRatio(), k_cursorLeftMarginRatio);
@@ -70,7 +70,7 @@ void TangentGraphController::reloadBannerView() {
 
   const char * legend = "a=";
   int legendLength = strlcpy(buffer, legend, bufferSize);
-  ExpiringPointer<CartesianFunction> function = app()->functionStore()->modelForRecord(m_record);
+  ExpiringPointer<CartesianFunction> function = App::app()->functionStore()->modelForRecord(m_record);
   double y = function->approximateDerivative(m_cursor->x(), context);
   PoincareHelpers::ConvertFloatToText<double>(y, buffer + legendLength, PrintFloat::bufferSizeForFloatsWithPrecision(Constant::MediumNumberOfSignificantDigits), Constant::MediumNumberOfSignificantDigits);
   m_bannerView->aView()->setText(buffer);

--- a/apps/graph/graph/tangent_graph_controller.cpp
+++ b/apps/graph/graph/tangent_graph_controller.cpp
@@ -62,7 +62,7 @@ void TangentGraphController::reloadBannerView() {
     return;
   }
   FunctionBannerDelegate::reloadBannerViewForCursorOnFunction(m_cursor, m_record, app()->functionStore(), CartesianFunction::Symbol());
-  GraphControllerHelper::reloadDerivativeInBannerViewForCursorOnFunction(m_cursor, m_record, app());
+  GraphControllerHelper::reloadDerivativeInBannerViewForCursorOnFunction(m_cursor, m_record);
   constexpr size_t bufferSize = FunctionBannerDelegate::k_maxNumberOfCharacters+PrintFloat::bufferSizeForFloatsWithPrecision(Constant::LargeNumberOfSignificantDigits);
   char buffer[bufferSize];
   const char * legend = "a=";
@@ -81,7 +81,7 @@ void TangentGraphController::reloadBannerView() {
 }
 
 bool TangentGraphController::moveCursorHorizontally(int direction) {
-  return privateMoveCursorHorizontally(m_cursor, direction, m_graphRange, k_numberOfCursorStepsInGradUnit, m_record, app());
+  return privateMoveCursorHorizontally(m_cursor, direction, m_graphRange, k_numberOfCursorStepsInGradUnit, m_record);
 }
 
 bool TangentGraphController::handleEnter() {

--- a/apps/graph/list/list_controller.cpp
+++ b/apps/graph/list/list_controller.cpp
@@ -38,7 +38,7 @@ void ListController::renameSelectedFunction() {
   computeTitlesColumnWidth(true);
   selectableTableView()->reloadData();
 
-  static_cast<AppsContainer *>(const_cast<Container *>(app()->container()))->setShiftAlphaStatus(Ion::Events::ShiftAlphaStatus::AlphaLock);
+  AppsContainer::sharedAppsContainer()->setShiftAlphaStatus(Ion::Events::ShiftAlphaStatus::AlphaLock);
   TextFieldFunctionTitleCell * selectedTitleCell = (TextFieldFunctionTitleCell *)(selectableTableView()->selectedCell());
   selectedTitleCell->setHorizontalAlignment(1.0f);
   app()->setFirstResponder(selectedTitleCell);
@@ -91,7 +91,7 @@ bool ListController::textFieldDidFinishEditing(TextField * textField, const char
     if (selectTab) {
       m_selectableTableView.parentResponder()->handleEvent(event);
     }
-    static_cast<AppsContainer *>(const_cast<Container *>(app()->container()))->setShiftAlphaStatus(Ion::Events::ShiftAlphaStatus::Default);
+    AppsContainer::sharedAppsContainer()->setShiftAlphaStatus(Ion::Events::ShiftAlphaStatus::Default);
     return true;
   } else if (error == Ion::Storage::Record::ErrorStatus::NameTaken) {
     app()->displayWarning(I18n::Message::NameTaken);
@@ -122,7 +122,7 @@ bool ListController::textFieldDidAbortEditing(TextField * textField) {
   setFunctionNameInTextField(function, textField);
   m_selectableTableView.selectedCell()->setHighlighted(true);
   app()->setFirstResponder(&m_selectableTableView);
-  static_cast<AppsContainer *>(const_cast<Container *>(app()->container()))->setShiftAlphaStatus(Ion::Events::ShiftAlphaStatus::Default);
+  AppsContainer::sharedAppsContainer()->setShiftAlphaStatus(Ion::Events::ShiftAlphaStatus::Default);
   return true;
 }
 

--- a/apps/graph/list/list_controller.cpp
+++ b/apps/graph/list/list_controller.cpp
@@ -189,4 +189,8 @@ void ListController::setFunctionNameInTextField(ExpiringPointer<Function> functi
   textField->setText(bufferName);
 }
 
+Shared::TextFieldDelegateApp * ListController::textFieldDelegateApp() {
+  return app();
+}
+
 }

--- a/apps/graph/list/list_controller.cpp
+++ b/apps/graph/list/list_controller.cpp
@@ -41,7 +41,7 @@ void ListController::renameSelectedFunction() {
   AppsContainer::sharedAppsContainer()->setShiftAlphaStatus(Ion::Events::ShiftAlphaStatus::AlphaLock);
   TextFieldFunctionTitleCell * selectedTitleCell = (TextFieldFunctionTitleCell *)(selectableTableView()->selectedCell());
   selectedTitleCell->setHorizontalAlignment(1.0f);
-  app()->setFirstResponder(selectedTitleCell);
+  Container::activeApp()->setFirstResponder(selectedTitleCell);
   selectedTitleCell->setEditing(true);
 }
 
@@ -87,27 +87,27 @@ bool ListController::textFieldDidFinishEditing(TextField * textField, const char
     }
     m_selectableTableView.selectedCell()->setHighlighted(true);
     m_selectableTableView.reloadData();
-    app()->setFirstResponder(&m_selectableTableView);
+    Container::activeApp()->setFirstResponder(&m_selectableTableView);
     if (selectTab) {
       m_selectableTableView.parentResponder()->handleEvent(event);
     }
     AppsContainer::sharedAppsContainer()->setShiftAlphaStatus(Ion::Events::ShiftAlphaStatus::Default);
     return true;
   } else if (error == Ion::Storage::Record::ErrorStatus::NameTaken) {
-    app()->displayWarning(I18n::Message::NameTaken);
+    Container::activeApp()->displayWarning(I18n::Message::NameTaken);
   } else if (error == Ion::Storage::Record::ErrorStatus::NonCompliantName) {
     assert(nameError != Function::NameNotCompliantError::None);
     if (nameError == Function::NameNotCompliantError::CharacterNotAllowed) {
-      app()->displayWarning(I18n::Message::AllowedCharactersAZaz09);
+      Container::activeApp()->displayWarning(I18n::Message::AllowedCharactersAZaz09);
     } else if (nameError == Function::NameNotCompliantError::NameCannotStartWithNumber) {
-      app()->displayWarning(I18n::Message::NameCannotStartWithNumber);
+      Container::activeApp()->displayWarning(I18n::Message::NameCannotStartWithNumber);
     } else {
       assert(nameError == Function::NameNotCompliantError::ReservedName);
-      app()->displayWarning(I18n::Message::ReservedName);
+      Container::activeApp()->displayWarning(I18n::Message::ReservedName);
     }
   } else {
     assert(error == Ion::Storage::Record::ErrorStatus::NotEnoughSpaceAvailable);
-    app()->displayWarning(I18n::Message::NameTooLong);
+    Container::activeApp()->displayWarning(I18n::Message::NameTooLong);
   }
   textField->setEditing(true, false);
   return false;
@@ -121,7 +121,7 @@ bool ListController::textFieldDidAbortEditing(TextField * textField) {
   ExpiringPointer<Function> function = modelStore()->modelForRecord(modelStore()->recordAtIndex(selectedRow()));
   setFunctionNameInTextField(function, textField);
   m_selectableTableView.selectedCell()->setHighlighted(true);
-  app()->setFirstResponder(&m_selectableTableView);
+  Container::activeApp()->setFirstResponder(&m_selectableTableView);
   AppsContainer::sharedAppsContainer()->setShiftAlphaStatus(Ion::Events::ShiftAlphaStatus::Default);
   return true;
 }

--- a/apps/graph/list/list_controller.cpp
+++ b/apps/graph/list/list_controller.cpp
@@ -189,8 +189,4 @@ void ListController::setFunctionNameInTextField(ExpiringPointer<Function> functi
   textField->setText(bufferName);
 }
 
-Shared::TextFieldDelegateApp * ListController::textFieldDelegateApp() {
-  return app();
-}
-
 }

--- a/apps/graph/list/list_controller.h
+++ b/apps/graph/list/list_controller.h
@@ -29,9 +29,7 @@ private:
   HighlightCell * expressionCells(int index) override;
   void willDisplayTitleCellAtIndex(HighlightCell * cell, int j) override;
   void willDisplayExpressionCellAtIndex(HighlightCell * cell, int j) override;
-  Shared::TextFieldDelegateApp * textFieldDelegateApp() override {
-    return static_cast<Shared::TextFieldDelegateApp *>(app());
-  }
+  Shared::TextFieldDelegateApp * textFieldDelegateApp() override;
   void setFunctionNameInTextField(Shared::ExpiringPointer<Shared::Function> function, TextField * textField);
   TextFieldFunctionTitleCell m_functionTitleCells[k_maxNumberOfDisplayableRows];
   Shared::FunctionExpressionCell m_expressionCells[k_maxNumberOfDisplayableRows];

--- a/apps/graph/list/list_controller.h
+++ b/apps/graph/list/list_controller.h
@@ -29,7 +29,6 @@ private:
   HighlightCell * expressionCells(int index) override;
   void willDisplayTitleCellAtIndex(HighlightCell * cell, int j) override;
   void willDisplayExpressionCellAtIndex(HighlightCell * cell, int j) override;
-  Shared::TextFieldDelegateApp * textFieldDelegateApp() override;
   void setFunctionNameInTextField(Shared::ExpiringPointer<Shared::Function> function, TextField * textField);
   TextFieldFunctionTitleCell m_functionTitleCells[k_maxNumberOfDisplayableRows];
   Shared::FunctionExpressionCell m_expressionCells[k_maxNumberOfDisplayableRows];

--- a/apps/graph/list/text_field_function_title_cell.cpp
+++ b/apps/graph/list/text_field_function_title_cell.cpp
@@ -24,7 +24,7 @@ Responder * TextFieldFunctionTitleCell::responder() {
 }
 
 void TextFieldFunctionTitleCell::setEditing(bool editing) {
-  app()->setFirstResponder(&m_textField);
+  Container::activeApp()->setFirstResponder(&m_textField);
   const char * previousText = m_textField.text();
   m_textField.setEditing(true, false);
   m_textField.setText(previousText);
@@ -67,7 +67,7 @@ void TextFieldFunctionTitleCell::layoutSubviews() {
 
 void TextFieldFunctionTitleCell::didBecomeFirstResponder() {
   if (isEditing()) {
-    app()->setFirstResponder(&m_textField);
+    Container::activeApp()->setFirstResponder(&m_textField);
   }
 }
 

--- a/apps/graph/values/derivative_parameter_controller.cpp
+++ b/apps/graph/values/derivative_parameter_controller.cpp
@@ -82,7 +82,7 @@ KDCoordinate DerivativeParameterController::cellHeight() {
 }
 
 CartesianFunctionStore * DerivativeParameterController::functionStore() {
-  return app()->functionStore();
+  return App::app()->functionStore();
 }
 
 }

--- a/apps/graph/values/derivative_parameter_controller.cpp
+++ b/apps/graph/values/derivative_parameter_controller.cpp
@@ -31,7 +31,7 @@ View * DerivativeParameterController::view() {
 
 void DerivativeParameterController::didBecomeFirstResponder() {
   selectCellAtLocation(0, 0);
-  app()->setFirstResponder(&m_selectableTableView);
+  Container::activeApp()->setFirstResponder(&m_selectableTableView);
 }
 
 bool DerivativeParameterController::handleEvent(Ion::Events::Event event) {

--- a/apps/graph/values/derivative_parameter_controller.cpp
+++ b/apps/graph/values/derivative_parameter_controller.cpp
@@ -82,8 +82,7 @@ KDCoordinate DerivativeParameterController::cellHeight() {
 }
 
 CartesianFunctionStore * DerivativeParameterController::functionStore() {
-  App * a = static_cast<App *>(app());
-  return a->functionStore();
+  return app()->functionStore();
 }
 
 }

--- a/apps/graph/values/function_parameter_controller.cpp
+++ b/apps/graph/values/function_parameter_controller.cpp
@@ -70,8 +70,7 @@ void FunctionParameterController::willDisplayCellForIndex(HighlightCell * cell, 
 }
 
 ExpiringPointer<CartesianFunction> FunctionParameterController::function() {
-  App * a = static_cast<App *>(app());
-  return a->functionStore()->modelForRecord(m_record);
+  return app()->functionStore()->modelForRecord(m_record);
 }
 
 }

--- a/apps/graph/values/function_parameter_controller.cpp
+++ b/apps/graph/values/function_parameter_controller.cpp
@@ -70,7 +70,7 @@ void FunctionParameterController::willDisplayCellForIndex(HighlightCell * cell, 
 }
 
 ExpiringPointer<CartesianFunction> FunctionParameterController::function() {
-  return app()->functionStore()->modelForRecord(m_record);
+  return App::app()->functionStore()->modelForRecord(m_record);
 }
 
 }

--- a/apps/graph/values/values_controller.cpp
+++ b/apps/graph/values/values_controller.cpp
@@ -1,6 +1,7 @@
 #include "values_controller.h"
 #include <assert.h>
 #include "../../constant.h"
+#include "../app.h"
 
 using namespace Shared;
 using namespace Poincare;
@@ -142,15 +143,14 @@ FunctionParameterController * ValuesController::functionParameterController() {
 }
 
 double ValuesController::evaluationOfAbscissaAtColumn(double abscissa, int columnIndex) {
-  TextFieldDelegateApp * myApp = (TextFieldDelegateApp *)app();
   bool isDerivative = isDerivativeColumn(columnIndex);
   /* isDerivativeColumn uses expiring pointers, so "function" must be created
    * after the isDerivativeColumn call, else it will expire. */
   Shared::ExpiringPointer<CartesianFunction> function = functionStore()->modelForRecord(recordAtColumn(columnIndex));
   if (isDerivative) {
-    return function->approximateDerivative(abscissa, myApp->localContext());
+    return function->approximateDerivative(abscissa, app()->localContext());
   }
-  return function->evaluateAtAbscissa(abscissa, myApp->localContext());
+  return function->evaluateAtAbscissa(abscissa, app()->localContext());
 }
 
 void ValuesController::updateNumberOfColumns() {

--- a/apps/graph/values/values_controller.cpp
+++ b/apps/graph/values/values_controller.cpp
@@ -147,10 +147,11 @@ double ValuesController::evaluationOfAbscissaAtColumn(double abscissa, int colum
   /* isDerivativeColumn uses expiring pointers, so "function" must be created
    * after the isDerivativeColumn call, else it will expire. */
   Shared::ExpiringPointer<CartesianFunction> function = functionStore()->modelForRecord(recordAtColumn(columnIndex));
+  Poincare::Context * context = textFieldDelegateApp()->localContext();
   if (isDerivative) {
-    return function->approximateDerivative(abscissa, app()->localContext());
+    return function->approximateDerivative(abscissa, context);
   }
-  return function->evaluateAtAbscissa(abscissa, app()->localContext());
+  return function->evaluateAtAbscissa(abscissa, context);
 }
 
 void ValuesController::updateNumberOfColumns() {

--- a/apps/hardware_test/app.cpp
+++ b/apps/hardware_test/app.cpp
@@ -1,5 +1,4 @@
 #include "app.h"
-#include "../apps_container.h"
 
 extern "C" {
 #include <assert.h>

--- a/apps/hardware_test/app.cpp
+++ b/apps/hardware_test/app.cpp
@@ -8,7 +8,7 @@ extern "C" {
 namespace HardwareTest {
 
 App * App::Snapshot::unpack(Container * container) {
-  return new (container->currentAppBuffer()) App(container, this);
+  return new (container->currentAppBuffer()) App(this);
 }
 
 App::Descriptor * App::Snapshot::descriptor() {
@@ -16,8 +16,8 @@ App::Descriptor * App::Snapshot::descriptor() {
   return &descriptor;
 }
 
-App::App(Container * container, Snapshot * snapshot) :
-  ::App(container, snapshot, &m_wizardViewController),
+App::App(Snapshot * snapshot) :
+  ::App(snapshot, &m_wizardViewController),
   m_wizardViewController(&m_modalViewController)
 {
 }

--- a/apps/hardware_test/app.h
+++ b/apps/hardware_test/app.h
@@ -34,7 +34,7 @@ private:
     SerialNumberController m_serialNumberController;
   };
 
-  App(Container * container, Snapshot * snapshot);
+  App(Snapshot * snapshot);
   WizardViewController m_wizardViewController;
 };
 

--- a/apps/hardware_test/app.h
+++ b/apps/hardware_test/app.h
@@ -8,8 +8,6 @@
 #include "battery_test_controller.h"
 #include "serial_number_controller.h"
 
-class AppsContainer;
-
 namespace HardwareTest {
 
 class App : public ::App {

--- a/apps/hardware_test/pop_up_controller.cpp
+++ b/apps/hardware_test/pop_up_controller.cpp
@@ -2,6 +2,7 @@
 #include <apps/i18n.h>
 #include "../apps_container.h"
 #include <assert.h>
+#include <escher/app.h>
 
 namespace HardwareTest {
 
@@ -34,8 +35,7 @@ bool PopUpController::handleEvent(Ion::Events::Event event) {
 PopUpController::ContentView::ContentView(Responder * parentResponder) :
   Responder(parentResponder),
   m_cancelButton(this, I18n::Message::Cancel, Invocation([](void * context, void * sender) {
-    PopUpController::ContentView * view = (PopUpController::ContentView *)context;
-    view->app()->dismissModalViewController();
+    app()->dismissModalViewController();
     return true;
   }, this), KDFont::SmallFont),
   m_okButton(this, I18n::Message::Ok, Invocation([](void * context, void * sender) {

--- a/apps/hardware_test/pop_up_controller.cpp
+++ b/apps/hardware_test/pop_up_controller.cpp
@@ -39,8 +39,7 @@ PopUpController::ContentView::ContentView(Responder * parentResponder) :
     return true;
   }, this), KDFont::SmallFont),
   m_okButton(this, I18n::Message::Ok, Invocation([](void * context, void * sender) {
-    PopUpController::ContentView * view = (PopUpController::ContentView *)context;
-    AppsContainer * appsContainer = (AppsContainer *)view->app()->container();
+    AppsContainer * appsContainer = AppsContainer::sharedAppsContainer();
     bool switched = appsContainer->switchTo(appsContainer->hardwareTestAppSnapshot());
     assert(switched);
     (void) switched; // Silence compilation warning about unused variable.

--- a/apps/hardware_test/pop_up_controller.cpp
+++ b/apps/hardware_test/pop_up_controller.cpp
@@ -35,7 +35,7 @@ bool PopUpController::handleEvent(Ion::Events::Event event) {
 PopUpController::ContentView::ContentView(Responder * parentResponder) :
   Responder(parentResponder),
   m_cancelButton(this, I18n::Message::Cancel, Invocation([](void * context, void * sender) {
-    app()->dismissModalViewController();
+    Container::activeApp()->dismissModalViewController();
     return true;
   }, this), KDFont::SmallFont),
   m_okButton(this, I18n::Message::Ok, Invocation([](void * context, void * sender) {
@@ -61,9 +61,9 @@ void PopUpController::ContentView::setSelectedButton(int selectedButton) {
   m_cancelButton.setHighlighted(selectedButton == 0);
   m_okButton.setHighlighted(selectedButton == 1);
   if (selectedButton == 0) {
-    app()->setFirstResponder(&m_cancelButton);
+    Container::activeApp()->setFirstResponder(&m_cancelButton);
   } else {
-    app()->setFirstResponder(&m_okButton);
+    Container::activeApp()->setFirstResponder(&m_okButton);
   }
 }
 

--- a/apps/home/app.cpp
+++ b/apps/home/app.cpp
@@ -1,6 +1,5 @@
 #include "app.h"
 #include <apps/i18n.h>
-#include "../apps_container.h"
 
 extern "C" {
 #include <assert.h>
@@ -27,7 +26,7 @@ App::Descriptor * App::Snapshot::descriptor() {
 
 App::App(Container * container, Snapshot * snapshot) :
   ::App(container, snapshot, &m_controller, I18n::Message::Warning),
-  m_controller(&m_modalViewController, (AppsContainer *)container, snapshot)
+  m_controller(&m_modalViewController, snapshot)
 {
 }
 

--- a/apps/home/app.cpp
+++ b/apps/home/app.cpp
@@ -16,7 +16,7 @@ I18n::Message App::Descriptor::upperName() {
 }
 
 App * App::Snapshot::unpack(Container * container) {
-  return new (container->currentAppBuffer()) App(container, this);
+  return new (container->currentAppBuffer()) App(this);
 }
 
 App::Descriptor * App::Snapshot::descriptor() {
@@ -24,8 +24,8 @@ App::Descriptor * App::Snapshot::descriptor() {
   return &descriptor;
 }
 
-App::App(Container * container, Snapshot * snapshot) :
-  ::App(container, snapshot, &m_controller, I18n::Message::Warning),
+App::App(Snapshot * snapshot) :
+  ::App(snapshot, &m_controller, I18n::Message::Warning),
   m_controller(&m_modalViewController, snapshot)
 {
 }

--- a/apps/home/app.h
+++ b/apps/home/app.h
@@ -4,8 +4,6 @@
 #include <escher.h>
 #include "controller.h"
 
-class AppsContainer;
-
 namespace Home {
 
 class App : public ::App {

--- a/apps/home/app.h
+++ b/apps/home/app.h
@@ -19,10 +19,17 @@ public:
     App * unpack(Container * container) override;
     Descriptor * descriptor() override;
   };
+  Snapshot * snapshot() const {
+    return static_cast<Snapshot *>(::App::snapshot());
+  }
 private:
   App(Snapshot * snapshot);
   Controller m_controller;
 };
+
+inline App * app() {
+  return static_cast<App *>(::app());
+}
 
 }
 

--- a/apps/home/app.h
+++ b/apps/home/app.h
@@ -15,6 +15,7 @@ public:
   };
   class Snapshot : public ::App::Snapshot, public SelectableTableViewDataSource {
   public:
+    Snapshot() { selectCellAtLocation(0, 0); }
     App * unpack(Container * container) override;
     Descriptor * descriptor() override;
   };

--- a/apps/home/app.h
+++ b/apps/home/app.h
@@ -27,7 +27,7 @@ private:
 };
 
 inline App * app() {
-  return static_cast<App *>(::app());
+  return static_cast<App *>(Container::activeApp());
 }
 
 }

--- a/apps/home/app.h
+++ b/apps/home/app.h
@@ -18,6 +18,9 @@ public:
     App * unpack(Container * container) override;
     Descriptor * descriptor() override;
   };
+  static App * app() {
+    return static_cast<App *>(Container::activeApp());
+  }
   Snapshot * snapshot() const {
     return static_cast<Snapshot *>(::App::snapshot());
   }
@@ -25,10 +28,6 @@ private:
   App(Snapshot * snapshot);
   Controller m_controller;
 };
-
-inline App * app() {
-  return static_cast<App *>(Container::activeApp());
-}
 
 }
 

--- a/apps/home/app.h
+++ b/apps/home/app.h
@@ -21,7 +21,7 @@ public:
     Descriptor * descriptor() override;
   };
 private:
-  App(Container * container, Snapshot * snapshot);
+  App(Snapshot * snapshot);
   Controller m_controller;
 };
 

--- a/apps/home/app.h
+++ b/apps/home/app.h
@@ -15,7 +15,6 @@ public:
   };
   class Snapshot : public ::App::Snapshot, public SelectableTableViewDataSource {
   public:
-    Snapshot() { selectCellAtLocation(0, 0); }
     App * unpack(Container * container) override;
     Descriptor * descriptor() override;
   };

--- a/apps/home/controller.cpp
+++ b/apps/home/controller.cpp
@@ -78,6 +78,9 @@ bool Controller::handleEvent(Ion::Events::Event event) {
 }
 
 void Controller::didBecomeFirstResponder() {
+  if (selectionDataSource()->selectedRow() == -1) {
+    selectionDataSource()->selectCellAtLocation(0, 0);
+  }
   app()->setFirstResponder(m_view.selectableTableView());
 }
 

--- a/apps/home/controller.cpp
+++ b/apps/home/controller.cpp
@@ -81,7 +81,7 @@ void Controller::didBecomeFirstResponder() {
   if (selectionDataSource()->selectedRow() == -1) {
     selectionDataSource()->selectCellAtLocation(0, 0);
   }
-  app()->setFirstResponder(m_view.selectableTableView());
+  Container::activeApp()->setFirstResponder(m_view.selectableTableView());
 }
 
 void Controller::viewWillAppear() {

--- a/apps/home/controller.cpp
+++ b/apps/home/controller.cpp
@@ -162,7 +162,7 @@ void Controller::tableViewDidChangeSelection(SelectableTableView * t, int previo
 }
 
 SelectableTableViewDataSource * Controller::selectionDataSource() const {
-  return app()->snapshot();
+  return App::app()->snapshot();
 }
 
 }

--- a/apps/home/controller.cpp
+++ b/apps/home/controller.cpp
@@ -78,9 +78,6 @@ bool Controller::handleEvent(Ion::Events::Event event) {
 }
 
 void Controller::didBecomeFirstResponder() {
-  if (m_selectionDataSource->selectedRow() == -1) {
-    m_selectionDataSource->selectCellAtLocation(0, 0);
-  }
   app()->setFirstResponder(m_view.selectableTableView());
 }
 

--- a/apps/home/controller.cpp
+++ b/apps/home/controller.cpp
@@ -1,4 +1,5 @@
 #include "controller.h"
+#include "app.h"
 #include "../apps_container.h"
 extern "C" {
 #include <assert.h>
@@ -49,15 +50,14 @@ void Controller::ContentView::layoutSubviews() {
 
 Controller::Controller(Responder * parentResponder, SelectableTableViewDataSource * selectionDataSource) :
   ViewController(parentResponder),
-  m_view(this, selectionDataSource),
-  m_selectionDataSource(selectionDataSource)
+  m_view(this, selectionDataSource)
 {
 }
 
 bool Controller::handleEvent(Ion::Events::Event event) {
   if (event == Ion::Events::OK || event == Ion::Events::EXE) {
     AppsContainer * container = AppsContainer::sharedAppsContainer();
-    bool switched = container->switchTo(container->appSnapshotAtIndex(m_selectionDataSource->selectedRow()*k_numberOfColumns+m_selectionDataSource->selectedColumn()+1));
+    bool switched = container->switchTo(container->appSnapshotAtIndex(selectionDataSource()->selectedRow()*k_numberOfColumns+selectionDataSource()->selectedColumn()+1));
     assert(switched);
     (void) switched; // Silence compilation warning about unused variable.
     return true;
@@ -67,11 +67,11 @@ bool Controller::handleEvent(Ion::Events::Event event) {
     return m_view.selectableTableView()->selectCellAtLocation(0,0);
   }
 
-  if (event == Ion::Events::Right && m_selectionDataSource->selectedRow() < numberOfRows()) {
-    return m_view.selectableTableView()->selectCellAtLocation(0, m_selectionDataSource->selectedRow()+1);
+  if (event == Ion::Events::Right && selectionDataSource()->selectedRow() < numberOfRows()) {
+    return m_view.selectableTableView()->selectCellAtLocation(0, selectionDataSource()->selectedRow()+1);
   }
-  if (event == Ion::Events::Left && m_selectionDataSource->selectedRow() > 0) {
-    return m_view.selectableTableView()->selectCellAtLocation(numberOfColumns()-1, m_selectionDataSource->selectedRow()-1);
+  if (event == Ion::Events::Left && selectionDataSource()->selectedRow() > 0) {
+    return m_view.selectableTableView()->selectCellAtLocation(numberOfColumns()-1, selectionDataSource()->selectedRow()-1);
   }
 
   return false;
@@ -156,6 +156,10 @@ void Controller::tableViewDidChangeSelection(SelectableTableView * t, int previo
   if (appIndex >= container->numberOfApps()) {
     t->selectCellAtLocation(previousSelectedCellX, previousSelectedCellY);
   }
+}
+
+SelectableTableViewDataSource * Controller::selectionDataSource() const {
+  return app()->snapshot();
 }
 
 }

--- a/apps/home/controller.cpp
+++ b/apps/home/controller.cpp
@@ -80,8 +80,6 @@ bool Controller::handleEvent(Ion::Events::Event event) {
 void Controller::didBecomeFirstResponder() {
   if (m_selectionDataSource->selectedRow() == -1) {
     m_selectionDataSource->selectCellAtLocation(0, 0);
-  } else {
-    m_selectionDataSource->selectCellAtLocation(m_selectionDataSource->selectedColumn(), m_selectionDataSource->selectedRow());
   }
   app()->setFirstResponder(m_view.selectableTableView());
 }

--- a/apps/home/controller.h
+++ b/apps/home/controller.h
@@ -10,7 +10,7 @@ namespace Home {
 
 class Controller : public ViewController, public SimpleTableViewDataSource, public SelectableTableViewDelegate {
 public:
-  Controller(Responder * parentResponder, ::AppsContainer * container, SelectableTableViewDataSource * selectionDataSource);
+  Controller(Responder * parentResponder, SelectableTableViewDataSource * selectionDataSource);
 
   View * view() override;
 
@@ -40,7 +40,6 @@ private:
     void layoutSubviews() override;
     SelectableTableView m_selectableTableView;
   };
-  AppsContainer * m_container;
   static constexpr KDCoordinate k_sideMargin = 4;
   static constexpr KDCoordinate k_bottomMargin = 14;
   static constexpr KDCoordinate k_indicatorMargin = 61;

--- a/apps/home/controller.h
+++ b/apps/home/controller.h
@@ -26,6 +26,7 @@ public:
   void tableViewDidChangeSelection(SelectableTableView * t, int previousSelectedCellX, int previousSelectedCellY, bool withinTemporarySelection) override;
 private:
   int numberOfIcons();
+  SelectableTableViewDataSource * selectionDataSource() const;
   class ContentView : public View {
   public:
     ContentView(Controller * controller, SelectableTableViewDataSource * selectionDataSource);
@@ -47,7 +48,6 @@ private:
   static constexpr int k_cellWidth = 104;
   ContentView m_view;
   AppCell m_cells[k_maxNumberOfCells];
-  SelectableTableViewDataSource * m_selectionDataSource;
 };
 
 }

--- a/apps/home/controller.h
+++ b/apps/home/controller.h
@@ -4,8 +4,6 @@
 #include <escher.h>
 #include "app_cell.h"
 
-class AppsContainer;
-
 namespace Home {
 
 class Controller : public ViewController, public SimpleTableViewDataSource, public SelectableTableViewDelegate {

--- a/apps/main.cpp
+++ b/apps/main.cpp
@@ -1,4 +1,4 @@
-#include "apps_container_storage.h"
+#include "apps_container.h"
 #include "global_preferences.h"
 #include <poincare/init.h>
 
@@ -32,8 +32,8 @@ void ion_main(int argc, char * argv[]) {
      * $ ./epsilon.elf --code-script hello_world.py:print("hello") --code-lock-on-console
      */
     const char * appNames[] = {"home", EPSILON_APPS_NAMES};
-    for (int j = 0; j < AppsContainerStorage::sharedContainer()->numberOfApps(); j++) {
-      App::Snapshot * snapshot = AppsContainerStorage::sharedContainer()->appSnapshotAtIndex(j);
+    for (int j = 0; j < AppsContainer::sharedAppsContainer()->numberOfApps(); j++) {
+      App::Snapshot * snapshot = AppsContainer::sharedAppsContainer()->appSnapshotAtIndex(j);
       int cmp = strcmp(argv[i]+2, appNames[j]);
       if (cmp == '-') {
         snapshot->setOpt(argv[i]+2+strlen(appNames[j])+1, argv[i+1]);
@@ -42,5 +42,5 @@ void ion_main(int argc, char * argv[]) {
     }
   }
 #endif
-  AppsContainerStorage::sharedContainer()->run();
+  AppsContainer::sharedAppsContainer()->run();
 }

--- a/apps/math_toolbox.cpp
+++ b/apps/math_toolbox.cpp
@@ -120,7 +120,7 @@ bool MathToolbox::selectLeaf(int selectedRow) {
     text = textToInsert;
   }
   sender()->handleEventWithText(text);
-  app()->dismissModalViewController();
+  Container::activeApp()->dismissModalViewController();
   return true;
 }
 

--- a/apps/on_boarding/app.cpp
+++ b/apps/on_boarding/app.cpp
@@ -4,7 +4,7 @@
 namespace OnBoarding {
 
 App * App::Snapshot::unpack(Container * container) {
-  return new (container->currentAppBuffer()) App(container, this);
+  return new (container->currentAppBuffer()) App(this);
 }
 
 App::Descriptor * App::Snapshot::descriptor() {
@@ -12,8 +12,8 @@ App::Descriptor * App::Snapshot::descriptor() {
   return &descriptor;
 }
 
-App::App(Container * container, Snapshot * snapshot) :
-  ::App(container, snapshot, &m_languageController),
+App::App(Snapshot * snapshot) :
+  ::App(snapshot, &m_languageController),
   m_languageController(&m_modalViewController, &m_logoController),
   m_logoController()
 {

--- a/apps/on_boarding/app.cpp
+++ b/apps/on_boarding/app.cpp
@@ -33,14 +33,19 @@ bool App::processEvent(Ion::Events::Event e) {
     return true;
   }
   if (e == Ion::Events::OnOff) {
-    m_languageController.reinitOnBoarding();
+    reinitOnBoarding();
   }
   return ::App::processEvent(e);
 }
 
 void App::didBecomeActive(Window * window) {
   ::App::didBecomeActive(window);
-  m_languageController.reinitOnBoarding();
+  reinitOnBoarding();
+}
+
+void App::reinitOnBoarding() {
+  m_languageController.resetSelection();
+  displayModalViewController(&m_logoController, 0.5f, 0.5f);
 }
 
 }

--- a/apps/on_boarding/app.cpp
+++ b/apps/on_boarding/app.cpp
@@ -14,7 +14,7 @@ App::Descriptor * App::Snapshot::descriptor() {
 
 App::App(Snapshot * snapshot) :
   ::App(snapshot, &m_languageController),
-  m_languageController(&m_modalViewController, &m_logoController),
+  m_languageController(&m_modalViewController),
   m_logoController()
 {
 }

--- a/apps/on_boarding/app.h
+++ b/apps/on_boarding/app.h
@@ -19,7 +19,7 @@ public:
   bool processEvent(Ion::Events::Event) override;
   void didBecomeActive(Window * window) override;
 private:
-  App(Container * container, Snapshot * snapshot);
+  App(Snapshot * snapshot);
   LanguageController m_languageController;
   LogoController m_logoController;
 };

--- a/apps/on_boarding/app.h
+++ b/apps/on_boarding/app.h
@@ -20,6 +20,7 @@ public:
   void didBecomeActive(Window * window) override;
 private:
   App(Snapshot * snapshot);
+  void reinitOnBoarding();
   LanguageController m_languageController;
   LogoController m_logoController;
 };

--- a/apps/on_boarding/language_controller.cpp
+++ b/apps/on_boarding/language_controller.cpp
@@ -17,7 +17,7 @@ void LanguageController::reinitOnBoarding() {
 
 bool LanguageController::handleEvent(Ion::Events::Event event) {
   if (Shared::LanguageController::handleEvent(event)) {
-    AppsContainer * appsContainer = (AppsContainer *)app()->container();
+    AppsContainer * appsContainer = AppsContainer::sharedAppsContainer();
 #ifdef EPSILON_BOOT_PROMPT
     app()->displayModalViewController(appsContainer->promptController(), 0.5f, 0.5f);
 #else

--- a/apps/on_boarding/language_controller.cpp
+++ b/apps/on_boarding/language_controller.cpp
@@ -4,9 +4,8 @@
 
 namespace OnBoarding {
 
-LanguageController::LanguageController(Responder * parentResponder, LogoController * logoController) :
-  Shared::LanguageController(parentResponder, (Ion::Display::Height - I18n::NumberOfLanguages*Metric::ParameterCellHeight)/2),
-  m_logoController(logoController)
+LanguageController::LanguageController(Responder * parentResponder) :
+  Shared::LanguageController(parentResponder, (Ion::Display::Height - I18n::NumberOfLanguages*Metric::ParameterCellHeight)/2)
 {
 }
 

--- a/apps/on_boarding/language_controller.cpp
+++ b/apps/on_boarding/language_controller.cpp
@@ -13,7 +13,7 @@ bool LanguageController::handleEvent(Ion::Events::Event event) {
   if (Shared::LanguageController::handleEvent(event)) {
     AppsContainer * appsContainer = AppsContainer::sharedAppsContainer();
 #ifdef EPSILON_BOOT_PROMPT
-    app()->displayModalViewController(appsContainer->promptController(), 0.5f, 0.5f);
+    Container::activeApp()->displayModalViewController(appsContainer->promptController(), 0.5f, 0.5f);
 #else
     appsContainer->switchTo(appsContainer->appSnapshotAtIndex(0));
 #endif

--- a/apps/on_boarding/language_controller.cpp
+++ b/apps/on_boarding/language_controller.cpp
@@ -10,11 +10,6 @@ LanguageController::LanguageController(Responder * parentResponder, LogoControll
 {
 }
 
-void LanguageController::reinitOnBoarding() {
-  resetSelection();
-  app()->displayModalViewController(m_logoController, 0.5f, 0.5f);
-}
-
 bool LanguageController::handleEvent(Ion::Events::Event event) {
   if (Shared::LanguageController::handleEvent(event)) {
     AppsContainer * appsContainer = AppsContainer::sharedAppsContainer();

--- a/apps/on_boarding/language_controller.h
+++ b/apps/on_boarding/language_controller.h
@@ -10,7 +10,6 @@ namespace OnBoarding {
 class LanguageController : public Shared::LanguageController {
 public:
   LanguageController(Responder * parentResponder, LogoController * logoController);
-  void reinitOnBoarding();
   bool handleEvent(Ion::Events::Event event) override;
 private:
   LogoController * m_logoController;

--- a/apps/on_boarding/language_controller.h
+++ b/apps/on_boarding/language_controller.h
@@ -9,10 +9,8 @@ namespace OnBoarding {
 
 class LanguageController : public Shared::LanguageController {
 public:
-  LanguageController(Responder * parentResponder, LogoController * logoController);
+  LanguageController(Responder * parentResponder);
   bool handleEvent(Ion::Events::Event event) override;
-private:
-  LogoController * m_logoController;
 };
 
 }

--- a/apps/on_boarding/logo_controller.cpp
+++ b/apps/on_boarding/logo_controller.cpp
@@ -14,7 +14,7 @@ View * LogoController::view() {
 }
 
 bool LogoController::fire() {
-  app()->dismissModalViewController();
+  Container::activeApp()->dismissModalViewController();
   return true;
 }
 

--- a/apps/on_boarding/pop_up_controller.cpp
+++ b/apps/on_boarding/pop_up_controller.cpp
@@ -53,7 +53,7 @@ PopUpController::PopUpController(I18n::Message * messages, KDColor * colors, uin
 bool PopUpController::handleEvent(Ion::Events::Event event) {
   if (event != Ion::Events::Back && event != Ion::Events::OnOff && event != Ion::Events::USBPlug && event != Ion::Events::USBEnumeration) {
     app()->dismissModalViewController();
-    AppsContainer * appsContainer = (AppsContainer *)app()->container();
+    AppsContainer * appsContainer = AppsContainer::sharedAppsContainer();
     if (appsContainer->activeApp()->snapshot() == appsContainer->onBoardingAppSnapshot()) {
       bool switched = appsContainer->switchTo(appsContainer->appSnapshotAtIndex(0));
       assert(switched);

--- a/apps/on_boarding/pop_up_controller.cpp
+++ b/apps/on_boarding/pop_up_controller.cpp
@@ -52,7 +52,7 @@ PopUpController::PopUpController(I18n::Message * messages, KDColor * colors, uin
 
 bool PopUpController::handleEvent(Ion::Events::Event event) {
   if (event != Ion::Events::Back && event != Ion::Events::OnOff && event != Ion::Events::USBPlug && event != Ion::Events::USBEnumeration) {
-    app()->dismissModalViewController();
+    Container::activeApp()->dismissModalViewController();
     AppsContainer * appsContainer = AppsContainer::sharedAppsContainer();
     if (appsContainer->activeApp()->snapshot() == appsContainer->onBoardingAppSnapshot()) {
       bool switched = appsContainer->switchTo(appsContainer->appSnapshotAtIndex(0));

--- a/apps/probability/app.cpp
+++ b/apps/probability/app.cpp
@@ -35,7 +35,7 @@ App::Snapshot::~Snapshot() {
 }
 
 App * App::Snapshot::unpack(Container * container) {
-  return new (container->currentAppBuffer()) App(container, this);
+  return new (container->currentAppBuffer()) App(this);
 }
 
 App::Descriptor * App::Snapshot::descriptor() {
@@ -67,8 +67,8 @@ App::Snapshot::Page App::Snapshot::activePage() {
   return m_activePage;
 }
 
-App::App(Container * container, Snapshot * snapshot) :
-  TextFieldDelegateApp(container, snapshot, &m_stackViewController),
+App::App(Snapshot * snapshot) :
+  TextFieldDelegateApp(snapshot, &m_stackViewController),
   m_calculationController(&m_stackViewController, this, snapshot->law(), snapshot->calculation()),
   m_parametersController(&m_stackViewController, this, snapshot->law(), &m_calculationController),
   m_lawController(&m_stackViewController, snapshot->law(), &m_parametersController),

--- a/apps/probability/app.h
+++ b/apps/probability/app.h
@@ -54,6 +54,9 @@ public:
     char m_calculation[k_calculationSize];
     Page m_activePage;
   };
+  static App * app() {
+    return static_cast<App *>(Container::activeApp());
+  }
   Snapshot * snapshot() const { return static_cast<Snapshot *>(::App::snapshot()); }
 private:
   App(Snapshot * snapshot);
@@ -62,10 +65,6 @@ private:
   LawController m_lawController;
   StackViewController m_stackViewController;
 };
-
-inline App * app() {
-  return static_cast<App *>(Container::activeApp());
-}
 
 }
 

--- a/apps/probability/app.h
+++ b/apps/probability/app.h
@@ -63,6 +63,10 @@ private:
   StackViewController m_stackViewController;
 };
 
+App * app() {
+  return static_cast<App *>(::app());
+}
+
 }
 
 #endif

--- a/apps/probability/app.h
+++ b/apps/probability/app.h
@@ -55,7 +55,7 @@ public:
     Page m_activePage;
   };
 private:
-  App(Container * container, Snapshot * snapshot);
+  App(Snapshot * snapshot);
   CalculationController m_calculationController;
   ParametersController m_parametersController;
   LawController m_lawController;

--- a/apps/probability/app.h
+++ b/apps/probability/app.h
@@ -54,6 +54,7 @@ public:
     char m_calculation[k_calculationSize];
     Page m_activePage;
   };
+  Snapshot * snapshot() const { return static_cast<Snapshot *>(::App::snapshot()); }
 private:
   App(Snapshot * snapshot);
   CalculationController m_calculationController;

--- a/apps/probability/app.h
+++ b/apps/probability/app.h
@@ -63,7 +63,7 @@ private:
   StackViewController m_stackViewController;
 };
 
-App * app() {
+inline App * app() {
   return static_cast<App *>(::app());
 }
 

--- a/apps/probability/app.h
+++ b/apps/probability/app.h
@@ -64,7 +64,7 @@ private:
 };
 
 inline App * app() {
-  return static_cast<App *>(::app());
+  return static_cast<App *>(Container::activeApp());
 }
 
 }

--- a/apps/probability/calculation_controller.cpp
+++ b/apps/probability/calculation_controller.cpp
@@ -266,10 +266,6 @@ void CalculationController::setCalculationAccordingToIndex(int index, bool force
   m_calculation->setLaw(m_law);
 }
 
-TextFieldDelegateApp * CalculationController::textFieldDelegateApp() {
-  return app();
-}
-
 void CalculationController::updateTitle() {
   int currentChar = 0;
   for (int index = 0; index < m_law->numberOfParameter(); index++) {

--- a/apps/probability/calculation_controller.cpp
+++ b/apps/probability/calculation_controller.cpp
@@ -86,7 +86,7 @@ void CalculationController::didEnterResponderChain(Responder * previousResponder
 }
 
 void CalculationController::didBecomeFirstResponder() {
-  app()->setFirstResponder(&m_selectableTableView);
+  Container::activeApp()->setFirstResponder(&m_selectableTableView);
 }
 
 View * CalculationController::view() {
@@ -192,7 +192,7 @@ bool CalculationController::textFieldDidHandleEvent(::TextField * textField, boo
     /* We do not reload the responder because the first responder might be the
      * toolbox (or the variable  box) and reloading the responder would corrupt
      * the first responder. */
-    bool shouldUpdateFirstResponder = app()->firstResponder() == textField;
+    bool shouldUpdateFirstResponder = Container::activeApp()->firstResponder() == textField;
     m_selectableTableView.reloadData(shouldUpdateFirstResponder);
     // The textField frame might have increased which forces to reload the textField scroll
     textField->scrollToCursor();

--- a/apps/probability/calculation_controller.cpp
+++ b/apps/probability/calculation_controller.cpp
@@ -79,8 +79,7 @@ CalculationController::CalculationController(Responder * parentResponder, InputE
 }
 
 void CalculationController::didEnterResponderChain(Responder * previousResponder) {
-  App::Snapshot * snapshot = (App::Snapshot *)app()->snapshot();
-  snapshot->setActivePage(App::Snapshot::Page::Calculations);
+  app()->snapshot()->setActivePage(App::Snapshot::Page::Calculations);
   updateTitle();
   reloadLawCurveView();
   m_selectableTableView.reloadData();

--- a/apps/probability/calculation_controller.cpp
+++ b/apps/probability/calculation_controller.cpp
@@ -79,7 +79,7 @@ CalculationController::CalculationController(Responder * parentResponder, InputE
 }
 
 void CalculationController::didEnterResponderChain(Responder * previousResponder) {
-  app()->snapshot()->setActivePage(App::Snapshot::Page::Calculations);
+  App::app()->snapshot()->setActivePage(App::Snapshot::Page::Calculations);
   updateTitle();
   reloadLawCurveView();
   m_selectableTableView.reloadData();

--- a/apps/probability/calculation_controller.cpp
+++ b/apps/probability/calculation_controller.cpp
@@ -267,7 +267,7 @@ void CalculationController::setCalculationAccordingToIndex(int index, bool force
 }
 
 TextFieldDelegateApp * CalculationController::textFieldDelegateApp() {
-  return (App *)app();
+  return app();
 }
 
 void CalculationController::updateTitle() {

--- a/apps/probability/calculation_controller.cpp
+++ b/apps/probability/calculation_controller.cpp
@@ -211,7 +211,7 @@ bool CalculationController::textFieldShouldFinishEditing(TextField * textField, 
 
 bool CalculationController::textFieldDidFinishEditing(TextField * textField, const char * text, Ion::Events::Event event) {
   double floatBody;
-  if (textFieldDelegateApp()->hasUndefinedValue(text, floatBody)) {
+  if (app()->hasUndefinedValue(text, floatBody)) {
     return false;
   }
   if (m_calculation->type() != Calculation::Type::FiniteIntegral && selectedColumn() == 2) {

--- a/apps/probability/calculation_controller.cpp
+++ b/apps/probability/calculation_controller.cpp
@@ -1,6 +1,5 @@
 #include "calculation_controller.h"
 #include "../constant.h"
-#include "../apps_container.h"
 #include "../shared/poincare_helpers.h"
 #include "app.h"
 #include "calculation/discrete_calculation.h"

--- a/apps/probability/calculation_controller.cpp
+++ b/apps/probability/calculation_controller.cpp
@@ -211,7 +211,7 @@ bool CalculationController::textFieldShouldFinishEditing(TextField * textField, 
 
 bool CalculationController::textFieldDidFinishEditing(TextField * textField, const char * text, Ion::Events::Event event) {
   double floatBody;
-  if (app()->hasUndefinedValue(text, floatBody)) {
+  if (textFieldDelegateApp()->hasUndefinedValue(text, floatBody)) {
     return false;
   }
   if (m_calculation->type() != Calculation::Type::FiniteIntegral && selectedColumn() == 2) {

--- a/apps/probability/calculation_controller.h
+++ b/apps/probability/calculation_controller.h
@@ -47,7 +47,6 @@ public:
 private:
   constexpr static int k_numberOfCalculationCells = 3;
   constexpr static KDCoordinate k_tableMargin = 3;
-  Shared::TextFieldDelegateApp * textFieldDelegateApp() override;
   void updateTitle();
   class ContentView : public View {
   public:

--- a/apps/probability/calculation_type_controller.cpp
+++ b/apps/probability/calculation_type_controller.cpp
@@ -39,21 +39,21 @@ void CalculationTypeController::viewDidDisappear() {
 }
 
 void CalculationTypeController::didBecomeFirstResponder() {
-  app()->setFirstResponder(&m_selectableTableView);
+  Container::activeApp()->setFirstResponder(&m_selectableTableView);
 }
 
 bool CalculationTypeController::handleEvent(Ion::Events::Event event) {
   if (event == Ion::Events::OK || event == Ion::Events::EXE) {
     m_calculationController->setCalculationAccordingToIndex(selectedRow());
     m_calculationController->reload();
-    app()->dismissModalViewController();
+    Container::activeApp()->dismissModalViewController();
     return true;
   }
   if (event == Ion::Events::Back || event == Ion::Events::Right) {
     if (event == Ion::Events::Right) {
       m_calculationController->selectCellAtLocation(1,0);
     }
-    app()->dismissModalViewController();
+    Container::activeApp()->dismissModalViewController();
     return true;
   }
   return false;

--- a/apps/probability/law_controller.cpp
+++ b/apps/probability/law_controller.cpp
@@ -79,7 +79,7 @@ void Probability::LawController::didBecomeFirstResponder() {
   } else {
     selectCellAtLocation(selectedColumn(), selectedRow());
   }
-  app()->setFirstResponder(&m_selectableTableView);
+  Container::activeApp()->setFirstResponder(&m_selectableTableView);
 }
 
 bool Probability::LawController::handleEvent(Ion::Events::Event event) {

--- a/apps/probability/law_controller.cpp
+++ b/apps/probability/law_controller.cpp
@@ -73,8 +73,7 @@ void Probability::LawController::viewWillAppear() {
 }
 
 void Probability::LawController::didBecomeFirstResponder() {
-  App::Snapshot * snapshot = (App::Snapshot *)app()->snapshot();
-  snapshot->setActivePage(App::Snapshot::Page::Law);
+  app()->snapshot()->setActivePage(App::Snapshot::Page::Law);
   if (selectedRow() == -1) {
     selectCellAtLocation(0, 0);
   } else {

--- a/apps/probability/law_controller.cpp
+++ b/apps/probability/law_controller.cpp
@@ -73,7 +73,7 @@ void Probability::LawController::viewWillAppear() {
 }
 
 void Probability::LawController::didBecomeFirstResponder() {
-  app()->snapshot()->setActivePage(App::Snapshot::Page::Law);
+  App::app()->snapshot()->setActivePage(App::Snapshot::Page::Law);
   if (selectedRow() == -1) {
     selectCellAtLocation(0, 0);
   } else {

--- a/apps/probability/parameters_controller.cpp
+++ b/apps/probability/parameters_controller.cpp
@@ -99,7 +99,7 @@ void ParametersController::reinitCalculation() {
 }
 
 void ParametersController::didBecomeFirstResponder() {
-  app()->snapshot()->setActivePage(App::Snapshot::Page::Parameters);
+  App::app()->snapshot()->setActivePage(App::Snapshot::Page::Parameters);
   FloatParameterController::didBecomeFirstResponder();
 }
 

--- a/apps/probability/parameters_controller.cpp
+++ b/apps/probability/parameters_controller.cpp
@@ -144,7 +144,7 @@ double ParametersController::parameterAtIndex(int index) {
 
 bool ParametersController::setParameterAtIndex(int parameterIndex, double f) {
   if (!m_law->authorizedValueAtIndex(f, parameterIndex)) {
-    app()->displayWarning(I18n::Message::ForbiddenValue);
+    Container::activeApp()->displayWarning(I18n::Message::ForbiddenValue);
     return false;
   }
   m_law->setParameterAtIndex(f, parameterIndex);

--- a/apps/probability/parameters_controller.cpp
+++ b/apps/probability/parameters_controller.cpp
@@ -99,8 +99,7 @@ void ParametersController::reinitCalculation() {
 }
 
 void ParametersController::didBecomeFirstResponder() {
-  App::Snapshot * snapshot = (App::Snapshot *)app()->snapshot();
-  snapshot->setActivePage(App::Snapshot::Page::Parameters);
+  app()->snapshot()->setActivePage(App::Snapshot::Page::Parameters);
   FloatParameterController::didBecomeFirstResponder();
 }
 

--- a/apps/probability/responder_image_cell.cpp
+++ b/apps/probability/responder_image_cell.cpp
@@ -21,8 +21,8 @@ KDSize ResponderImageCell::minimalSizeForOptimalDisplay() const {
 
 bool ResponderImageCell::handleEvent(Ion::Events::Event event) {
   if (event == Ion::Events::OK || event == Ion::Events::EXE || event == Ion::Events::Down) {
-    KDPoint topLeftAngle = app()->modalView()->pointFromPointInView(this, KDPoint(k_outline, k_outline));
-    app()->displayModalViewController(&m_calculationTypeController, 0.0f, 0.0f, topLeftAngle.y(), topLeftAngle.x());
+    KDPoint topLeftAngle = Container::activeApp()->modalView()->pointFromPointInView(this, KDPoint(k_outline, k_outline));
+    Container::activeApp()->displayModalViewController(&m_calculationTypeController, 0.0f, 0.0f, topLeftAngle.y(), topLeftAngle.x());
     return true;
   }
   return false;

--- a/apps/regression/app.cpp
+++ b/apps/regression/app.cpp
@@ -29,7 +29,7 @@ App::Snapshot::Snapshot() :
 }
 
 App * App::Snapshot::unpack(Container * container) {
-  return new (container->currentAppBuffer()) App(container, this);
+  return new (container->currentAppBuffer()) App(this);
 }
 
 void App::Snapshot::reset() {
@@ -50,8 +50,8 @@ void App::Snapshot::tidy() {
   m_store.tidy();
 }
 
-App::App(Container * container, Snapshot * snapshot) :
-  TextFieldDelegateApp(container, snapshot, &m_tabViewController),
+App::App(Snapshot * snapshot) :
+  TextFieldDelegateApp(snapshot, &m_tabViewController),
   m_calculationController(&m_calculationAlternateEmptyViewController, &m_calculationHeader, snapshot->store()),
   m_calculationAlternateEmptyViewController(&m_calculationHeader, &m_calculationController, &m_calculationController),
   m_calculationHeader(&m_tabViewController, &m_calculationAlternateEmptyViewController, &m_calculationController),

--- a/apps/regression/app.h
+++ b/apps/regression/app.h
@@ -58,7 +58,7 @@ private:
 };
 
 inline App * app() {
-  return static_cast<App *>(::app());
+  return static_cast<App *>(Container::activeApp());
 }
 
 }

--- a/apps/regression/app.h
+++ b/apps/regression/app.h
@@ -42,7 +42,7 @@ public:
   };
   RegressionController * regressionController() { return &m_regressionController; }
 private:
-  App(Container * container, Snapshot * snapshot);
+  App(Snapshot * snapshot);
   CalculationController m_calculationController;
   AlternateEmptyViewController m_calculationAlternateEmptyViewController;
   ButtonRowController m_calculationHeader;

--- a/apps/regression/app.h
+++ b/apps/regression/app.h
@@ -57,6 +57,10 @@ private:
   RegressionController m_regressionController;
 };
 
+inline App * app() {
+  return static_cast<App *>(::app());
+}
+
 }
 
 #endif

--- a/apps/regression/app.h
+++ b/apps/regression/app.h
@@ -40,6 +40,9 @@ public:
     uint32_t m_rangeVersion;
     int m_selectedSeriesIndex;
   };
+  static App * app() {
+    return static_cast<App *>(Container::activeApp());
+  }
   RegressionController * regressionController() { return &m_regressionController; }
 private:
   App(Snapshot * snapshot);
@@ -56,10 +59,6 @@ private:
   TabViewController m_tabViewController;
   RegressionController m_regressionController;
 };
-
-inline App * app() {
-  return static_cast<App *>(Container::activeApp());
-}
 
 }
 

--- a/apps/regression/calculation_controller.cpp
+++ b/apps/regression/calculation_controller.cpp
@@ -203,7 +203,7 @@ void CalculationController::willDisplayCellAtLocation(HighlightCell * cell, int 
     Model::Type modelType = m_store->seriesRegressionType(seriesNumber);
 
     // Put dashes if regression is not defined
-    Poincare::Context * globContext = const_cast<AppsContainer *>(static_cast<const AppsContainer *>(app()->container()))->globalContext();
+    Poincare::Context * globContext = AppsContainer::sharedAppsContainer()->globalContext();
     double * coefficients = m_store->coefficientsForSeries(seriesNumber, globContext);
     bool coefficientsAreDefined = true;
     int numberOfCoefs = m_store->modelForSeries(seriesNumber)->numberOfCoefficients();

--- a/apps/regression/calculation_controller.cpp
+++ b/apps/regression/calculation_controller.cpp
@@ -50,7 +50,7 @@ const char * CalculationController::title() {
 bool CalculationController::handleEvent(Ion::Events::Event event) {
   if (event == Ion::Events::Up) {
     selectableTableView()->deselectTable();
-    app()->setFirstResponder(tabController());
+    Container::activeApp()->setFirstResponder(tabController());
     return true;
   }
   return false;
@@ -78,7 +78,7 @@ void CalculationController::tableViewDidChangeSelection(SelectableTableView * t,
   if (t->selectedRow() == 0 && t->selectedColumn() == 0) {
     if (previousSelectedCellX == 0 && previousSelectedCellY == 1) {
       selectableTableView()->deselectTable();
-      app()->setFirstResponder(tabController());
+      Container::activeApp()->setFirstResponder(tabController());
     } else {
       t->selectCellAtLocation(0, 1);
     }

--- a/apps/regression/go_to_parameter_controller.cpp
+++ b/apps/regression/go_to_parameter_controller.cpp
@@ -40,7 +40,7 @@ double GoToParameterController::parameterAtIndex(int index) {
 bool GoToParameterController::setParameterAtIndex(int parameterIndex, double f) {
   assert(parameterIndex == 0);
   int series = m_graphController->selectedSeriesIndex();
-  Poincare::Context * globContext = const_cast<AppsContainer *>(static_cast<const AppsContainer *>(app()->container()))->globalContext();
+  Poincare::Context * globContext = AppsContainer::sharedAppsContainer()->globalContext();
   double unknown = m_xPrediction ?
     m_store->yValueForXValue(series, f, globContext) :
     m_store->xValueForYValue(series, f, globContext);

--- a/apps/regression/go_to_parameter_controller.cpp
+++ b/apps/regression/go_to_parameter_controller.cpp
@@ -57,7 +57,7 @@ bool GoToParameterController::setParameterAtIndex(int parameterIndex, double f) 
       }
     }
     // Value not reached
-    app()->displayWarning(I18n::Message::ValueNotReachedByRegression);
+    Container::activeApp()->displayWarning(I18n::Message::ValueNotReachedByRegression);
     return false;
   }
   m_graphController->selectRegressionCurve();
@@ -68,7 +68,7 @@ bool GoToParameterController::setParameterAtIndex(int parameterIndex, double f) 
     /* We here compute y2 = a*((y1-b)/a)+b, which does not always give y1,
      * because of computation precision. y2 migth thus be invalid. */
     if (std::isnan(yFromX) || std::isinf(yFromX)) {
-      app()->displayWarning(I18n::Message::ForbiddenValue);
+      Container::activeApp()->displayWarning(I18n::Message::ForbiddenValue);
       return false;
     }
     m_cursor->moveTo(unknown, yFromX);

--- a/apps/regression/graph_controller.cpp
+++ b/apps/regression/graph_controller.cpp
@@ -18,7 +18,7 @@ GraphController::GraphController(Responder * parentResponder, InputEventHandlerD
   m_crossCursorView(),
   m_roundCursorView(),
   m_bannerView(this, inputEventHandlerDelegate, this),
-  m_view(store, m_cursor, &m_bannerView, &m_crossCursorView, this),
+  m_view(store, m_cursor, &m_bannerView, &m_crossCursorView),
   m_store(store),
   m_initialisationParameterController(this, m_store),
   m_graphOptionsController(this, inputEventHandlerDelegate, m_store, m_cursor, this),

--- a/apps/regression/graph_controller.cpp
+++ b/apps/regression/graph_controller.cpp
@@ -97,7 +97,7 @@ void GraphController::selectRegressionCurve() {
 // Private
 
 Poincare::Context * GraphController::globalContext() {
-  return const_cast<AppsContainer *>(static_cast<const AppsContainer *>(app()->container()))->globalContext();
+  return AppsContainer::sharedAppsContainer()->globalContext();
 }
 
 // SimpleInteractiveCurveViewController

--- a/apps/regression/graph_options_controller.cpp
+++ b/apps/regression/graph_options_controller.cpp
@@ -41,7 +41,7 @@ void GraphOptionsController::viewWillAppear() {
 bool GraphOptionsController::handleEvent(Ion::Events::Event event) {
   if (event == Ion::Events::OK || event == Ion::Events::EXE || event == Ion::Events::Right) {
     if (selectedRow() == numberOfRows() -1) {
-      RegressionController * regressionController = app()->regressionController();
+      RegressionController * regressionController = App::app()->regressionController();
       regressionController->setSeries(m_graphController->selectedSeriesIndex());
       StackViewController * stack = static_cast<StackViewController *>(parentResponder());
       stack->push(regressionController);

--- a/apps/regression/graph_options_controller.cpp
+++ b/apps/regression/graph_options_controller.cpp
@@ -42,7 +42,7 @@ void GraphOptionsController::viewWillAppear() {
 bool GraphOptionsController::handleEvent(Ion::Events::Event event) {
   if (event == Ion::Events::OK || event == Ion::Events::EXE || event == Ion::Events::Right) {
     if (selectedRow() == numberOfRows() -1) {
-      RegressionController * regressionController = static_cast<Regression::App *>(app())->regressionController();
+      RegressionController * regressionController = app()->regressionController();
       regressionController->setSeries(m_graphController->selectedSeriesIndex());
       StackViewController * stack = static_cast<StackViewController *>(parentResponder());
       stack->push(regressionController);

--- a/apps/regression/graph_options_controller.cpp
+++ b/apps/regression/graph_options_controller.cpp
@@ -2,7 +2,6 @@
 #include "app.h"
 #include "graph_controller.h"
 #include "regression_controller.h"
-#include <apps/apps_container.h>
 #include <assert.h>
 
 using namespace Shared;
@@ -32,7 +31,7 @@ void GraphOptionsController::didBecomeFirstResponder() {
   if (selectedRow() < 0) {
     selectCellAtLocation(0, 0);
   }
-  app()->setFirstResponder(&m_selectableTableView);
+  Container::activeApp()->setFirstResponder(&m_selectableTableView);
 }
 
 void GraphOptionsController::viewWillAppear() {

--- a/apps/regression/graph_view.cpp
+++ b/apps/regression/graph_view.cpp
@@ -8,12 +8,11 @@ using namespace Shared;
 
 namespace Regression {
 
-GraphView::GraphView(Store * store, CurveViewCursor * cursor, BannerView * bannerView, View * cursorView, Responder * controller) :
+GraphView::GraphView(Store * store, CurveViewCursor * cursor, BannerView * bannerView, View * cursorView) :
   CurveView(store, cursor, bannerView, cursorView),
   m_store(store),
   m_xLabels{},
-  m_yLabels{},
-  m_controller(controller)
+  m_yLabels{}
 {
 }
 

--- a/apps/regression/graph_view.cpp
+++ b/apps/regression/graph_view.cpp
@@ -22,11 +22,11 @@ void GraphView::drawRect(KDContext * ctx, KDRect rect) const {
   drawGrid(ctx, rect);
   drawAxes(ctx, rect);
   simpleDrawBothAxesLabels(ctx, rect);
+  Poincare::Context * globContext = AppsContainer::sharedAppsContainer()->globalContext();
   for (int series = 0; series < Store::k_numberOfSeries; series++) {
     if (!m_store->seriesIsEmpty(series)) {
       KDColor color = Palette::DataColor[series];
       Model * seriesModel = m_store->modelForSeries(series);
-      Poincare::Context * globContext = const_cast<AppsContainer *>(static_cast<const AppsContainer *>(m_controller->app()->container()))->globalContext();
       drawCurve(ctx, rect, [](float abscissa, void * model, void * context) {
           Model * regressionModel = static_cast<Model *>(model);
           double * regressionCoefficients = static_cast<double *>(context);

--- a/apps/regression/graph_view.h
+++ b/apps/regression/graph_view.h
@@ -1,7 +1,6 @@
 #ifndef REGRESSION_GRAPH_VIEW_H
 #define REGRESSION_GRAPH_VIEW_H
 
-#include <escher.h>
 #include "store.h"
 #include "../constant.h"
 #include "../shared/curve_view.h"
@@ -10,14 +9,13 @@ namespace Regression {
 
 class GraphView : public Shared::CurveView {
 public:
-  GraphView(Store * store, Shared::CurveViewCursor * cursor, Shared::BannerView * bannerView, View * cursorView, Responder * controller);
+  GraphView(Store * store, Shared::CurveViewCursor * cursor, Shared::BannerView * bannerView, View * cursorView);
   void drawRect(KDContext * ctx, KDRect rect) const override;
 private:
   char * label(Axis axis, int index) const override;
   Store * m_store;
   char m_xLabels[k_maxNumberOfXLabels][k_labelBufferMaxSize];
   char m_yLabels[k_maxNumberOfYLabels][k_labelBufferMaxSize];
-  Responder * m_controller;
 };
 
 }

--- a/apps/regression/initialisation_parameter_controller.cpp
+++ b/apps/regression/initialisation_parameter_controller.cpp
@@ -22,7 +22,7 @@ View * InitialisationParameterController::view() {
 
 void InitialisationParameterController::didBecomeFirstResponder() {
   selectCellAtLocation(0, 0);
-  app()->setFirstResponder(&m_selectableTableView);
+  Container::activeApp()->setFirstResponder(&m_selectableTableView);
 }
 
 bool InitialisationParameterController::handleEvent(Ion::Events::Event event) {

--- a/apps/regression/regression_controller.cpp
+++ b/apps/regression/regression_controller.cpp
@@ -30,7 +30,7 @@ const char * RegressionController::title() {
 
 void RegressionController::didBecomeFirstResponder() {
   selectCellAtLocation(0, 0);
-  app()->setFirstResponder(&m_selectableTableView);
+  Container::activeApp()->setFirstResponder(&m_selectableTableView);
 }
 
 bool RegressionController::handleEvent(Ion::Events::Event event) {

--- a/apps/regression/store.cpp
+++ b/apps/regression/store.cpp
@@ -1,6 +1,5 @@
 #include "store.h"
 #include "linear_model_helper.h"
-#include "apps/apps_container.h"
 #include <poincare/preferences.h>
 #include <assert.h>
 #include <float.h>

--- a/apps/regression/store_controller.cpp
+++ b/apps/regression/store_controller.cpp
@@ -19,7 +19,7 @@ StoreController::StoreController(Responder * parentResponder, InputEventHandlerD
 }
 
 StoreContext * StoreController::storeContext() {
-  m_regressionContext.setParentContext(const_cast<AppsContainer *>(static_cast<const AppsContainer *>(app()->container()))->globalContext());
+  m_regressionContext.setParentContext(AppsContainer::sharedAppsContainer()->globalContext());
   return &m_regressionContext;
 }
 

--- a/apps/regression/store_parameter_controller.cpp
+++ b/apps/regression/store_parameter_controller.cpp
@@ -20,7 +20,7 @@ void StoreParameterController::viewWillAppear() {
 
 bool StoreParameterController::handleEvent(Ion::Events::Event event) {
   if ((event == Ion::Events::OK || event == Ion::Events::EXE || event == Ion::Events::Right) && selectedRow() == numberOfRows() - 1) {
-    RegressionController * regressionController = app()->regressionController();
+    RegressionController * regressionController = App::app()->regressionController();
     regressionController->setSeries(m_series);
     StackViewController * stack = static_cast<StackViewController *>(parentResponder());
     stack->push(regressionController);

--- a/apps/regression/store_parameter_controller.cpp
+++ b/apps/regression/store_parameter_controller.cpp
@@ -37,7 +37,7 @@ void StoreParameterController::didBecomeFirstResponder() {
     selectCellAtLocation(0, 0);
   }
   m_lastSelectionIsRegression = false;
-  app()->setFirstResponder(&m_selectableTableView);
+  Container::activeApp()->setFirstResponder(&m_selectableTableView);
 }
 
 HighlightCell * StoreParameterController::reusableCell(int index, int type) {

--- a/apps/regression/store_parameter_controller.cpp
+++ b/apps/regression/store_parameter_controller.cpp
@@ -20,7 +20,7 @@ void StoreParameterController::viewWillAppear() {
 
 bool StoreParameterController::handleEvent(Ion::Events::Event event) {
   if ((event == Ion::Events::OK || event == Ion::Events::EXE || event == Ion::Events::Right) && selectedRow() == numberOfRows() - 1) {
-    RegressionController * regressionController = static_cast<Regression::App *>(app())->regressionController();
+    RegressionController * regressionController = app()->regressionController();
     regressionController->setSeries(m_series);
     StackViewController * stack = static_cast<StackViewController *>(parentResponder());
     stack->push(regressionController);

--- a/apps/sequence/app.cpp
+++ b/apps/sequence/app.cpp
@@ -26,7 +26,7 @@ App::Snapshot::Snapshot() :
 }
 
 App * App::Snapshot::unpack(Container * container) {
-  return new (container->currentAppBuffer()) App(container, this);
+  return new (container->currentAppBuffer()) App(this);
 }
 
 void App::Snapshot::reset() {
@@ -53,9 +53,9 @@ void App::Snapshot::tidy() {
   m_graphRange.setDelegate(nullptr);
 }
 
-App::App(Container * container, Snapshot * snapshot) :
-  FunctionApp(container, snapshot, &m_inputViewController),
-  m_sequenceContext(((AppsContainer *)container)->globalContext(), snapshot->functionStore()),
+App::App(Snapshot * snapshot) :
+  FunctionApp(snapshot, &m_inputViewController),
+  m_sequenceContext(AppsContainer::sharedAppsContainer()->globalContext(), snapshot->functionStore()),
   m_listController(&m_listFooter, this, &m_listHeader, &m_listFooter),
   m_listFooter(&m_listHeader, &m_listController, &m_listController, ButtonRowController::Position::Bottom, ButtonRowController::Style::EmbossedGrey),
   m_listHeader(nullptr, &m_listFooter, &m_listController),

--- a/apps/sequence/app.h
+++ b/apps/sequence/app.h
@@ -33,6 +33,9 @@ public:
     SequenceStore m_sequenceStore;
     CurveViewRange m_graphRange;
   };
+  static App * app() {
+    return static_cast<App *>(Container::activeApp());
+  }
   InputViewController * inputViewController() override;
   // TODO: override variableBoxForInputEventHandler to lock sequence in the variable box once they appear there
   // NestedMenuController * variableBoxForInputEventHandler(InputEventHandler * textInput) override;
@@ -57,10 +60,6 @@ private:
   TabViewController m_tabViewController;
   InputViewController m_inputViewController;
 };
-
-inline App * app() {
-  return static_cast<App *>(Container::activeApp());
-}
 
 }
 

--- a/apps/sequence/app.h
+++ b/apps/sequence/app.h
@@ -40,7 +40,7 @@ public:
   SequenceContext * localContext() override;
   SequenceStore * functionStore() override { return static_cast<SequenceStore *>(Shared::FunctionApp::functionStore()); }
 private:
-  App(Container * container, Snapshot * snapshot);
+  App(Snapshot * snapshot);
   SequenceContext m_sequenceContext;
   ListController m_listController;
   ButtonRowController m_listFooter;

--- a/apps/sequence/app.h
+++ b/apps/sequence/app.h
@@ -59,7 +59,7 @@ private:
 };
 
 inline App * app() {
-  return static_cast<App *>(::app());
+  return static_cast<App *>(Container::activeApp());
 }
 
 }

--- a/apps/sequence/app.h
+++ b/apps/sequence/app.h
@@ -58,6 +58,10 @@ private:
   InputViewController m_inputViewController;
 };
 
+inline App * app() {
+  return static_cast<App *>(::app());
+}
+
 }
 
 #endif

--- a/apps/sequence/graph/graph_controller.cpp
+++ b/apps/sequence/graph/graph_controller.cpp
@@ -1,6 +1,7 @@
 #include "graph_controller.h"
 #include <cmath>
 #include <limits.h>
+#include "../app.h"
 
 using namespace Shared;
 using namespace Poincare;
@@ -10,7 +11,7 @@ namespace Sequence {
 static inline int minInt(int x, int y) { return (x < y ? x : y); }
 static inline int maxInt(int x, int y) { return (x > y ? x : y); }
 
-GraphController::GraphController(Responder * parentResponder, InputEventHandlerDelegate * inputEventHandlerDelegate, SequenceStore * sequenceStore, CurveViewRange * graphRange, CurveViewCursor * cursor, int * indexFunctionSelectedByCursor, uint32_t * modelVersion, uint32_t * rangeVersion, Preferences::AngleUnit * angleUnitVersion, ButtonRowController * header) :
+GraphController::GraphController(Responder * parentResponder, ::InputEventHandlerDelegate * inputEventHandlerDelegate, SequenceStore * sequenceStore, CurveViewRange * graphRange, CurveViewCursor * cursor, int * indexFunctionSelectedByCursor, uint32_t * modelVersion, uint32_t * rangeVersion, Preferences::AngleUnit * angleUnitVersion, ButtonRowController * header) :
   FunctionGraphController(parentResponder, inputEventHandlerDelegate, header, graphRange, &m_view, cursor, indexFunctionSelectedByCursor, modelVersion, rangeVersion, angleUnitVersion),
   m_bannerView(this, inputEventHandlerDelegate, this),
   m_view(sequenceStore, graphRange, m_cursor, &m_bannerView, &m_cursorView),
@@ -95,8 +96,7 @@ bool GraphController::moveCursorHorizontally(int direction) {
     return false;
   }
   Sequence * s = functionStore()->modelForRecord(functionStore()->activeRecordAtIndex(indexFunctionSelectedByCursor()));
-  TextFieldDelegateApp * myApp = (TextFieldDelegateApp *)app();
-  double y = s->evaluateAtAbscissa(x, myApp->localContext());
+  double y = s->evaluateAtAbscissa(x, app()->localContext());
   m_cursor->moveTo(x, y);
   return true;
 }

--- a/apps/sequence/graph/graph_controller.cpp
+++ b/apps/sequence/graph/graph_controller.cpp
@@ -61,12 +61,13 @@ float GraphController::interestingXHalfRange() const {
 }
 
 bool GraphController::textFieldDidFinishEditing(TextField * textField, const char * text, Ion::Events::Event event) {
+  Shared::TextFieldDelegateApp * myApp = textFieldDelegateApp();
   double floatBody;
-  if (app()->hasUndefinedValue(text, floatBody)) {
+  if (myApp->hasUndefinedValue(text, floatBody)) {
     return false;
   }
   floatBody = std::fmax(0, std::round(floatBody));
-  double y = yValue(selectedCurveIndex(), floatBody, app()->localContext());
+  double y = yValue(selectedCurveIndex(), floatBody, myApp->localContext());
   m_cursor->moveTo(floatBody, y);
   interactiveCurveViewRange()->panToMakePointVisible(m_cursor->x(), m_cursor->y(), cursorTopMarginRatio(), k_cursorRightMarginRatio, cursorBottomMarginRatio(), k_cursorLeftMarginRatio);
   reloadBannerView();
@@ -96,7 +97,7 @@ bool GraphController::moveCursorHorizontally(int direction) {
     return false;
   }
   Sequence * s = functionStore()->modelForRecord(functionStore()->activeRecordAtIndex(indexFunctionSelectedByCursor()));
-  double y = s->evaluateAtAbscissa(x, app()->localContext());
+  double y = s->evaluateAtAbscissa(x, textFieldDelegateApp()->localContext());
   m_cursor->moveTo(x, y);
   return true;
 }

--- a/apps/sequence/graph/graph_controller.cpp
+++ b/apps/sequence/graph/graph_controller.cpp
@@ -62,11 +62,11 @@ float GraphController::interestingXHalfRange() const {
 
 bool GraphController::textFieldDidFinishEditing(TextField * textField, const char * text, Ion::Events::Event event) {
   double floatBody;
-  if (textFieldDelegateApp()->hasUndefinedValue(text, floatBody)) {
+  if (app()->hasUndefinedValue(text, floatBody)) {
     return false;
   }
   floatBody = std::fmax(0, std::round(floatBody));
-  double y = yValue(selectedCurveIndex(), floatBody, textFieldDelegateApp()->localContext());
+  double y = yValue(selectedCurveIndex(), floatBody, app()->localContext());
   m_cursor->moveTo(floatBody, y);
   interactiveCurveViewRange()->panToMakePointVisible(m_cursor->x(), m_cursor->y(), cursorTopMarginRatio(), k_cursorRightMarginRatio, cursorBottomMarginRatio(), k_cursorLeftMarginRatio);
   reloadBannerView();

--- a/apps/sequence/graph/graph_controller.h
+++ b/apps/sequence/graph/graph_controller.h
@@ -14,7 +14,7 @@ namespace Sequence {
 
 class GraphController final : public Shared::FunctionGraphController {
 public:
-  GraphController(Responder * parentResponder, InputEventHandlerDelegate * inputEventHandlerDelegate, SequenceStore * sequenceStore, CurveViewRange * graphRange, Shared::CurveViewCursor * cursor, int * indexFunctionSelectedByCursor, uint32_t * modelVersion, uint32_t * rangeVersion, Poincare::Preferences::AngleUnit * angleUnitVersion, ButtonRowController * header);
+  GraphController(Responder * parentResponder, ::InputEventHandlerDelegate * inputEventHandlerDelegate, SequenceStore * sequenceStore, CurveViewRange * graphRange, Shared::CurveViewCursor * cursor, int * indexFunctionSelectedByCursor, uint32_t * modelVersion, uint32_t * rangeVersion, Poincare::Preferences::AngleUnit * angleUnitVersion, ButtonRowController * header);
   I18n::Message emptyMessage() override;
   void viewWillAppear() override;
   TermSumController * termSumController() { return &m_termSumController; }

--- a/apps/sequence/list/list_controller.cpp
+++ b/apps/sequence/list/list_controller.cpp
@@ -258,7 +258,7 @@ int ListController::sequenceDefinitionForRow(int j) {
 }
 
 void ListController::addEmptyModel() {
-  app()->displayModalViewController(&m_typeStackController, 0.f, 0.f, Metric::TabHeight+Metric::ModalTopMargin, Metric::CommonRightMargin, Metric::ModalBottomMargin, Metric::CommonLeftMargin);
+  Container::activeApp()->displayModalViewController(&m_typeStackController, 0.f, 0.f, Metric::TabHeight+Metric::ModalTopMargin, Metric::CommonRightMargin, Metric::ModalBottomMargin, Metric::CommonLeftMargin);
 }
 
 void ListController::editExpression(Ion::Events::Event event) {

--- a/apps/sequence/list/list_controller.cpp
+++ b/apps/sequence/list/list_controller.cpp
@@ -162,10 +162,6 @@ TextFieldDelegateApp * ListController::textFieldDelegateApp() {
   return app();
 }
 
-ExpressionFieldDelegateApp * ListController::expressionFieldDelegateApp() {
-  return app();
-}
-
 ListParameterController * ListController::parameterController() {
   return &m_parameterController;
 }

--- a/apps/sequence/list/list_controller.cpp
+++ b/apps/sequence/list/list_controller.cpp
@@ -109,7 +109,7 @@ void ListController::editExpression(int sequenceDefinition, Ion::Events::Event e
   }
   InputViewController * inputController = Shared::FunctionApp::app()->inputViewController();
   // Invalidate the sequences context cache
-  app()->localContext()->resetCache();
+  App::app()->localContext()->resetCache();
   switch (sequenceDefinition) {
     case 0:
       inputController->edit(this, event, this, initialText,
@@ -267,7 +267,7 @@ void ListController::editExpression(Ion::Events::Event event) {
 
 void ListController::reinitSelectedExpression(ExpiringPointer<ExpressionModelHandle> model) {
   // Invalidate the sequences context cache
-  app()->localContext()->resetCache();
+  App::app()->localContext()->resetCache();
   Sequence * sequence = static_cast<Sequence *>(model.pointer());
   switch (sequenceDefinitionForRow(selectedRow())) {
     case 1:
@@ -295,7 +295,7 @@ void ListController::reinitSelectedExpression(ExpiringPointer<ExpressionModelHan
 bool ListController::removeModelRow(Ion::Storage::Record record) {
   Shared::FunctionListController::removeModelRow(record);
   // Invalidate the sequences context cache
-  app()->localContext()->resetCache();
+  App::app()->localContext()->resetCache();
   return true;
 }
 

--- a/apps/sequence/list/list_controller.cpp
+++ b/apps/sequence/list/list_controller.cpp
@@ -166,10 +166,6 @@ ExpressionFieldDelegateApp * ListController::expressionFieldDelegateApp() {
   return app();
 }
 
-InputEventHandlerDelegateApp * ListController::inputEventHandlerDelegateApp() {
-  return app();
-}
-
 ListParameterController * ListController::parameterController() {
   return &m_parameterController;
 }

--- a/apps/sequence/list/list_controller.cpp
+++ b/apps/sequence/list/list_controller.cpp
@@ -107,10 +107,9 @@ void ListController::editExpression(int sequenceDefinition, Ion::Events::Event e
     // Replace UCodePointUnknownN with 'n'
     replaceUnknownSymbolWithReadableSymbol(initialText);
   }
-  App * myApp = (App *)app();
-  InputViewController * inputController = myApp->inputViewController();
+  InputViewController * inputController = app()->inputViewController();
   // Invalidate the sequences context cache
-  static_cast<App *>(app())->localContext()->resetCache();
+  app()->localContext()->resetCache();
   switch (sequenceDefinition) {
     case 0:
       inputController->edit(this, event, this, initialText,
@@ -160,15 +159,15 @@ bool ListController::editInitialConditionOfSelectedRecordWithText(const char * t
 }
 
 TextFieldDelegateApp * ListController::textFieldDelegateApp() {
-  return (App *)app();
+  return app();
 }
 
 ExpressionFieldDelegateApp * ListController::expressionFieldDelegateApp() {
-  return (App *)app();
+  return app();
 }
 
 InputEventHandlerDelegateApp * ListController::inputEventHandlerDelegateApp() {
-  return (App *)app();
+  return app();
 }
 
 ListParameterController * ListController::parameterController() {
@@ -280,7 +279,7 @@ void ListController::editExpression(Ion::Events::Event event) {
 
 void ListController::reinitSelectedExpression(ExpiringPointer<ExpressionModelHandle> model) {
   // Invalidate the sequences context cache
-  static_cast<App *>(app())->localContext()->resetCache();
+  app()->localContext()->resetCache();
   Sequence * sequence = static_cast<Sequence *>(model.pointer());
   switch (sequenceDefinitionForRow(selectedRow())) {
     case 1:
@@ -308,7 +307,7 @@ void ListController::reinitSelectedExpression(ExpiringPointer<ExpressionModelHan
 bool ListController::removeModelRow(Ion::Storage::Record record) {
   Shared::FunctionListController::removeModelRow(record);
   // Invalidate the sequences context cache
-  static_cast<App *>(app())->localContext()->resetCache();
+  app()->localContext()->resetCache();
   return true;
 }
 

--- a/apps/sequence/list/list_controller.cpp
+++ b/apps/sequence/list/list_controller.cpp
@@ -107,7 +107,7 @@ void ListController::editExpression(int sequenceDefinition, Ion::Events::Event e
     // Replace UCodePointUnknownN with 'n'
     replaceUnknownSymbolWithReadableSymbol(initialText);
   }
-  InputViewController * inputController = app()->inputViewController();
+  InputViewController * inputController = Shared::FunctionApp::app()->inputViewController();
   // Invalidate the sequences context cache
   app()->localContext()->resetCache();
   switch (sequenceDefinition) {

--- a/apps/sequence/list/list_controller.cpp
+++ b/apps/sequence/list/list_controller.cpp
@@ -158,10 +158,6 @@ bool ListController::editInitialConditionOfSelectedRecordWithText(const char * t
   return (error == Ion::Storage::Record::ErrorStatus::None);
 }
 
-TextFieldDelegateApp * ListController::textFieldDelegateApp() {
-  return app();
-}
-
 ListParameterController * ListController::parameterController() {
   return &m_parameterController;
 }

--- a/apps/sequence/list/list_controller.h
+++ b/apps/sequence/list/list_controller.h
@@ -29,7 +29,6 @@ private:
   static constexpr KDCoordinate k_expressionCellVerticalMargin = 3;
   bool editInitialConditionOfSelectedRecordWithText(const char * text, bool firstInitialCondition);
   Shared::TextFieldDelegateApp * textFieldDelegateApp() override;
-  Shared::ExpressionFieldDelegateApp * expressionFieldDelegateApp() override;
   ListParameterController * parameterController() override;
   int maxNumberOfDisplayableRows() override;
   Shared::FunctionTitleCell * titleCells(int index) override;

--- a/apps/sequence/list/list_controller.h
+++ b/apps/sequence/list/list_controller.h
@@ -30,7 +30,6 @@ private:
   bool editInitialConditionOfSelectedRecordWithText(const char * text, bool firstInitialCondition);
   Shared::TextFieldDelegateApp * textFieldDelegateApp() override;
   Shared::ExpressionFieldDelegateApp * expressionFieldDelegateApp() override;
-  Shared::InputEventHandlerDelegateApp * inputEventHandlerDelegateApp() override;
   ListParameterController * parameterController() override;
   int maxNumberOfDisplayableRows() override;
   Shared::FunctionTitleCell * titleCells(int index) override;

--- a/apps/sequence/list/list_controller.h
+++ b/apps/sequence/list/list_controller.h
@@ -28,7 +28,6 @@ public:
 private:
   static constexpr KDCoordinate k_expressionCellVerticalMargin = 3;
   bool editInitialConditionOfSelectedRecordWithText(const char * text, bool firstInitialCondition);
-  Shared::TextFieldDelegateApp * textFieldDelegateApp() override;
   ListParameterController * parameterController() override;
   int maxNumberOfDisplayableRows() override;
   Shared::FunctionTitleCell * titleCells(int index) override;

--- a/apps/sequence/list/list_parameter_controller.cpp
+++ b/apps/sequence/list/list_parameter_controller.cpp
@@ -56,7 +56,7 @@ bool ListParameterController::handleEvent(Ion::Events::Event event) {
 #else
     if (selectedRowIndex == 2+hasAdditionalRow) {
 #endif
-      app()->localContext()->resetCache();
+      App::app()->localContext()->resetCache();
       return handleEnterOnRow(selectedRowIndex-hasAdditionalRow-1);
     }
   }
@@ -82,7 +82,7 @@ bool ListParameterController::textFieldDidFinishEditing(TextField * textField, c
   }
   sequence()->setInitialRank(index);
   // Invalidate sequence context cache when changing sequence type
-  app()->localContext()->resetCache();
+  App::app()->localContext()->resetCache();
   m_selectableTableView.reloadCellAtLocation(0, selectedRow());
   m_selectableTableView.handleEvent(event);
   return true;

--- a/apps/sequence/list/list_parameter_controller.cpp
+++ b/apps/sequence/list/list_parameter_controller.cpp
@@ -1,7 +1,6 @@
 #include "list_parameter_controller.h"
 #include "list_controller.h"
 #include "../app.h"
-#include "../../apps_container.h"
 #include "../../shared/poincare_helpers.h"
 
 using namespace Poincare;

--- a/apps/sequence/list/list_parameter_controller.cpp
+++ b/apps/sequence/list/list_parameter_controller.cpp
@@ -72,7 +72,7 @@ bool ListParameterController::textFieldDidFinishEditing(TextField * textField, c
   /* -1 to take into account a double recursive sequence, which has
    * SecondIndex = FirstIndex + 1 */
   double floatBody;
-  if (app()->hasUndefinedValue(text, floatBody)) {
+  if (textFieldDelegateApp()->hasUndefinedValue(text, floatBody)) {
     return false;
   }
   int index = std::round(floatBody);

--- a/apps/sequence/list/list_parameter_controller.cpp
+++ b/apps/sequence/list/list_parameter_controller.cpp
@@ -148,10 +148,6 @@ void ListParameterController::willDisplayCellForIndex(HighlightCell * cell, int 
   }
 }
 
-TextFieldDelegateApp * ListParameterController::textFieldDelegateApp() {
-  return app();
-}
-
 int ListParameterController::totalNumberOfCells() const {
   if (hasInitialRankRow()) {
     return k_totalNumberOfCell;

--- a/apps/sequence/list/list_parameter_controller.cpp
+++ b/apps/sequence/list/list_parameter_controller.cpp
@@ -77,7 +77,7 @@ bool ListParameterController::textFieldDidFinishEditing(TextField * textField, c
   }
   int index = std::round(floatBody);
   if (index < 0  || floatBody >= maxFirstIndex) {
-    app()->displayWarning(I18n::Message::ForbiddenValue);
+    Container::activeApp()->displayWarning(I18n::Message::ForbiddenValue);
     return false;
   }
   sequence()->setInitialRank(index);
@@ -104,7 +104,7 @@ void ListParameterController::tableViewDidChangeSelection(SelectableTableView * 
     if (myCell) {
       myCell->setEditing(false);
     }
-    app()->setFirstResponder(&m_selectableTableView);
+    Container::activeApp()->setFirstResponder(&m_selectableTableView);
   }
 #if FUNCTION_COLOR_CHOICE
   if (t->selectedRow() == 2) {
@@ -112,7 +112,7 @@ void ListParameterController::tableViewDidChangeSelection(SelectableTableView * 
   if (t->selectedRow() == 1) {
 #endif
     MessageTableCellWithEditableText * myNewCell = (MessageTableCellWithEditableText *)t->selectedCell();
-    app()->setFirstResponder(myNewCell);
+    Container::activeApp()->setFirstResponder(myNewCell);
   }
 }
 

--- a/apps/sequence/list/list_parameter_controller.cpp
+++ b/apps/sequence/list/list_parameter_controller.cpp
@@ -72,7 +72,7 @@ bool ListParameterController::textFieldDidFinishEditing(TextField * textField, c
   /* -1 to take into account a double recursive sequence, which has
    * SecondIndex = FirstIndex + 1 */
   double floatBody;
-  if (textFieldDelegateApp()->hasUndefinedValue(text, floatBody)) {
+  if (app()->hasUndefinedValue(text, floatBody)) {
     return false;
   }
   int index = std::round(floatBody);

--- a/apps/sequence/list/list_parameter_controller.cpp
+++ b/apps/sequence/list/list_parameter_controller.cpp
@@ -56,7 +56,7 @@ bool ListParameterController::handleEvent(Ion::Events::Event event) {
 #else
     if (selectedRowIndex == 2+hasAdditionalRow) {
 #endif
-      static_cast<App *>(app())->localContext()->resetCache();
+      app()->localContext()->resetCache();
       return handleEnterOnRow(selectedRowIndex-hasAdditionalRow-1);
     }
   }
@@ -82,7 +82,7 @@ bool ListParameterController::textFieldDidFinishEditing(TextField * textField, c
   }
   sequence()->setInitialRank(index);
   // Invalidate sequence context cache when changing sequence type
-  static_cast<App *>(app())->localContext()->resetCache();
+  app()->localContext()->resetCache();
   m_selectableTableView.reloadCellAtLocation(0, selectedRow());
   m_selectableTableView.handleEvent(event);
   return true;
@@ -149,7 +149,7 @@ void ListParameterController::willDisplayCellForIndex(HighlightCell * cell, int 
 }
 
 TextFieldDelegateApp * ListParameterController::textFieldDelegateApp() {
-  return (TextFieldDelegateApp *)app();
+  return app();
 }
 
 int ListParameterController::totalNumberOfCells() const {

--- a/apps/sequence/list/list_parameter_controller.h
+++ b/apps/sequence/list/list_parameter_controller.h
@@ -20,7 +20,6 @@ public:
   bool textFieldShouldFinishEditing(TextField * textField, Ion::Events::Event event) override;
   bool textFieldDidFinishEditing(TextField * textField, const char * text, Ion::Events::Event event) override;
   void tableViewDidChangeSelection(SelectableTableView * t, int previousSelectedCellX, int previousSelectedCellY, bool withinTemporarySelection) override;
-  Shared::TextFieldDelegateApp * textFieldDelegateApp() override;
 
   // ListViewDataSource
   HighlightCell * reusableCell(int index, int type) override;

--- a/apps/sequence/list/sequence_toolbox.cpp
+++ b/apps/sequence/list/sequence_toolbox.cpp
@@ -99,7 +99,7 @@ bool SequenceToolbox::selectAddedCell(int selectedRow){
   char buffer[bufferSize];
   m_addedCellLayout[selectedRow].serializeParsedExpression(buffer, bufferSize);
   sender()->handleEventWithText(buffer);
-  app()->dismissModalViewController();
+  Container::activeApp()->dismissModalViewController();
   return true;
 }
 

--- a/apps/sequence/list/type_parameter_controller.cpp
+++ b/apps/sequence/list/type_parameter_controller.cpp
@@ -49,7 +49,7 @@ void TypeParameterController::viewDidDisappear() {
 
 void TypeParameterController::didBecomeFirstResponder() {
   selectCellAtLocation(0, 0);
-  app()->setFirstResponder(&m_selectableTableView);
+  Container::activeApp()->setFirstResponder(&m_selectableTableView);
 }
 
 bool TypeParameterController::handleEvent(Ion::Events::Event event) {
@@ -81,7 +81,7 @@ bool TypeParameterController::handleEvent(Ion::Events::Event event) {
     Ion::Storage::Record record = sequenceStore()->recordAtIndex(sequenceStore()->numberOfModels()-1);
     Sequence * newSequence = sequenceStore()->modelForRecord(record);
     newSequence->setType((Sequence::Type)selectedRow());
-    app()->dismissModalViewController();
+    Container::activeApp()->dismissModalViewController();
     m_listController->editExpression(0, Ion::Events::OK);
     return true;
   }

--- a/apps/sequence/list/type_parameter_controller.cpp
+++ b/apps/sequence/list/type_parameter_controller.cpp
@@ -60,7 +60,7 @@ bool TypeParameterController::handleEvent(Ion::Events::Event event) {
         m_listController->selectPreviousNewSequenceCell();
         sequence()->setType(sequenceType);
         // Invalidate sequence context cache when changing sequence type
-        static_cast<App *>(app())->localContext()->resetCache();
+        app()->localContext()->resetCache();
         // Reset the first index if the new type is "Explicit"
         if (sequenceType == Sequence::Type::Explicit) {
           sequence()->setInitialRank(0);
@@ -135,8 +135,7 @@ void TypeParameterController::setRecord(Ion::Storage::Record record) {
 }
 
 SequenceStore * TypeParameterController::sequenceStore() {
-  App * a = static_cast<App *>(app());
-  return a->functionStore();
+  return app()->functionStore();
 }
 
 StackViewController * TypeParameterController::stackController() const {

--- a/apps/sequence/list/type_parameter_controller.cpp
+++ b/apps/sequence/list/type_parameter_controller.cpp
@@ -60,7 +60,7 @@ bool TypeParameterController::handleEvent(Ion::Events::Event event) {
         m_listController->selectPreviousNewSequenceCell();
         sequence()->setType(sequenceType);
         // Invalidate sequence context cache when changing sequence type
-        app()->localContext()->resetCache();
+        App::app()->localContext()->resetCache();
         // Reset the first index if the new type is "Explicit"
         if (sequenceType == Sequence::Type::Explicit) {
           sequence()->setInitialRank(0);
@@ -135,7 +135,7 @@ void TypeParameterController::setRecord(Ion::Storage::Record record) {
 }
 
 SequenceStore * TypeParameterController::sequenceStore() {
-  return app()->functionStore();
+  return App::app()->functionStore();
 }
 
 StackViewController * TypeParameterController::stackController() const {

--- a/apps/sequence/values/interval_parameter_controller.cpp
+++ b/apps/sequence/values/interval_parameter_controller.cpp
@@ -22,7 +22,7 @@ void IntervalParameterController::willDisplayCellForIndex(HighlightCell * cell, 
 
 bool IntervalParameterController::setParameterAtIndex(int parameterIndex, double f) {
   if (f < 0) {
-    app()->displayWarning(I18n::Message::ForbiddenValue);
+    Container::activeApp()->displayWarning(I18n::Message::ForbiddenValue);
     return false;
   }
   double parameter = std::round(f);

--- a/apps/settings/app.cpp
+++ b/apps/settings/app.cpp
@@ -17,7 +17,7 @@ const Image * App::Descriptor::icon() {
 }
 
 App * App::Snapshot::unpack(Container * container) {
-  return new (container->currentAppBuffer()) App(container, this);
+  return new (container->currentAppBuffer()) App(this);
 }
 
 App::Descriptor * App::Snapshot::descriptor() {
@@ -25,8 +25,8 @@ App::Descriptor * App::Snapshot::descriptor() {
   return &descriptor;
 }
 
-App::App(Container * container, Snapshot * snapshot) :
-  Shared::TextFieldDelegateApp(container, snapshot, &m_stackViewController),
+App::App(Snapshot * snapshot) :
+  Shared::TextFieldDelegateApp(snapshot, &m_stackViewController),
   m_mainController(&m_stackViewController, this),
   m_stackViewController(&m_modalViewController, &m_mainController)
 {

--- a/apps/settings/app.h
+++ b/apps/settings/app.h
@@ -25,10 +25,6 @@ private:
   StackViewController m_stackViewController;
 };
 
-inline App * app() {
-  return static_cast<App *>(::app());
-}
-
 }
 
 #endif

--- a/apps/settings/app.h
+++ b/apps/settings/app.h
@@ -20,7 +20,7 @@ public:
     Descriptor * descriptor() override;
   };
 private:
-  App(Container * container, Snapshot * snapshot);
+  App(Snapshot * snapshot);
   MainController m_mainController;
   StackViewController m_stackViewController;
 };

--- a/apps/settings/app.h
+++ b/apps/settings/app.h
@@ -25,7 +25,7 @@ private:
   StackViewController m_stackViewController;
 };
 
-App * app() {
+inline App * app() {
   return static_cast<App *>(::app());
 }
 

--- a/apps/settings/app.h
+++ b/apps/settings/app.h
@@ -25,6 +25,10 @@ private:
   StackViewController m_stackViewController;
 };
 
+App * app() {
+  return static_cast<App *>(::app());
+}
+
 }
 
 #endif

--- a/apps/settings/main_controller.cpp
+++ b/apps/settings/main_controller.cpp
@@ -65,7 +65,7 @@ void MainController::didBecomeFirstResponder() {
   if (selectedRow() < 0) {
     selectCellAtLocation(0, 0);
   }
-  app()->setFirstResponder(&m_selectableTableView);
+  Container::activeApp()->setFirstResponder(&m_selectableTableView);
 }
 
 bool MainController::handleEvent(Ion::Events::Event event) {

--- a/apps/settings/sub_menu/about_controller.cpp
+++ b/apps/settings/sub_menu/about_controller.cpp
@@ -18,7 +18,7 @@ bool AboutController::handleEvent(Ion::Events::Event event) {
   /* We hide here the activation hardware test app: in the menu "about", by
    * clicking on '6' on the last row. */
   if ((event == Ion::Events::Six || event == Ion::Events::LowerT || event == Ion::Events::UpperT) && m_messageTreeModel->label() == I18n::Message::About && selectedRow() == numberOfRows()-1) {
-    app()->displayModalViewController(&m_hardwareTestPopUpController, 0.f, 0.f, Metric::ExamPopUpTopMargin, Metric::PopUpRightMargin, Metric::ExamPopUpBottomMargin, Metric::PopUpLeftMargin);
+    Container::activeApp()->displayModalViewController(&m_hardwareTestPopUpController, 0.f, 0.f, Metric::ExamPopUpTopMargin, Metric::PopUpRightMargin, Metric::ExamPopUpBottomMargin, Metric::PopUpLeftMargin);
     return true;
   }
   if (event == Ion::Events::OK || event == Ion::Events::EXE) {

--- a/apps/settings/sub_menu/about_controller.cpp
+++ b/apps/settings/sub_menu/about_controller.cpp
@@ -1,9 +1,6 @@
 #include "about_controller.h"
-#include "../../apps_container.h"
 #include <assert.h>
 #include <cmath>
-
-using namespace Shared;
 
 namespace Settings {
 

--- a/apps/settings/sub_menu/display_mode_controller.cpp
+++ b/apps/settings/sub_menu/display_mode_controller.cpp
@@ -78,7 +78,7 @@ bool DisplayModeController::textFieldShouldFinishEditing(TextField * textField, 
 
 bool DisplayModeController::textFieldDidFinishEditing(TextField * textField, const char * text, Ion::Events::Event event) {
   double floatBody;
-  if (app()->hasUndefinedValue(text, floatBody)) {
+  if (textFieldDelegateApp()->hasUndefinedValue(text, floatBody)) {
     return false;
   }
   if (floatBody < 1) {

--- a/apps/settings/sub_menu/display_mode_controller.cpp
+++ b/apps/settings/sub_menu/display_mode_controller.cpp
@@ -2,6 +2,7 @@
 #include "../../shared/poincare_helpers.h"
 #include <assert.h>
 #include <cmath>
+#include "../app.h"
 
 #include <poincare/integer.h>
 
@@ -95,7 +96,7 @@ bool DisplayModeController::textFieldDidFinishEditing(TextField * textField, con
 }
 
 Shared::TextFieldDelegateApp * DisplayModeController::textFieldDelegateApp() {
-  return (Shared::TextFieldDelegateApp *)app();
+  return app();
 }
 
 }

--- a/apps/settings/sub_menu/display_mode_controller.cpp
+++ b/apps/settings/sub_menu/display_mode_controller.cpp
@@ -95,8 +95,4 @@ bool DisplayModeController::textFieldDidFinishEditing(TextField * textField, con
   return true;
 }
 
-Shared::TextFieldDelegateApp * DisplayModeController::textFieldDelegateApp() {
-  return app();
-}
-
 }

--- a/apps/settings/sub_menu/display_mode_controller.cpp
+++ b/apps/settings/sub_menu/display_mode_controller.cpp
@@ -78,7 +78,7 @@ bool DisplayModeController::textFieldShouldFinishEditing(TextField * textField, 
 
 bool DisplayModeController::textFieldDidFinishEditing(TextField * textField, const char * text, Ion::Events::Event event) {
   double floatBody;
-  if (textFieldDelegateApp()->hasUndefinedValue(text, floatBody)) {
+  if (app()->hasUndefinedValue(text, floatBody)) {
     return false;
   }
   if (floatBody < 1) {

--- a/apps/settings/sub_menu/display_mode_controller.h
+++ b/apps/settings/sub_menu/display_mode_controller.h
@@ -20,7 +20,6 @@ public:
   bool textFieldShouldFinishEditing(TextField * textField, Ion::Events::Event event) override;
   bool textFieldDidFinishEditing(TextField * textField, const char * text, Ion::Events::Event event) override;
 private:
-  Shared::TextFieldDelegateApp * textFieldDelegateApp() override;
   MessageTableCellWithEditableTextWithSeparator m_editableCell;
   char m_draftTextBuffer[MessageTableCellWithEditableText::k_bufferLength];
 };

--- a/apps/settings/sub_menu/exam_mode_controller.cpp
+++ b/apps/settings/sub_menu/exam_mode_controller.cpp
@@ -24,8 +24,7 @@ bool ExamModeController::handleEvent(Ion::Events::Event event) {
     if (GlobalPreferences::sharedGlobalPreferences()->examMode() == GlobalPreferences::ExamMode::Activate) {
       return false;
     }
-    AppsContainer * container = (AppsContainer *)(app()->container());
-    container->displayExamModePopUp(true);
+    AppsContainer::sharedAppsContainer()->displayExamModePopUp(true);
     return true;
   }
   return GenericSubController::handleEvent(event);

--- a/apps/settings/sub_menu/generic_sub_controller.cpp
+++ b/apps/settings/sub_menu/generic_sub_controller.cpp
@@ -28,7 +28,7 @@ View * GenericSubController::view() {
 
 void GenericSubController::didBecomeFirstResponder() {
   selectCellAtLocation(0, 0);
-  app()->setFirstResponder(&m_selectableTableView);
+  Container::activeApp()->setFirstResponder(&m_selectableTableView);
 }
 
 bool GenericSubController::handleEvent(Ion::Events::Event event) {

--- a/apps/settings/sub_menu/generic_sub_controller.cpp
+++ b/apps/settings/sub_menu/generic_sub_controller.cpp
@@ -1,10 +1,8 @@
 #include "generic_sub_controller.h"
-#include "../../apps_container.h"
 #include <assert.h>
 #include <cmath>
 
 using namespace Poincare;
-using namespace Shared;
 
 namespace Settings {
 

--- a/apps/settings/sub_menu/preferences_controller.cpp
+++ b/apps/settings/sub_menu/preferences_controller.cpp
@@ -22,7 +22,7 @@ PreferencesController::PreferencesController(Responder * parentResponder) :
 
 void PreferencesController::didBecomeFirstResponder() {
   selectCellAtLocation(0, valueIndexForPreference(m_messageTreeModel->label()));
-  app()->setFirstResponder(&m_selectableTableView);
+  Container::activeApp()->setFirstResponder(&m_selectableTableView);
 }
 
 bool PreferencesController::handleEvent(Ion::Events::Event event) {

--- a/apps/settings/sub_menu/preferences_controller.cpp
+++ b/apps/settings/sub_menu/preferences_controller.cpp
@@ -30,8 +30,7 @@ bool PreferencesController::handleEvent(Ion::Events::Event event) {
     /* Generic behaviour of preference menu*/
     assert(m_messageTreeModel->label() != I18n::Message::DisplayMode || selectedRow() != numberOfRows()-1); // In that case, events OK and EXE are handled by the cell
     setPreferenceWithValueIndex(m_messageTreeModel->label(), selectedRow());
-    AppsContainer * myContainer = (AppsContainer * )app()->container();
-    myContainer->refreshPreferences();
+    AppsContainer::sharedAppsContainer()->refreshPreferences();
     StackViewController * stack = stackController();
     stack->pop();
     return true;

--- a/apps/shared/buffer_text_view_with_text_field.cpp
+++ b/apps/shared/buffer_text_view_with_text_field.cpp
@@ -40,7 +40,7 @@ void BufferTextViewWithTextField::drawRect(KDContext * ctx, KDRect rect) const {
 }
 
 void BufferTextViewWithTextField::didBecomeFirstResponder() {
-  app()->setFirstResponder(&m_textField);
+  Container::activeApp()->setFirstResponder(&m_textField);
   m_textField.setEditing(true, false);
   markRectAsDirty(bounds());
 }

--- a/apps/shared/editable_cell_table_view_controller.cpp
+++ b/apps/shared/editable_cell_table_view_controller.cpp
@@ -1,7 +1,6 @@
 #include "editable_cell_table_view_controller.h"
 #include "../shared/poincare_helpers.h"
 #include "../constant.h"
-#include "text_field_delegate_app.h"
 #include <assert.h>
 #include <cmath>
 
@@ -110,10 +109,6 @@ void EditableCellTableViewController::viewWillAppear() {
     selColumn = selColumn >= numberOfColumns() ? numberOfColumns() - 1 : selColumn;
     selectCellAtLocation(selColumn, selRow);
   }
-}
-
-TextFieldDelegateApp * EditableCellTableViewController::textFieldDelegateApp() {
-  return (TextFieldDelegateApp *)app();
 }
 
 }

--- a/apps/shared/editable_cell_table_view_controller.cpp
+++ b/apps/shared/editable_cell_table_view_controller.cpp
@@ -1,5 +1,4 @@
 #include "editable_cell_table_view_controller.h"
-#include "../apps_container.h"
 #include "../shared/poincare_helpers.h"
 #include "../constant.h"
 #include "text_field_delegate_app.h"

--- a/apps/shared/editable_cell_table_view_controller.cpp
+++ b/apps/shared/editable_cell_table_view_controller.cpp
@@ -27,7 +27,7 @@ bool EditableCellTableViewController::textFieldDidFinishEditing(TextField * text
     return false;
   }
   if (!setDataAtLocation(floatBody, selectedColumn(), selectedRow())) {
-    app()->displayWarning(I18n::Message::ForbiddenValue);
+    Container::activeApp()->displayWarning(I18n::Message::ForbiddenValue);
     return false;
   }
   /* At this point, a new cell is selected depending on the event, before the

--- a/apps/shared/editable_cell_table_view_controller.h
+++ b/apps/shared/editable_cell_table_view_controller.h
@@ -23,7 +23,6 @@ public:
 protected:
   static constexpr KDCoordinate k_cellHeight = 20;
 private:
-  TextFieldDelegateApp * textFieldDelegateApp() override;
   virtual bool cellAtLocationIsEditable(int columnIndex, int rowIndex) = 0;
   virtual bool setDataAtLocation(double floatBody, int columnIndex, int rowIndex) = 0;
   virtual double dataAtLocation(int columnIndex, int rowIndex) = 0;

--- a/apps/shared/expression_field_delegate_app.cpp
+++ b/apps/shared/expression_field_delegate_app.cpp
@@ -1,7 +1,7 @@
 #include "expression_field_delegate_app.h"
 #include <escher.h>
 #include <apps/i18n.h>
-#include "../apps_container.h"
+#include <poincare/expression.h>
 
 using namespace Poincare;
 

--- a/apps/shared/expression_field_delegate_app.cpp
+++ b/apps/shared/expression_field_delegate_app.cpp
@@ -7,8 +7,8 @@ using namespace Poincare;
 
 namespace Shared {
 
-ExpressionFieldDelegateApp::ExpressionFieldDelegateApp(Container * container, Snapshot * snapshot, ViewController * rootViewController) :
-  TextFieldDelegateApp(container, snapshot, rootViewController),
+ExpressionFieldDelegateApp::ExpressionFieldDelegateApp(Snapshot * snapshot, ViewController * rootViewController) :
+  TextFieldDelegateApp(snapshot, rootViewController),
   LayoutFieldDelegate()
 {
 }

--- a/apps/shared/expression_field_delegate_app.cpp
+++ b/apps/shared/expression_field_delegate_app.cpp
@@ -20,7 +20,7 @@ bool ExpressionFieldDelegateApp::layoutFieldShouldFinishEditing(LayoutField * la
 bool ExpressionFieldDelegateApp::layoutFieldDidReceiveEvent(LayoutField * layoutField, Ion::Events::Event event) {
   if (layoutField->isEditing() && layoutField->shouldFinishEditing(event)) {
     if (!layoutField->hasText()) {
-      layoutField->app()->displayWarning(I18n::Message::SyntaxError);
+      displayWarning(I18n::Message::SyntaxError);
       return true;
     }
     /* An acceptable layout has to be parsable and serialized in a fixed-size

--- a/apps/shared/expression_field_delegate_app.h
+++ b/apps/shared/expression_field_delegate_app.h
@@ -12,7 +12,7 @@ public:
   bool layoutFieldShouldFinishEditing(LayoutField * layoutField, Ion::Events::Event event) override;
   virtual bool layoutFieldDidReceiveEvent(LayoutField * layoutField, Ion::Events::Event event) override;
 protected:
-  ExpressionFieldDelegateApp(Container * container, Snapshot * snapshot, ViewController * rootViewController);
+  ExpressionFieldDelegateApp(Snapshot * snapshot, ViewController * rootViewController);
 };
 
 }

--- a/apps/shared/float_parameter_controller.cpp
+++ b/apps/shared/float_parameter_controller.cpp
@@ -1,6 +1,5 @@
 #include "float_parameter_controller.h"
 #include "../constant.h"
-#include "../apps_container.h"
 #include "../shared/poincare_helpers.h"
 #include "text_field_delegate_app.h"
 #include <assert.h>

--- a/apps/shared/float_parameter_controller.cpp
+++ b/apps/shared/float_parameter_controller.cpp
@@ -27,7 +27,7 @@ void FloatParameterController::didBecomeFirstResponder() {
     selColumn = selColumn >= numberOfColumns() ? numberOfColumns() - 1 : selColumn;
     selectCellAtLocation(selColumn, selRow);
   }
-  app()->setFirstResponder(&m_selectableTableView);
+  Container::activeApp()->setFirstResponder(&m_selectableTableView);
 }
 
 void FloatParameterController::viewWillAppear() {

--- a/apps/shared/float_parameter_controller.cpp
+++ b/apps/shared/float_parameter_controller.cpp
@@ -1,7 +1,6 @@
 #include "float_parameter_controller.h"
 #include "../constant.h"
 #include "../shared/poincare_helpers.h"
-#include "text_field_delegate_app.h"
 #include <assert.h>
 #include <cmath>
 
@@ -136,10 +135,6 @@ bool FloatParameterController::textFieldDidFinishEditing(TextField * textField, 
     m_selectableTableView.handleEvent(event);
   }
   return true;
-}
-
-TextFieldDelegateApp * FloatParameterController::textFieldDelegateApp() {
-  return (TextFieldDelegateApp *)app();
 }
 
 int FloatParameterController::activeCell() {

--- a/apps/shared/float_parameter_controller.h
+++ b/apps/shared/float_parameter_controller.h
@@ -39,7 +39,6 @@ private:
   virtual void buttonAction();
   virtual int reusableParameterCellCount(int type) = 0;
   virtual HighlightCell * reusableParameterCell(int index, int type) = 0;
-  TextFieldDelegateApp * textFieldDelegateApp() override;
   virtual bool setParameterAtIndex(int parameterIndex, double f) = 0;
 };
 

--- a/apps/shared/function_app.cpp
+++ b/apps/shared/function_app.cpp
@@ -1,5 +1,4 @@
 #include "function_app.h"
-#include "../apps_container.h"
 
 using namespace Poincare;
 

--- a/apps/shared/function_app.h
+++ b/apps/shared/function_app.h
@@ -32,7 +32,7 @@ public:
     Poincare::Preferences::AngleUnit m_angleUnitVersion;
   };
   static FunctionApp * app() {
-    return static_cast<FunctionApp *>(::app());
+    return static_cast<FunctionApp *>(Container::activeApp());
   }
   virtual ~FunctionApp() = default;
   virtual FunctionStore * functionStore() { return static_cast<FunctionApp::Snapshot *>(snapshot())->functionStore(); }

--- a/apps/shared/function_app.h
+++ b/apps/shared/function_app.h
@@ -6,8 +6,6 @@
 #include "curve_view_cursor.h"
 #include "interval.h"
 
-class AppsContainer;
-
 namespace Shared {
 
 class FunctionApp : public ExpressionFieldDelegateApp {

--- a/apps/shared/function_app.h
+++ b/apps/shared/function_app.h
@@ -30,7 +30,10 @@ public:
     uint32_t m_modelVersion;
     uint32_t m_rangeVersion;
     Poincare::Preferences::AngleUnit m_angleUnitVersion;
- };
+  };
+  static FunctionApp * app() {
+    return static_cast<FunctionApp *>(::app());
+  }
   virtual ~FunctionApp() = default;
   virtual FunctionStore * functionStore() { return static_cast<FunctionApp::Snapshot *>(snapshot())->functionStore(); }
   virtual InputViewController * inputViewController() = 0;

--- a/apps/shared/function_app.h
+++ b/apps/shared/function_app.h
@@ -39,8 +39,8 @@ public:
   void willBecomeInactive() override;
 
 protected:
-  FunctionApp(Container * container, Snapshot * snapshot, ViewController * rootViewController) :
-    ExpressionFieldDelegateApp(container, snapshot, rootViewController)
+  FunctionApp(Snapshot * snapshot, ViewController * rootViewController) :
+    ExpressionFieldDelegateApp(snapshot, rootViewController)
   {}
   // TextFieldDelegateApp
   bool isAcceptableExpression(const Poincare::Expression expression) override;

--- a/apps/shared/function_curve_parameter_controller.cpp
+++ b/apps/shared/function_curve_parameter_controller.cpp
@@ -19,7 +19,7 @@ void FunctionCurveParameterController::didBecomeFirstResponder() {
   if (selectedRow() < 0) {
     selectCellAtLocation(0, 0);
   }
-  app()->setFirstResponder(&m_selectableTableView);
+  Container::activeApp()->setFirstResponder(&m_selectableTableView);
 }
 
 bool FunctionCurveParameterController::handleGotoSelection() {

--- a/apps/shared/function_go_to_parameter_controller.cpp
+++ b/apps/shared/function_go_to_parameter_controller.cpp
@@ -22,7 +22,7 @@ double FunctionGoToParameterController::parameterAtIndex(int index) {
 
 bool FunctionGoToParameterController::setParameterAtIndex(int parameterIndex, double f) {
   assert(parameterIndex == 0);
-  FunctionApp * myApp = (FunctionApp *)app();
+  FunctionApp * myApp = FunctionApp::app();
   ExpiringPointer<Function> function = myApp->functionStore()->modelForRecord(m_record);
   float y = function->evaluateAtAbscissa(f, myApp->localContext());
   m_cursor->moveTo(f, y);

--- a/apps/shared/function_graph_controller.cpp
+++ b/apps/shared/function_graph_controller.cpp
@@ -31,7 +31,7 @@ void FunctionGraphController::didBecomeFirstResponder() {
   if (curveView()->isMainViewSelected()) {
     bannerView()->abscissaValue()->setParentResponder(this);
     bannerView()->abscissaValue()->setDelegates(textFieldDelegateApp(), this);
-    app()->setFirstResponder(bannerView()->abscissaValue());
+    Container::activeApp()->setFirstResponder(bannerView()->abscissaValue());
   } else {
     InteractiveCurveViewController::didBecomeFirstResponder();
   }

--- a/apps/shared/function_graph_controller.cpp
+++ b/apps/shared/function_graph_controller.cpp
@@ -111,8 +111,7 @@ double FunctionGraphController::defaultCursorAbscissa() {
 }
 
 FunctionStore * FunctionGraphController::functionStore() const {
-  FunctionApp * myApp = static_cast<FunctionApp *>(app());
-  return myApp->functionStore();
+  return FunctionApp::app()->functionStore();
 }
 
 void FunctionGraphController::initCursorParameters() {

--- a/apps/shared/function_graph_controller.cpp
+++ b/apps/shared/function_graph_controller.cpp
@@ -42,8 +42,7 @@ void FunctionGraphController::viewWillAppear() {
   functionGraphView()->setAreaHighlight(NAN,NAN);
 
   if (functionGraphView()->context() == nullptr) {
-    FunctionApp * myApp = static_cast<FunctionApp *>(app());
-    functionGraphView()->setContext(myApp->localContext());
+    functionGraphView()->setContext(textFieldDelegateApp()->localContext());
   }
   Preferences::AngleUnit newAngleUnitVersion = Preferences::sharedPreferences()->angleUnit();
   if (*m_angleUnitVersion != newAngleUnitVersion) {
@@ -74,7 +73,7 @@ void FunctionGraphController::reloadBannerView() {
 }
 
 InteractiveCurveViewRangeDelegate::Range FunctionGraphController::computeYRange(InteractiveCurveViewRange * interactiveCurveViewRange) {
-  FunctionApp * myApp = static_cast<FunctionApp *>(app());
+  Poincare::Context * context = textFieldDelegateApp()->localContext();
   float min = FLT_MAX;
   float max = -FLT_MAX;
   float xMin = interactiveCurveViewRange->xMin();
@@ -87,13 +86,12 @@ InteractiveCurveViewRangeDelegate::Range FunctionGraphController::computeYRange(
   }
   for (int i=0; i<functionStore()->numberOfActiveFunctions(); i++) {
     ExpiringPointer<Function> f = functionStore()->modelForRecord(functionStore()->activeRecordAtIndex(i));
-    float y = 0.0f;
     float res = curveView()->resolution();
     /* Scan x-range from the middle to the extrema in order to get balanced
      * y-range for even functions (y = 1/x). */
     for (int j = -res/2; j <= res/2; j++) {
       float x = (xMin+xMax)/2.0+(xMax-xMin)*j/res;
-      y = f->evaluateAtAbscissa(x, myApp->localContext());
+      float y = f->evaluateAtAbscissa(x, context);
       if (!std::isnan(y) && !std::isinf(y)) {
         min = min < y ? min : y;
         max = max > y ? max : y;
@@ -116,12 +114,12 @@ FunctionStore * FunctionGraphController::functionStore() const {
 
 void FunctionGraphController::initCursorParameters() {
   double x = defaultCursorAbscissa();
-  FunctionApp * myApp = static_cast<FunctionApp *>(app());
+  Poincare::Context * context = textFieldDelegateApp()->localContext();
   int functionIndex = 0;
   double y = 0;
   do {
     ExpiringPointer<Function> firstFunction = functionStore()->modelForRecord(functionStore()->activeRecordAtIndex(functionIndex++));
-    y = firstFunction->evaluateAtAbscissa(x, myApp->localContext());
+    y = firstFunction->evaluateAtAbscissa(x, context);
   } while ((std::isnan(y) || std::isinf(y)) && functionIndex < functionStore()->numberOfActiveFunctions());
   m_cursor->moveTo(x, y);
   functionIndex = (std::isnan(y) || std::isinf(y)) ? 0 : functionIndex - 1;
@@ -133,8 +131,7 @@ void FunctionGraphController::initCursorParameters() {
 
 bool FunctionGraphController::moveCursorVertically(int direction) {
   int currentActiveFunctionIndex = indexFunctionSelectedByCursor();
-  Poincare::Context * context = static_cast<FunctionApp *>(app())->localContext();
-
+  Poincare::Context * context = textFieldDelegateApp()->localContext();
   int nextActiveFunctionIndex = InteractiveCurveViewController::closestCurveIndexVertically(direction > 0, currentActiveFunctionIndex, context);
   if (nextActiveFunctionIndex < 0) {
     return false;

--- a/apps/shared/function_list_controller.cpp
+++ b/apps/shared/function_list_controller.cpp
@@ -154,7 +154,7 @@ void FunctionListController::didBecomeFirstResponder() {
     selectCellAtLocation(selectedColumn(), numberOfRows()-1);
   }
   footer()->setSelectedButton(-1);
-  app()->setFirstResponder(selectableTableView());
+  Container::activeApp()->setFirstResponder(selectableTableView());
 }
 
 bool FunctionListController::handleEvent(Ion::Events::Event event) {
@@ -162,12 +162,12 @@ bool FunctionListController::handleEvent(Ion::Events::Event event) {
     if (selectedRow() == -1) {
       footer()->setSelectedButton(-1);
       selectableTableView()->selectCellAtLocation(1, numberOfRows()-1);
-      app()->setFirstResponder(selectableTableView());
+      Container::activeApp()->setFirstResponder(selectableTableView());
       return true;
     }
     selectableTableView()->deselectTable();
     assert(selectedRow() == -1);
-    app()->setFirstResponder(tabController());
+    Container::activeApp()->setFirstResponder(tabController());
     return true;
   }
   if (event == Ion::Events::Down) {

--- a/apps/shared/function_list_controller.cpp
+++ b/apps/shared/function_list_controller.cpp
@@ -249,13 +249,11 @@ TabViewController * FunctionListController::tabController() const {
 }
 
 FunctionStore * FunctionListController::modelStore() {
-  FunctionApp * myApp = static_cast<FunctionApp *>(app());
-  return myApp->functionStore();
+  return FunctionApp::app()->functionStore();
 }
 
 InputViewController * FunctionListController::inputController() {
-  FunctionApp * myApp = static_cast<FunctionApp *>(app());
-  return myApp->inputViewController();
+  return FunctionApp::app()->inputViewController();
 }
 
 KDCoordinate FunctionListController::maxFunctionNameWidth() {

--- a/apps/shared/go_to_parameter_controller.cpp
+++ b/apps/shared/go_to_parameter_controller.cpp
@@ -1,5 +1,4 @@
 #include "go_to_parameter_controller.h"
-#include "text_field_delegate_app.h"
 #include <assert.h>
 
 namespace Shared {

--- a/apps/shared/initialisation_parameter_controller.cpp
+++ b/apps/shared/initialisation_parameter_controller.cpp
@@ -29,7 +29,7 @@ if (event == Ion::Events::OK || event == Ion::Events::EXE) {
 
 void InitialisationParameterController::didBecomeFirstResponder() {
   m_selectableTableView.selectCellAtLocation(0, 0);
-  app()->setFirstResponder(&m_selectableTableView);
+  Container::activeApp()->setFirstResponder(&m_selectableTableView);
 }
 
 int InitialisationParameterController::numberOfRows() {

--- a/apps/shared/input_event_handler_delegate.h
+++ b/apps/shared/input_event_handler_delegate.h
@@ -10,7 +10,7 @@ public:
   Toolbox * toolboxForInputEventHandler(InputEventHandler * textInput) override { return inputEventHandlerDelegateApp()->toolboxForInputEventHandler(textInput); }
   NestedMenuController * variableBoxForInputEventHandler(InputEventHandler * textInput) override { return inputEventHandlerDelegateApp()->variableBoxForInputEventHandler(textInput); }
 private:
-  InputEventHandlerDelegateApp * inputEventHandlerDelegateApp() {
+  InputEventHandlerDelegateApp * inputEventHandlerDelegateApp() const {
     return static_cast<InputEventHandlerDelegateApp *>(::app());
   }
 };

--- a/apps/shared/input_event_handler_delegate.h
+++ b/apps/shared/input_event_handler_delegate.h
@@ -1,7 +1,6 @@
 #ifndef SHARED_INPUT_EVENT_HANDLER_DELEGATE_H
 #define SHARED_INPUT_EVENT_HANDLER_DELEGATE_H
 
-#include <escher.h>
 #include "input_event_handler_delegate_app.h"
 
 namespace Shared {
@@ -11,7 +10,9 @@ public:
   Toolbox * toolboxForInputEventHandler(InputEventHandler * textInput) override { return inputEventHandlerDelegateApp()->toolboxForInputEventHandler(textInput); }
   NestedMenuController * variableBoxForInputEventHandler(InputEventHandler * textInput) override { return inputEventHandlerDelegateApp()->variableBoxForInputEventHandler(textInput); }
 private:
-  virtual InputEventHandlerDelegateApp * inputEventHandlerDelegateApp() = 0;
+  InputEventHandlerDelegateApp * inputEventHandlerDelegateApp() {
+    return static_cast<InputEventHandlerDelegateApp *>(::app());
+  }
 };
 
 }

--- a/apps/shared/input_event_handler_delegate.h
+++ b/apps/shared/input_event_handler_delegate.h
@@ -11,7 +11,7 @@ public:
   NestedMenuController * variableBoxForInputEventHandler(InputEventHandler * textInput) override { return inputEventHandlerDelegateApp()->variableBoxForInputEventHandler(textInput); }
 private:
   InputEventHandlerDelegateApp * inputEventHandlerDelegateApp() const {
-    return static_cast<InputEventHandlerDelegateApp *>(::app());
+    return static_cast<InputEventHandlerDelegateApp *>(Container::activeApp());
   }
 };
 

--- a/apps/shared/input_event_handler_delegate_app.cpp
+++ b/apps/shared/input_event_handler_delegate_app.cpp
@@ -14,7 +14,7 @@ InputEventHandlerDelegateApp::InputEventHandlerDelegateApp(Container * container
 }
 
 AppsContainer * InputEventHandlerDelegateApp::container() {
-  return (AppsContainer *)(app()->container());
+  return static_cast<AppsContainer *>(const_cast<Container *>(::App::container()));
 }
 
 Toolbox * InputEventHandlerDelegateApp::toolboxForInputEventHandler(InputEventHandler * textInput) {

--- a/apps/shared/input_event_handler_delegate_app.cpp
+++ b/apps/shared/input_event_handler_delegate_app.cpp
@@ -13,18 +13,14 @@ InputEventHandlerDelegateApp::InputEventHandlerDelegateApp(Container * container
 {
 }
 
-AppsContainer * InputEventHandlerDelegateApp::container() {
-  return static_cast<AppsContainer *>(const_cast<Container *>(::App::container()));
-}
-
 Toolbox * InputEventHandlerDelegateApp::toolboxForInputEventHandler(InputEventHandler * textInput) {
-  Toolbox * toolbox = container()->mathToolbox();
+  Toolbox * toolbox = AppsContainer::sharedAppsContainer()->mathToolbox();
   toolbox->setSender(textInput);
   return toolbox;
 }
 
 NestedMenuController * InputEventHandlerDelegateApp::variableBoxForInputEventHandler(InputEventHandler * textInput) {
-  VariableBoxController * varBox = container()->variableBoxController();
+  VariableBoxController * varBox = AppsContainer::sharedAppsContainer()->variableBoxController();
   varBox->setSender(textInput);
   varBox->lockDeleteEvent(VariableBoxController::Page::RootMenu);
   return varBox;

--- a/apps/shared/input_event_handler_delegate_app.cpp
+++ b/apps/shared/input_event_handler_delegate_app.cpp
@@ -7,8 +7,8 @@ using namespace Poincare;
 
 namespace Shared {
 
-InputEventHandlerDelegateApp::InputEventHandlerDelegateApp(Container * container, Snapshot * snapshot, ViewController * rootViewController) :
-  ::App(container, snapshot, rootViewController, I18n::Message::Warning),
+InputEventHandlerDelegateApp::InputEventHandlerDelegateApp(Snapshot * snapshot, ViewController * rootViewController) :
+  ::App(snapshot, rootViewController, I18n::Message::Warning),
   InputEventHandlerDelegate()
 {
 }

--- a/apps/shared/input_event_handler_delegate_app.h
+++ b/apps/shared/input_event_handler_delegate_app.h
@@ -3,8 +3,6 @@
 
 #include <escher.h>
 
-class AppsContainer;
-
 namespace Shared {
 
 class InputEventHandlerDelegateApp : public ::App, public InputEventHandlerDelegate {

--- a/apps/shared/input_event_handler_delegate_app.h
+++ b/apps/shared/input_event_handler_delegate_app.h
@@ -13,7 +13,7 @@ public:
   Toolbox * toolboxForInputEventHandler(InputEventHandler * textInput) override;
   NestedMenuController * variableBoxForInputEventHandler(InputEventHandler * textInput) override;
 protected:
-  InputEventHandlerDelegateApp(Container * container, Snapshot * snapshot, ViewController * rootViewController);
+  InputEventHandlerDelegateApp(Snapshot * snapshot, ViewController * rootViewController);
 };
 
 }

--- a/apps/shared/input_event_handler_delegate_app.h
+++ b/apps/shared/input_event_handler_delegate_app.h
@@ -1,7 +1,8 @@
 #ifndef SHARED_INPUT_EVENT_HANDLER_DELEGATE_APP_H
 #define SHARED_INPUT_EVENT_HANDLER_DELEGATE_APP_H
 
-#include <escher.h>
+#include <escher/app.h>
+#include <escher/input_event_handler_delegate.h>
 
 namespace Shared {
 

--- a/apps/shared/input_event_handler_delegate_app.h
+++ b/apps/shared/input_event_handler_delegate_app.h
@@ -14,7 +14,6 @@ public:
   NestedMenuController * variableBoxForInputEventHandler(InputEventHandler * textInput) override;
 protected:
   InputEventHandlerDelegateApp(Container * container, Snapshot * snapshot, ViewController * rootViewController);
-  AppsContainer * container();
 };
 
 }

--- a/apps/shared/input_event_handler_delegate_app.h
+++ b/apps/shared/input_event_handler_delegate_app.h
@@ -10,11 +10,11 @@ namespace Shared {
 class InputEventHandlerDelegateApp : public ::App, public InputEventHandlerDelegate {
 public:
   virtual ~InputEventHandlerDelegateApp() = default;
-  AppsContainer * container();
   Toolbox * toolboxForInputEventHandler(InputEventHandler * textInput) override;
   NestedMenuController * variableBoxForInputEventHandler(InputEventHandler * textInput) override;
 protected:
   InputEventHandlerDelegateApp(Container * container, Snapshot * snapshot, ViewController * rootViewController);
+  AppsContainer * container();
 };
 
 }

--- a/apps/shared/interactive_curve_view_controller.cpp
+++ b/apps/shared/interactive_curve_view_controller.cpp
@@ -78,14 +78,14 @@ bool InteractiveCurveViewController::handleEvent(Ion::Events::Event event) {
     if (event == Ion::Events::Down) {
       header()->setSelectedButton(-1);
       curveView()->selectMainView(true);
-      app()->setFirstResponder(this);
+      Container::activeApp()->setFirstResponder(this);
       reloadBannerView();
       curveView()->reload();
       return true;
     }
     if (event == Ion::Events::Up) {
       header()->setSelectedButton(-1);
-      app()->setFirstResponder(tabController());
+      Container::activeApp()->setFirstResponder(tabController());
       return true;
     }
     return false;

--- a/apps/shared/interactive_curve_view_controller.cpp
+++ b/apps/shared/interactive_curve_view_controller.cpp
@@ -1,5 +1,4 @@
 #include "interactive_curve_view_controller.h"
-#include "text_field_delegate_app.h"
 #include <cmath>
 #include <float.h>
 #include <assert.h>

--- a/apps/shared/interval_parameter_controller.cpp
+++ b/apps/shared/interval_parameter_controller.cpp
@@ -44,14 +44,14 @@ double IntervalParameterController::parameterAtIndex(int index) {
 
 bool IntervalParameterController::setParameterAtIndex(int parameterIndex, double f) {
   if (f <= 0.0f && parameterIndex == 2) {
-    app()->displayWarning(I18n::Message::ForbiddenValue);
+    Container::activeApp()->displayWarning(I18n::Message::ForbiddenValue);
     return false;
   }
   double start = parameterIndex == 0 ? f : m_interval->start();
   double end = parameterIndex == 1 ? f : m_interval->end();
   if (start > end) {
     if (parameterIndex == 1) {
-      app()->displayWarning(I18n::Message::ForbiddenValue);
+      Container::activeApp()->displayWarning(I18n::Message::ForbiddenValue);
       return false;
     }
     double g = f+1.0;

--- a/apps/shared/language_controller.cpp
+++ b/apps/shared/language_controller.cpp
@@ -31,7 +31,7 @@ View * LanguageController::view() {
 }
 
 void LanguageController::didBecomeFirstResponder() {
-  app()->setFirstResponder(&m_selectableTableView);
+  Container::activeApp()->setFirstResponder(&m_selectableTableView);
 }
 
 void LanguageController::viewWillAppear() {

--- a/apps/shared/language_controller.cpp
+++ b/apps/shared/language_controller.cpp
@@ -43,8 +43,7 @@ bool LanguageController::handleEvent(Ion::Events::Event event) {
     GlobalPreferences::sharedGlobalPreferences()->setLanguage((I18n::Language)(selectedRow()+1));
     /* We need to reload the whole title bar in order to translate both the
      * "Settings" title and the degree preference. */
-    AppsContainer * myContainer = (AppsContainer * )app()->container();
-    myContainer->reloadTitleBarView();
+    AppsContainer::sharedAppsContainer()->reloadTitleBarView();
     return true;
   }
   return false;

--- a/apps/shared/layout_field_delegate.h
+++ b/apps/shared/layout_field_delegate.h
@@ -1,7 +1,6 @@
 #ifndef SHARED_LAYOUT_FIELD_DELEGATE_H
 #define SHARED_LAYOUT_FIELD_DELEGATE_H
 
-#include <escher/layout_field_delegate.h>
 #include "expression_field_delegate_app.h"
 
 namespace Shared {
@@ -14,7 +13,9 @@ public:
   bool layoutFieldDidAbortEditing(LayoutField * layoutField) override;
   void layoutFieldDidChangeSize(LayoutField * layoutField) override;
 private:
-  virtual ExpressionFieldDelegateApp * expressionFieldDelegateApp() = 0;
+  ExpressionFieldDelegateApp * expressionFieldDelegateApp() {
+    return static_cast<ExpressionFieldDelegateApp *>(::app());
+  }
 };
 
 }

--- a/apps/shared/layout_field_delegate.h
+++ b/apps/shared/layout_field_delegate.h
@@ -13,7 +13,7 @@ public:
   bool layoutFieldDidAbortEditing(LayoutField * layoutField) override;
   void layoutFieldDidChangeSize(LayoutField * layoutField) override;
 private:
-  ExpressionFieldDelegateApp * expressionFieldDelegateApp() {
+  ExpressionFieldDelegateApp * expressionFieldDelegateApp() const {
     return static_cast<ExpressionFieldDelegateApp *>(::app());
   }
 };

--- a/apps/shared/layout_field_delegate.h
+++ b/apps/shared/layout_field_delegate.h
@@ -12,7 +12,7 @@ public:
   bool layoutFieldDidFinishEditing(LayoutField * layoutField, Poincare::Layout layoutR, Ion::Events::Event event) override;
   bool layoutFieldDidAbortEditing(LayoutField * layoutField) override;
   void layoutFieldDidChangeSize(LayoutField * layoutField) override;
-private:
+protected:
   ExpressionFieldDelegateApp * expressionFieldDelegateApp() const {
     return static_cast<ExpressionFieldDelegateApp *>(::app());
   }

--- a/apps/shared/layout_field_delegate.h
+++ b/apps/shared/layout_field_delegate.h
@@ -14,7 +14,7 @@ public:
   void layoutFieldDidChangeSize(LayoutField * layoutField) override;
 protected:
   ExpressionFieldDelegateApp * expressionFieldDelegateApp() const {
-    return static_cast<ExpressionFieldDelegateApp *>(::app());
+    return static_cast<ExpressionFieldDelegateApp *>(Container::activeApp());
   }
 };
 

--- a/apps/shared/list_parameter_controller.cpp
+++ b/apps/shared/list_parameter_controller.cpp
@@ -21,7 +21,7 @@ const char * ListParameterController::title() {
 }
 
 void ListParameterController::didBecomeFirstResponder() {
-  app()->setFirstResponder(&m_selectableTableView);
+  Container::activeApp()->setFirstResponder(&m_selectableTableView);
 }
 
 void ListParameterController::viewWillAppear() {

--- a/apps/shared/list_parameter_controller.cpp
+++ b/apps/shared/list_parameter_controller.cpp
@@ -112,8 +112,7 @@ ExpiringPointer<Function> ListParameterController::function() {
 }
 
 FunctionStore * ListParameterController::functionStore() {
-  FunctionApp * a = static_cast<FunctionApp *>(app());
-  return a->functionStore();
+  return FunctionApp::app()->functionStore();
 }
 
 

--- a/apps/shared/message_controller.cpp
+++ b/apps/shared/message_controller.cpp
@@ -8,7 +8,7 @@ MessageController::MessageController(I18n::Message * messages, KDColor * colors,
 
 bool MessageController::handleEvent(Ion::Events::Event event) {
   if (event != Ion::Events::Back && event != Ion::Events::OnOff && event != Ion::Events::Home) {
-    app()->dismissModalViewController();
+    Container::activeApp()->dismissModalViewController();
     return true;
   }
   return false;

--- a/apps/shared/message_controller.cpp
+++ b/apps/shared/message_controller.cpp
@@ -1,5 +1,4 @@
 #include "message_controller.h"
-#include "../apps_container.h"
 
 MessageController::MessageController(I18n::Message * messages, KDColor * colors, uint8_t numberOfMessages) :
   ViewController(nullptr),

--- a/apps/shared/parameter_text_field_delegate.cpp
+++ b/apps/shared/parameter_text_field_delegate.cpp
@@ -1,10 +1,9 @@
 #include "parameter_text_field_delegate.h"
-
-using namespace Poincare;
+#include <escher/text_field.h>
 
 namespace Shared {
 
-bool ParameterTextFieldDelegate::textFieldDidReceiveEvent(::TextField * textField, Ion::Events::Event event) {
+bool ParameterTextFieldDelegate::textFieldDidReceiveEvent(TextField * textField, Ion::Events::Event event) {
   if (event == Ion::Events::Backspace && !textField->isEditing()) {
     textField->setEditing(true);
     return true;

--- a/apps/shared/parameter_text_field_delegate.h
+++ b/apps/shared/parameter_text_field_delegate.h
@@ -1,9 +1,7 @@
 #ifndef SHARED_PARAMETER_TEXT_FIELD_DELEGATE_H
 #define SHARED_PARAMETER_TEXT_FIELD_DELEGATE_H
 
-#include <escher.h>
 #include "text_field_delegate.h"
-#include "text_field_delegate_app.h"
 
 namespace Shared {
 

--- a/apps/shared/range_parameter_controller.cpp
+++ b/apps/shared/range_parameter_controller.cpp
@@ -1,6 +1,5 @@
 #include "range_parameter_controller.h"
 #include "text_field_delegate_app.h"
-#include "../apps_container.h"
 #include <assert.h>
 
 using namespace Poincare;
@@ -124,4 +123,3 @@ int RangeParameterController::reusableParameterCellCount(int type) {
 }
 
 }
-

--- a/apps/shared/range_parameter_controller.cpp
+++ b/apps/shared/range_parameter_controller.cpp
@@ -1,5 +1,4 @@
 #include "range_parameter_controller.h"
-#include "text_field_delegate_app.h"
 #include <assert.h>
 
 using namespace Poincare;

--- a/apps/shared/scrollable_exact_approximate_expressions_cell.cpp
+++ b/apps/shared/scrollable_exact_approximate_expressions_cell.cpp
@@ -32,7 +32,7 @@ void ScrollableExactApproximateExpressionsCell::reloadScroll() {
 
 void ScrollableExactApproximateExpressionsCell::didBecomeFirstResponder() {
   m_view.setSelectedSubviewPosition(ScrollableExactApproximateExpressionsView::SubviewPosition::Left);
-  app()->setFirstResponder(&m_view);
+  Container::activeApp()->setFirstResponder(&m_view);
 }
 
 int ScrollableExactApproximateExpressionsCell::numberOfSubviews() const {

--- a/apps/shared/simple_interactive_curve_view_controller.h
+++ b/apps/shared/simple_interactive_curve_view_controller.h
@@ -2,7 +2,6 @@
 #define SHARED_SIMPLE_INTERACTIVE_CURVE_VIEW_CONTROLLER_H
 
 #include <escher/view_controller.h>
-#include <escher/app.h>
 #include "text_field_delegate.h"
 #include "interactive_curve_view_range.h"
 #include "curve_view_cursor.h"
@@ -21,9 +20,6 @@ public:
   bool textFieldDidAbortEditing(TextField * textField) override;
   bool textFieldDidReceiveEvent(TextField * textField, Ion::Events::Event event) override;
 protected:
-  TextFieldDelegateApp * textFieldDelegateApp() override {
-    return static_cast<TextFieldDelegateApp *>(app());
-  }
   constexpr static float k_cursorRightMarginRatio = 0.04f; // (cursorWidth/2)/graphViewWidth
   constexpr static float k_cursorLeftMarginRatio = 0.04f;  // (cursorWidth/2)/graphViewWidth
   virtual float cursorTopMarginRatio() { return 0.07f; }   // (cursorHeight/2)/graphViewHeight

--- a/apps/shared/simple_interactive_curve_view_controller.h
+++ b/apps/shared/simple_interactive_curve_view_controller.h
@@ -2,6 +2,7 @@
 #define SHARED_SIMPLE_INTERACTIVE_CURVE_VIEW_CONTROLLER_H
 
 #include <escher/view_controller.h>
+#include <escher/app.h>
 #include "text_field_delegate.h"
 #include "interactive_curve_view_range.h"
 #include "curve_view_cursor.h"

--- a/apps/shared/store_controller.cpp
+++ b/apps/shared/store_controller.cpp
@@ -258,7 +258,7 @@ bool StoreController::privateFillColumnWithFormula(Expression formula, Expressio
   constexpr static int k_maxSizeOfStoreSymbols = 3; // "V1", "N1", "X1", "Y1"
   char variables[Expression::k_maxNumberOfVariables][k_maxSizeOfStoreSymbols];
   variables[0][0] = 0;
-  AppsContainer * appsContainer = ((TextFieldDelegateApp *)app())->container();
+  AppsContainer * appsContainer = (AppsContainer *)app()->container();
   int nbOfVariables = formula.getVariables(*(appsContainer->globalContext()), isVariable, (char *)variables, k_maxSizeOfStoreSymbols);
   (void) nbOfVariables; // Remove compilation warning of nused variable
   assert(nbOfVariables >= 0);

--- a/apps/shared/store_controller.cpp
+++ b/apps/shared/store_controller.cpp
@@ -258,7 +258,7 @@ bool StoreController::privateFillColumnWithFormula(Expression formula, Expressio
   constexpr static int k_maxSizeOfStoreSymbols = 3; // "V1", "N1", "X1", "Y1"
   char variables[Expression::k_maxNumberOfVariables][k_maxSizeOfStoreSymbols];
   variables[0][0] = 0;
-  AppsContainer * appsContainer = (AppsContainer *)app()->container();
+  AppsContainer * appsContainer = AppsContainer::sharedAppsContainer();
   int nbOfVariables = formula.getVariables(*(appsContainer->globalContext()), isVariable, (char *)variables, k_maxSizeOfStoreSymbols);
   (void) nbOfVariables; // Remove compilation warning of nused variable
   assert(nbOfVariables >= 0);

--- a/apps/shared/store_controller.cpp
+++ b/apps/shared/store_controller.cpp
@@ -36,7 +36,7 @@ void StoreController::ContentView::displayFormulaInput(bool display) {
 }
 
 void StoreController::ContentView::didBecomeFirstResponder() {
-  app()->setFirstResponder(m_displayFormulaInputView ? static_cast<Responder *>(&m_formulaInputView) : static_cast<Responder *>(&m_dataView));
+  Container::activeApp()->setFirstResponder(m_displayFormulaInputView ? static_cast<Responder *>(&m_formulaInputView) : static_cast<Responder *>(&m_dataView));
 }
 
 View * StoreController::ContentView::subviewAtIndex(int index) {
@@ -86,12 +86,12 @@ bool StoreController::textFieldDidFinishEditing(TextField * textField, const cha
     // Handle formula input
     Expression expression = Expression::Parse(textField->text());
     if (expression.isUninitialized()) {
-      app()->displayWarning(I18n::Message::SyntaxError);
+      Container::activeApp()->displayWarning(I18n::Message::SyntaxError);
       return false;
     }
     m_contentView.displayFormulaInput(false);
     if (fillColumnWithFormula(expression)) {
-      app()->setFirstResponder(&m_contentView);
+      Container::activeApp()->setFirstResponder(&m_contentView);
     }
     return true;
   }
@@ -107,7 +107,7 @@ bool StoreController::textFieldDidFinishEditing(TextField * textField, const cha
 bool StoreController::textFieldDidAbortEditing(TextField * textField) {
   if (textField == m_contentView.formulaInputView()->textField()) {
     m_contentView.displayFormulaInput(false);
-    app()->setFirstResponder(&m_contentView);
+    Container::activeApp()->setFirstResponder(&m_contentView);
     return true;
   }
   return EditableCellTableViewController::textFieldDidAbortEditing(textField);
@@ -185,7 +185,7 @@ bool StoreController::handleEvent(Ion::Events::Event event) {
   if (event == Ion::Events::Up) {
     selectableTableView()->deselectTable();
     assert(selectedRow() == -1);
-    app()->setFirstResponder(tabController());
+    Container::activeApp()->setFirstResponder(tabController());
     return true;
   }
   assert(selectedColumn() >= 0 && selectedColumn() < numberOfColumns());
@@ -213,7 +213,7 @@ void StoreController::didBecomeFirstResponder() {
     selectCellAtLocation(0, 0);
   }
   EditableCellTableViewController::didBecomeFirstResponder();
-  app()->setFirstResponder(&m_contentView);
+  Container::activeApp()->setFirstResponder(&m_contentView);
 }
 
 Responder * StoreController::tabController() const {
@@ -289,7 +289,7 @@ bool StoreController::privateFillColumnWithFormula(Expression formula, Expressio
     // Compute the new value using the formula
     double evaluation = PoincareHelpers::ApproximateToScalar<double>(formula, *store);
     if (std::isnan(evaluation) || std::isinf(evaluation)) {
-      app()->displayWarning(I18n::Message::DataNotSuitable);
+      Container::activeApp()->displayWarning(I18n::Message::DataNotSuitable);
       return false;
     }
   }

--- a/apps/shared/store_parameter_controller.cpp
+++ b/apps/shared/store_parameter_controller.cpp
@@ -26,7 +26,7 @@ const char * StoreParameterController::title() {
 
 void StoreParameterController::didBecomeFirstResponder() {
   selectCellAtLocation(0, 0);
-  app()->setFirstResponder(&m_selectableTableView);
+  Container::activeApp()->setFirstResponder(&m_selectableTableView);
 }
 
 bool StoreParameterController::handleEvent(Ion::Events::Event event) {

--- a/apps/shared/sum_graph_controller.cpp
+++ b/apps/shared/sum_graph_controller.cpp
@@ -1,6 +1,5 @@
 #include "sum_graph_controller.h"
 #include "function_app.h"
-#include "../apps_container.h"
 #include <poincare/empty_layout.h>
 #include <poincare/condensed_sum_layout.h>
 #include <poincare/layout_helper.h>

--- a/apps/shared/sum_graph_controller.cpp
+++ b/apps/shared/sum_graph_controller.cpp
@@ -44,14 +44,14 @@ void SumGraphController::viewWillAppear() {
 
 
 void SumGraphController::didEnterResponderChain(Responder * previousFirstResponder) {
-  app()->setFirstResponder(m_legendView.textField());
+  Container::activeApp()->setFirstResponder(m_legendView.textField());
 }
 
 bool SumGraphController::handleEvent(Ion::Events::Event event) {
   if (event == Ion::Events::Back && m_step != Step::FirstParameter) {
     m_step = (Step)((int)m_step-1);
     if (m_step == Step::SecondParameter) {
-      app()->setFirstResponder(m_legendView.textField());
+      Container::activeApp()->setFirstResponder(m_legendView.textField());
       m_graphView->setAreaHighlightColor(false);
       m_graphView->setCursorView(&m_cursorView);
     }
@@ -95,7 +95,7 @@ bool SumGraphController::textFieldDidFinishEditing(TextField * textField, const 
     return false;
   }
   if ((m_step == Step::SecondParameter && floatBody < m_startSum) || !moveCursorHorizontallyToPosition(floatBody)) {
-    app()->displayWarning(I18n::Message::ForbiddenValue);
+    Container::activeApp()->displayWarning(I18n::Message::ForbiddenValue);
     return false;
   }
   return handleEnter();
@@ -125,7 +125,7 @@ bool SumGraphController::handleEnter() {
     } else {
       m_graphView->setAreaHighlightColor(true);
       m_graphView->setCursorView(nullptr);
-      app()->setFirstResponder(this);
+      Container::activeApp()->setFirstResponder(this);
     }
     m_step = (Step)((int)m_step+1);
     reloadBannerView();

--- a/apps/shared/sum_graph_controller.cpp
+++ b/apps/shared/sum_graph_controller.cpp
@@ -66,7 +66,7 @@ bool SumGraphController::handleEvent(Ion::Events::Event event) {
 }
 
 bool SumGraphController::moveCursorHorizontallyToPosition(double x) {
-  FunctionApp * myApp = static_cast<FunctionApp *>(app());
+  FunctionApp * myApp = FunctionApp::app();
   assert(!m_record.isNull());
   ExpiringPointer<Function> function = myApp->functionStore()->modelForRecord(m_record);
   double y = function->evaluateAtAbscissa(x, myApp->localContext());
@@ -138,7 +138,7 @@ void SumGraphController::reloadBannerView() {
   double result;
   Poincare::Layout functionLayout;
   if (m_step == Step::Result) {
-    FunctionApp * myApp = static_cast<FunctionApp *>(app());
+    FunctionApp * myApp = FunctionApp::app();
     assert(!m_record.isNull());
     ExpiringPointer<Function> function = myApp->functionStore()->modelForRecord(m_record);
     result = function->sumBetweenBounds(m_startSum, m_endSum, myApp->localContext());

--- a/apps/shared/tab_table_controller.cpp
+++ b/apps/shared/tab_table_controller.cpp
@@ -8,7 +8,7 @@ TabTableController::TabTableController(Responder * parentResponder) :
 }
 
 void TabTableController::didBecomeFirstResponder() {
-  app()->setFirstResponder(selectableTableView());
+  Container::activeApp()->setFirstResponder(selectableTableView());
 }
 
 void TabTableController::viewWillAppear() {

--- a/apps/shared/text_field_delegate.h
+++ b/apps/shared/text_field_delegate.h
@@ -1,7 +1,6 @@
 #ifndef SHARED_TEXT_FIELD_DELEGATE_H
 #define SHARED_TEXT_FIELD_DELEGATE_H
 
-#include <escher.h>
 #include "text_field_delegate_app.h"
 
 namespace Shared {
@@ -10,8 +9,10 @@ class TextFieldDelegate : public ::TextFieldDelegate {
 public:
   bool textFieldShouldFinishEditing(TextField * textField, Ion::Events::Event event) override;
   bool textFieldDidReceiveEvent(TextField * textField, Ion::Events::Event event) override;
-private:
-  virtual TextFieldDelegateApp * textFieldDelegateApp() = 0;
+protected:
+  TextFieldDelegateApp * textFieldDelegateApp() {
+    return static_cast<TextFieldDelegateApp *>(::app());
+  }
 };
 
 }

--- a/apps/shared/text_field_delegate.h
+++ b/apps/shared/text_field_delegate.h
@@ -11,7 +11,7 @@ public:
   bool textFieldDidReceiveEvent(TextField * textField, Ion::Events::Event event) override;
 protected:
   TextFieldDelegateApp * textFieldDelegateApp() const {
-    return static_cast<TextFieldDelegateApp *>(::app());
+    return static_cast<TextFieldDelegateApp *>(Container::activeApp());
   }
 };
 

--- a/apps/shared/text_field_delegate.h
+++ b/apps/shared/text_field_delegate.h
@@ -10,7 +10,7 @@ public:
   bool textFieldShouldFinishEditing(TextField * textField, Ion::Events::Event event) override;
   bool textFieldDidReceiveEvent(TextField * textField, Ion::Events::Event event) override;
 protected:
-  TextFieldDelegateApp * textFieldDelegateApp() {
+  TextFieldDelegateApp * textFieldDelegateApp() const {
     return static_cast<TextFieldDelegateApp *>(::app());
   }
 };

--- a/apps/shared/text_field_delegate_app.cpp
+++ b/apps/shared/text_field_delegate_app.cpp
@@ -25,7 +25,7 @@ bool TextFieldDelegateApp::textFieldShouldFinishEditing(TextField * textField, I
 bool TextFieldDelegateApp::textFieldDidReceiveEvent(TextField * textField, Ion::Events::Event event) {
   if (textField->isEditing() && textField->shouldFinishEditing(event)) {
     if (!isAcceptableText(textField->text())) {
-      textField->app()->displayWarning(I18n::Message::SyntaxError);
+      displayWarning(I18n::Message::SyntaxError);
       return true;
     }
   }

--- a/apps/shared/text_field_delegate_app.cpp
+++ b/apps/shared/text_field_delegate_app.cpp
@@ -11,7 +11,7 @@ using namespace Poincare;
 namespace Shared {
 
 Context * TextFieldDelegateApp::localContext() {
-  return container()->globalContext();
+  return AppsContainer::sharedAppsContainer()->globalContext();
 }
 
 char TextFieldDelegateApp::XNT() {

--- a/apps/shared/text_field_delegate_app.cpp
+++ b/apps/shared/text_field_delegate_app.cpp
@@ -25,7 +25,6 @@ bool TextFieldDelegateApp::textFieldShouldFinishEditing(TextField * textField, I
 bool TextFieldDelegateApp::textFieldDidReceiveEvent(TextField * textField, Ion::Events::Event event) {
   if (textField->isEditing() && textField->shouldFinishEditing(event)) {
     if (!isAcceptableText(textField->text())) {
-      displayWarning(I18n::Message::SyntaxError);
       return true;
     }
   }
@@ -38,7 +37,11 @@ bool TextFieldDelegateApp::textFieldDidReceiveEvent(TextField * textField, Ion::
 
 bool TextFieldDelegateApp::isAcceptableText(const char * text) {
   Expression exp = Expression::Parse(text);
-  return isAcceptableExpression(exp);
+  bool isAcceptable = isAcceptableExpression(exp);
+  if (!isAcceptable) {
+    displayWarning(I18n::Message::SyntaxError);
+  }
+  return isAcceptable;
 }
 
 bool TextFieldDelegateApp::hasUndefinedValue(const char * text, double & value) {

--- a/apps/shared/text_field_delegate_app.cpp
+++ b/apps/shared/text_field_delegate_app.cpp
@@ -52,8 +52,8 @@ bool TextFieldDelegateApp::hasUndefinedValue(const char * text, double & value) 
 
 /* Protected */
 
-TextFieldDelegateApp::TextFieldDelegateApp(Container * container, Snapshot * snapshot, ViewController * rootViewController) :
-  InputEventHandlerDelegateApp(container, snapshot, rootViewController),
+TextFieldDelegateApp::TextFieldDelegateApp(Snapshot * snapshot, ViewController * rootViewController) :
+  InputEventHandlerDelegateApp(snapshot, rootViewController),
   TextFieldDelegate()
 {
 }

--- a/apps/shared/text_field_delegate_app.h
+++ b/apps/shared/text_field_delegate_app.h
@@ -20,7 +20,7 @@ public:
   bool isAcceptableText(const char * text);
   bool hasUndefinedValue(const char * text, double & value);
 protected:
-  TextFieldDelegateApp(Container * container, Snapshot * snapshot, ViewController * rootViewController);
+  TextFieldDelegateApp(Snapshot * snapshot, ViewController * rootViewController);
   bool fieldDidReceiveEvent(EditableField * field, Responder * responder, Ion::Events::Event event);
   bool isFinishingEvent(Ion::Events::Event event);
   virtual bool isAcceptableExpression(const Poincare::Expression expression);

--- a/apps/shared/text_field_delegate_app.h
+++ b/apps/shared/text_field_delegate_app.h
@@ -2,9 +2,11 @@
 #define SHARED_TEXT_FIELD_DELEGATE_APP_H
 
 #include <poincare/context.h>
-#include <escher.h>
 #include "input_event_handler_delegate_app.h"
+#include <escher/text_field_delegate.h>
 #include <apps/i18n.h>
+
+class EditableField;
 
 namespace Shared {
 

--- a/apps/shared/text_field_delegate_app.h
+++ b/apps/shared/text_field_delegate_app.h
@@ -6,8 +6,6 @@
 #include "input_event_handler_delegate_app.h"
 #include <apps/i18n.h>
 
-class AppsContainer;
-
 namespace Shared {
 
 class TextFieldDelegateApp : public InputEventHandlerDelegateApp, public TextFieldDelegate {

--- a/apps/shared/values_controller.cpp
+++ b/apps/shared/values_controller.cpp
@@ -336,8 +336,7 @@ void ValuesController::updateNumberOfColumns() {
 }
 
 FunctionStore * ValuesController::functionStore() const {
-  FunctionApp * myApp = static_cast<FunctionApp *>(app());
-  return myApp->functionStore();
+  return FunctionApp::app()->functionStore();
 }
 
 }

--- a/apps/shared/values_controller.cpp
+++ b/apps/shared/values_controller.cpp
@@ -79,7 +79,7 @@ bool ValuesController::handleEvent(Ion::Events::Event event) {
     if (selectedRow() == -1) {
       header()->setSelectedButton(-1);
       selectableTableView()->selectCellAtLocation(0,0);
-      app()->setFirstResponder(selectableTableView());
+      Container::activeApp()->setFirstResponder(selectableTableView());
       return true;
     }
     return false;
@@ -88,7 +88,7 @@ bool ValuesController::handleEvent(Ion::Events::Event event) {
   if (event == Ion::Events::Up) {
     if (selectedRow() == -1) {
       header()->setSelectedButton(-1);
-      app()->setFirstResponder(tabController());
+      Container::activeApp()->setFirstResponder(tabController());
       return true;
     }
     selectableTableView()->deselectTable();

--- a/apps/shared/values_controller.cpp
+++ b/apps/shared/values_controller.cpp
@@ -327,8 +327,7 @@ int ValuesController::maxNumberOfElements() const {
 
 double ValuesController::evaluationOfAbscissaAtColumn(double abscissa, int columnIndex) {
   ExpiringPointer<Function> function = functionStore()->modelForRecord(recordAtColumn(columnIndex));
-  TextFieldDelegateApp * myApp = (TextFieldDelegateApp *)app();
-  return function->evaluateAtAbscissa(abscissa, myApp->localContext());
+  return function->evaluateAtAbscissa(abscissa, textFieldDelegateApp()->localContext());
 }
 
 void ValuesController::updateNumberOfColumns() {

--- a/apps/shared/values_controller.cpp
+++ b/apps/shared/values_controller.cpp
@@ -1,7 +1,6 @@
 #include "values_controller.h"
 #include "function_app.h"
 #include "../constant.h"
-#include "../apps_container.h"
 #include "poincare_helpers.h"
 #include <assert.h>
 
@@ -342,4 +341,3 @@ FunctionStore * ValuesController::functionStore() const {
 }
 
 }
-

--- a/apps/shared/values_function_parameter_controller.cpp
+++ b/apps/shared/values_function_parameter_controller.cpp
@@ -15,7 +15,7 @@ void ValuesFunctionParameterController::viewWillAppear() {
 void ValuesFunctionParameterController::didBecomeFirstResponder() {
   m_selectableTableView.reloadData();
   selectCellAtLocation(0, 0);
-  app()->setFirstResponder(&m_selectableTableView);
+  Container::activeApp()->setFirstResponder(&m_selectableTableView);
 }
 
 }

--- a/apps/shared/values_function_parameter_controller.cpp
+++ b/apps/shared/values_function_parameter_controller.cpp
@@ -9,8 +9,7 @@ const char * ValuesFunctionParameterController::title() {
 }
 
 void ValuesFunctionParameterController::viewWillAppear() {
-  FunctionApp * myApp = static_cast<FunctionApp *>(app());
-  myApp->functionStore()->modelForRecord(m_record)->nameWithArgument(m_pageTitle, Function::k_maxNameWithArgumentSize, m_symbol);
+  FunctionApp::app()->functionStore()->modelForRecord(m_record)->nameWithArgument(m_pageTitle, Function::k_maxNameWithArgumentSize, m_symbol);
 }
 
 void ValuesFunctionParameterController::didBecomeFirstResponder() {

--- a/apps/shared/values_parameter_controller.cpp
+++ b/apps/shared/values_parameter_controller.cpp
@@ -38,7 +38,7 @@ void ValuesParameterController::didBecomeFirstResponder() {
   if (selectedRow() < 0) {
     selectCellAtLocation(0, 0);
   }
-  app()->setFirstResponder(&m_selectableTableView);
+  Container::activeApp()->setFirstResponder(&m_selectableTableView);
 }
 
 bool ValuesParameterController::handleEvent(Ion::Events::Event event) {

--- a/apps/solver/app.cpp
+++ b/apps/solver/app.cpp
@@ -24,7 +24,7 @@ App::Snapshot::Snapshot() :
 }
 
 App * App::Snapshot::unpack(Container * container) {
-  return new (container->currentAppBuffer()) App(container, this);
+  return new (container->currentAppBuffer()) App(this);
 }
 
 App::Descriptor * App::Snapshot::descriptor() {
@@ -42,8 +42,8 @@ void App::Snapshot::tidy() {
   m_equationStore.tidy();
 }
 
-App::App(Container * container, Snapshot * snapshot) :
-  ExpressionFieldDelegateApp(container, snapshot, &m_inputViewController),
+App::App(Snapshot * snapshot) :
+  ExpressionFieldDelegateApp(snapshot, &m_inputViewController),
   m_solutionsController(&m_alternateEmptyViewController, snapshot->equationStore()),
   m_intervalController(nullptr, this, snapshot->equationStore()),
   m_alternateEmptyViewController(nullptr, &m_solutionsController, &m_solutionsController),

--- a/apps/solver/app.h
+++ b/apps/solver/app.h
@@ -35,7 +35,7 @@ public:
   void willBecomeInactive() override;
   char XNT() override;
 private:
-  App(Container * container, Snapshot * snapshot);
+  App(Snapshot * snapshot);
   SolutionsController m_solutionsController;
   IntervalController m_intervalController;
   AlternateEmptyViewController m_alternateEmptyViewController;

--- a/apps/solver/app.h
+++ b/apps/solver/app.h
@@ -29,6 +29,9 @@ public:
     void tidy() override;
     EquationStore m_equationStore;
   };
+  static App * app() {
+    return static_cast<App *>(Container::activeApp());
+  }
   InputViewController * inputViewController() { return &m_inputViewController; }
   ViewController * solutionsControllerStack() { return &m_alternateEmptyViewController; }
   ViewController * intervalController() { return &m_intervalController; }
@@ -44,10 +47,6 @@ private:
   StackViewController m_stackViewController;
   InputViewController m_inputViewController;
 };
-
-inline App * app() {
-  return static_cast<App *>(Container::activeApp());
-}
 
 }
 

--- a/apps/solver/app.h
+++ b/apps/solver/app.h
@@ -45,6 +45,10 @@ private:
   InputViewController m_inputViewController;
 };
 
+inline App * app() {
+  return static_cast<App *>(::app());
+}
+
 }
 
 #endif

--- a/apps/solver/app.h
+++ b/apps/solver/app.h
@@ -46,7 +46,7 @@ private:
 };
 
 inline App * app() {
-  return static_cast<App *>(::app());
+  return static_cast<App *>(Container::activeApp());
 }
 
 }

--- a/apps/solver/equation_list_view.cpp
+++ b/apps/solver/equation_list_view.cpp
@@ -44,7 +44,7 @@ View * EquationListView::subviewAtIndex(int index) {
 }
 
 void EquationListView::didBecomeFirstResponder() {
-  app()->setFirstResponder(&m_listView);
+  Container::activeApp()->setFirstResponder(&m_listView);
 }
 
 void EquationListView::layoutSubviews() {

--- a/apps/solver/equation_models_parameter_controller.cpp
+++ b/apps/solver/equation_models_parameter_controller.cpp
@@ -42,7 +42,7 @@ void EquationModelsParameterController::viewWillAppear() {
 }
 
 void EquationModelsParameterController::didBecomeFirstResponder() {
-  app()->setFirstResponder(&m_selectableTableView);
+  Container::activeApp()->setFirstResponder(&m_selectableTableView);
 }
 
 bool EquationModelsParameterController::handleEvent(Ion::Events::Event event) {
@@ -53,7 +53,7 @@ bool EquationModelsParameterController::handleEvent(Ion::Events::Event event) {
     }
     assert(error == Ion::Storage::Record::ErrorStatus::None);
     m_listController->editSelectedRecordWithText(k_models[selectedRow()]);
-    app()->dismissModalViewController();
+    Container::activeApp()->dismissModalViewController();
     m_listController->editExpression(Ion::Events::OK);
     return true;
   }

--- a/apps/solver/interval_controller.cpp
+++ b/apps/solver/interval_controller.cpp
@@ -104,7 +104,7 @@ bool IntervalController::textFieldDidFinishEditing(TextField * textField, const 
 void IntervalController::buttonAction() {
   StackViewController * stack = stackController();
   m_equationStore->approximateSolve(textFieldDelegateApp()->localContext());
-  stack->push(app()->solutionsControllerStack(), KDColorWhite, Palette::SubTab, Palette::SubTab);
+  stack->push(App::app()->solutionsControllerStack(), KDColorWhite, Palette::SubTab, Palette::SubTab);
 }
 
 }

--- a/apps/solver/interval_controller.cpp
+++ b/apps/solver/interval_controller.cpp
@@ -103,7 +103,7 @@ bool IntervalController::textFieldDidFinishEditing(TextField * textField, const 
 
 void IntervalController::buttonAction() {
   StackViewController * stack = stackController();
-  m_equationStore->approximateSolve(app()->localContext());
+  m_equationStore->approximateSolve(textFieldDelegateApp()->localContext());
   stack->push(app()->solutionsControllerStack(), KDColorWhite, Palette::SubTab, Palette::SubTab);
 }
 

--- a/apps/solver/interval_controller.cpp
+++ b/apps/solver/interval_controller.cpp
@@ -103,9 +103,8 @@ bool IntervalController::textFieldDidFinishEditing(TextField * textField, const 
 
 void IntervalController::buttonAction() {
   StackViewController * stack = stackController();
-  App * solverApp = static_cast<App *>(app());
-  m_equationStore->approximateSolve(solverApp->localContext());
-  stack->push(solverApp->solutionsControllerStack(), KDColorWhite, Palette::SubTab, Palette::SubTab);
+  m_equationStore->approximateSolve(app()->localContext());
+  stack->push(app()->solutionsControllerStack(), KDColorWhite, Palette::SubTab, Palette::SubTab);
 }
 
 }

--- a/apps/solver/list_controller.cpp
+++ b/apps/solver/list_controller.cpp
@@ -228,10 +228,6 @@ SelectableTableView * ListController::selectableTableView() {
   return m_equationListView.selectableTableView();
 }
 
-Shared::TextFieldDelegateApp * ListController::textFieldDelegateApp() {
-  return app();
-}
-
 StackViewController * ListController::stackController() const {
   return static_cast<StackViewController *>(parentResponder()->parentResponder());
 }

--- a/apps/solver/list_controller.cpp
+++ b/apps/solver/list_controller.cpp
@@ -81,7 +81,7 @@ bool ListController::handleEvent(Ion::Events::Event event) {
   if (event == Ion::Events::Up && selectedRow() == -1) {
     footer()->setSelectedButton(-1);
     selectableTableView()->selectCellAtLocation(0, numberOfRows()-1);
-    app()->setFirstResponder(selectableTableView());
+    Container::activeApp()->setFirstResponder(selectableTableView());
     return true;
   }
   if (event == Ion::Events::Down) {
@@ -105,7 +105,7 @@ void ListController::didBecomeFirstResponder() {
     selectCellAtLocation(selectedColumn(), numberOfRows()-1);
   }
   footer()->setSelectedButton(-1);
-  app()->setFirstResponder(selectableTableView());
+  Container::activeApp()->setFirstResponder(selectableTableView());
 }
 
 void ListController::didEnterResponderChain(Responder * previousFirstResponder) {
@@ -132,7 +132,7 @@ bool ListController::textFieldDidReceiveEvent(TextField * textField, Ion::Events
       textField->handleEvent(Ion::Events::ShiftRight);
       textField->handleEventWithText("=0");
       if (!textRepresentsAnEquality(textField->text())) {
-        app()->displayWarning(I18n::Message::RequireEquation);
+        Container::activeApp()->displayWarning(I18n::Message::RequireEquation);
         return true;
       }
     }
@@ -149,7 +149,7 @@ bool ListController::layoutFieldDidReceiveEvent(LayoutField * layoutField, Ion::
       layoutField->handleEvent(Ion::Events::ShiftRight);
       layoutField->handleEventWithText("=0");
       if (!layoutRepresentsAnEquality(layoutField->layout())) {
-        app()->displayWarning(I18n::Message::RequireEquation);
+        Container::activeApp()->displayWarning(I18n::Message::RequireEquation);
         return true;
       }
     }
@@ -172,22 +172,22 @@ bool ListController::layoutFieldDidFinishEditing(LayoutField * layoutField, Poin
 
 void ListController::resolveEquations() {
   if (m_equationStore->numberOfDefinedModels() == 0) {
-    app()->displayWarning(I18n::Message::EnterEquation);
+    Container::activeApp()->displayWarning(I18n::Message::EnterEquation);
     return;
   }
   EquationStore::Error e = m_equationStore->exactSolve(textFieldDelegateApp()->localContext());
   switch (e) {
     case EquationStore::Error::EquationUndefined:
-      app()->displayWarning(I18n::Message::UndefinedEquation);
+      Container::activeApp()->displayWarning(I18n::Message::UndefinedEquation);
       return;
     case EquationStore::Error::EquationUnreal:
-      app()->displayWarning(I18n::Message::UnrealEquation);
+      Container::activeApp()->displayWarning(I18n::Message::UnrealEquation);
       return;
     case EquationStore::Error::TooManyVariables:
-      app()->displayWarning(I18n::Message::TooManyVariables);
+      Container::activeApp()->displayWarning(I18n::Message::TooManyVariables);
       return;
     case EquationStore::Error::NonLinearSystem:
-      app()->displayWarning(I18n::Message::NonLinearSystem);
+      Container::activeApp()->displayWarning(I18n::Message::NonLinearSystem);
       return;
     case EquationStore::Error::RequireApproximateSolution:
     {
@@ -209,7 +209,7 @@ void ListController::reloadButtonMessage() {
 }
 
 void ListController::addEmptyModel() {
-  app()->displayModalViewController(&m_modelsStackController, 0.f, 0.f, Metric::CommonTopMargin, Metric::CommonRightMargin, 0, Metric::CommonLeftMargin);
+  Container::activeApp()->displayModalViewController(&m_modelsStackController, 0.f, 0.f, Metric::CommonTopMargin, Metric::CommonRightMargin, 0, Metric::CommonLeftMargin);
 }
 
 bool ListController::removeModelRow(Ion::Storage::Record record) {

--- a/apps/solver/list_controller.cpp
+++ b/apps/solver/list_controller.cpp
@@ -232,10 +232,6 @@ Shared::TextFieldDelegateApp * ListController::textFieldDelegateApp() {
   return app();
 }
 
-Shared::ExpressionFieldDelegateApp * ListController::expressionFieldDelegateApp() {
-  return app();
-}
-
 StackViewController * ListController::stackController() const {
   return static_cast<StackViewController *>(parentResponder()->parentResponder());
 }

--- a/apps/solver/list_controller.cpp
+++ b/apps/solver/list_controller.cpp
@@ -175,7 +175,7 @@ void ListController::resolveEquations() {
     app()->displayWarning(I18n::Message::EnterEquation);
     return;
   }
-  EquationStore::Error e = m_equationStore->exactSolve(static_cast<App *>(app())->localContext());
+  EquationStore::Error e = m_equationStore->exactSolve(app()->localContext());
   switch (e) {
     case EquationStore::Error::EquationUndefined:
       app()->displayWarning(I18n::Message::UndefinedEquation);
@@ -192,16 +192,14 @@ void ListController::resolveEquations() {
     case EquationStore::Error::RequireApproximateSolution:
     {
       StackViewController * stack = stackController();
-      App * solverApp = static_cast<App *>(app());
-      stack->push(solverApp->intervalController(), KDColorWhite, Palette::PurpleBright, Palette::PurpleBright);
+      stack->push(app()->intervalController(), KDColorWhite, Palette::PurpleBright, Palette::PurpleBright);
       return;
     }
     default:
     {
       assert(e == EquationStore::Error::NoError);
       StackViewController * stack = stackController();
-      App * solverApp = static_cast<App *>(app());
-      stack->push(solverApp->solutionsControllerStack(), KDColorWhite, Palette::PurpleBright, Palette::PurpleBright);
+      stack->push(app()->solutionsControllerStack(), KDColorWhite, Palette::PurpleBright, Palette::PurpleBright);
     }
  }
 }
@@ -231,11 +229,11 @@ SelectableTableView * ListController::selectableTableView() {
 }
 
 Shared::TextFieldDelegateApp * ListController::textFieldDelegateApp() {
-  return static_cast<App *>(app());
+  return app();
 }
 
 Shared::ExpressionFieldDelegateApp * ListController::expressionFieldDelegateApp() {
-  return static_cast<App *>(app());
+  return app();
 }
 
 StackViewController * ListController::stackController() const {
@@ -243,7 +241,7 @@ StackViewController * ListController::stackController() const {
 }
 
 InputViewController * ListController::inputController() {
-  return static_cast<App *>(app())->inputViewController();
+  return app()->inputViewController();
 }
 
 }

--- a/apps/solver/list_controller.cpp
+++ b/apps/solver/list_controller.cpp
@@ -192,14 +192,14 @@ void ListController::resolveEquations() {
     case EquationStore::Error::RequireApproximateSolution:
     {
       StackViewController * stack = stackController();
-      stack->push(app()->intervalController(), KDColorWhite, Palette::PurpleBright, Palette::PurpleBright);
+      stack->push(App::app()->intervalController(), KDColorWhite, Palette::PurpleBright, Palette::PurpleBright);
       return;
     }
     default:
     {
       assert(e == EquationStore::Error::NoError);
       StackViewController * stack = stackController();
-      stack->push(app()->solutionsControllerStack(), KDColorWhite, Palette::PurpleBright, Palette::PurpleBright);
+      stack->push(App::app()->solutionsControllerStack(), KDColorWhite, Palette::PurpleBright, Palette::PurpleBright);
     }
  }
 }
@@ -233,7 +233,7 @@ StackViewController * ListController::stackController() const {
 }
 
 InputViewController * ListController::inputController() {
-  return app()->inputViewController();
+  return App::app()->inputViewController();
 }
 
 }

--- a/apps/solver/list_controller.cpp
+++ b/apps/solver/list_controller.cpp
@@ -175,7 +175,7 @@ void ListController::resolveEquations() {
     app()->displayWarning(I18n::Message::EnterEquation);
     return;
   }
-  EquationStore::Error e = m_equationStore->exactSolve(app()->localContext());
+  EquationStore::Error e = m_equationStore->exactSolve(textFieldDelegateApp()->localContext());
   switch (e) {
     case EquationStore::Error::EquationUndefined:
       app()->displayWarning(I18n::Message::UndefinedEquation);

--- a/apps/solver/list_controller.h
+++ b/apps/solver/list_controller.h
@@ -38,7 +38,6 @@ public:
   /* ViewController */
   View * view() override { return &m_equationListView; }
   /* Text/Layout Field Delegate */
-  Shared::TextFieldDelegateApp * textFieldDelegateApp() override;
   bool textFieldDidReceiveEvent(TextField * textField, Ion::Events::Event event) override;
   bool layoutFieldDidReceiveEvent(LayoutField * layoutField, Ion::Events::Event event) override;
   bool textFieldDidFinishEditing(TextField * textField, const char * text, Ion::Events::Event event) override;

--- a/apps/solver/list_controller.h
+++ b/apps/solver/list_controller.h
@@ -39,7 +39,6 @@ public:
   View * view() override { return &m_equationListView; }
   /* Text/Layout Field Delegate */
   Shared::TextFieldDelegateApp * textFieldDelegateApp() override;
-  Shared::ExpressionFieldDelegateApp * expressionFieldDelegateApp() override;
   bool textFieldDidReceiveEvent(TextField * textField, Ion::Events::Event event) override;
   bool layoutFieldDidReceiveEvent(LayoutField * layoutField, Ion::Events::Event event) override;
   bool textFieldDidFinishEditing(TextField * textField, const char * text, Ion::Events::Event event) override;

--- a/apps/solver/solutions_controller.cpp
+++ b/apps/solver/solutions_controller.cpp
@@ -108,7 +108,7 @@ void SolutionsController::viewWillAppear() {
   bool requireWarning = false;
   if (m_equationStore->type() == EquationStore::Type::Monovariable) {
     m_contentView.setWarningMessages(I18n::Message::OnlyFirstSolutionsDisplayed0, I18n::Message::OnlyFirstSolutionsDisplayed1);
-    requireWarning = m_equationStore->haveMoreApproximationSolutions(app()->localContext());
+    requireWarning = m_equationStore->haveMoreApproximationSolutions(App::app()->localContext());
   } else if (m_equationStore->type() == EquationStore::Type::PolynomialMonovariable && m_equationStore->numberOfSolutions() == 1) {
     assert(Preferences::sharedPreferences()->complexFormat() == Preferences::ComplexFormat::Real);
     m_contentView.setWarningMessages(I18n::Message::PolynomeHasNoRealSolution0, I18n::Message::PolynomeHasNoRealSolution1);

--- a/apps/solver/solutions_controller.cpp
+++ b/apps/solver/solutions_controller.cpp
@@ -284,7 +284,7 @@ int SolutionsController::typeAtLocation(int i, int j) {
 }
 
 void SolutionsController::didBecomeFirstResponder() {
-  app()->setFirstResponder(m_contentView.selectableTableView());
+  Container::activeApp()->setFirstResponder(m_contentView.selectableTableView());
 }
 
 }

--- a/apps/solver/solutions_controller.cpp
+++ b/apps/solver/solutions_controller.cpp
@@ -105,11 +105,10 @@ View * SolutionsController::view() {
 
 void SolutionsController::viewWillAppear() {
   ViewController::viewWillAppear();
-  App * solverApp = static_cast<App *>(app());
   bool requireWarning = false;
   if (m_equationStore->type() == EquationStore::Type::Monovariable) {
     m_contentView.setWarningMessages(I18n::Message::OnlyFirstSolutionsDisplayed0, I18n::Message::OnlyFirstSolutionsDisplayed1);
-    requireWarning = m_equationStore->haveMoreApproximationSolutions(solverApp->localContext());
+    requireWarning = m_equationStore->haveMoreApproximationSolutions(app()->localContext());
   } else if (m_equationStore->type() == EquationStore::Type::PolynomialMonovariable && m_equationStore->numberOfSolutions() == 1) {
     assert(Preferences::sharedPreferences()->complexFormat() == Preferences::ComplexFormat::Real);
     m_contentView.setWarningMessages(I18n::Message::PolynomeHasNoRealSolution0, I18n::Message::PolynomeHasNoRealSolution1);

--- a/apps/statistics/app.cpp
+++ b/apps/statistics/app.cpp
@@ -31,7 +31,7 @@ App::Snapshot::Snapshot() :
 }
 
 App * App::Snapshot::unpack(Container * container) {
-  return new (container->currentAppBuffer()) App(container, this);
+  return new (container->currentAppBuffer()) App(this);
 }
 
 void App::Snapshot::reset() {
@@ -49,8 +49,8 @@ App::Descriptor * App::Snapshot::descriptor() {
   return &descriptor;
 }
 
-App::App(Container * container, Snapshot * snapshot) :
-  TextFieldDelegateApp(container, snapshot, &m_tabViewController),
+App::App(Snapshot * snapshot) :
+  TextFieldDelegateApp(snapshot, &m_tabViewController),
   m_calculationController(&m_calculationAlternateEmptyViewController, &m_calculationHeader, snapshot->store()),
   m_calculationAlternateEmptyViewController(&m_calculationHeader, &m_calculationController, &m_calculationController),
   m_calculationHeader(&m_tabViewController, &m_calculationAlternateEmptyViewController, &m_calculationController),

--- a/apps/statistics/app.h
+++ b/apps/statistics/app.h
@@ -44,7 +44,7 @@ public:
     BoxView::Quantile m_selectedBoxQuantile;
   };
 private:
-  App(Container * container, Snapshot * snapshot);
+  App(Snapshot * snapshot);
   CalculationController m_calculationController;
   AlternateEmptyViewController m_calculationAlternateEmptyViewController;
   ButtonRowController m_calculationHeader;

--- a/apps/statistics/box_controller.cpp
+++ b/apps/statistics/box_controller.cpp
@@ -1,7 +1,6 @@
 #include "box_controller.h"
 #include "app.h"
 #include "../shared/poincare_helpers.h"
-#include "../apps_container.h"
 
 using namespace Poincare;
 using namespace Shared;

--- a/apps/statistics/calculation_controller.cpp
+++ b/apps/statistics/calculation_controller.cpp
@@ -167,7 +167,7 @@ const char * CalculationController::title() {
 bool CalculationController::handleEvent(Ion::Events::Event event) {
   if (event == Ion::Events::Up) {
     selectableTableView()->deselectTable();
-    app()->setFirstResponder(tabController());
+    Container::activeApp()->setFirstResponder(tabController());
     return true;
   }
   return false;

--- a/apps/statistics/calculation_controller.cpp
+++ b/apps/statistics/calculation_controller.cpp
@@ -1,5 +1,5 @@
 #include "calculation_controller.h"
-#include "../apps_container.h"
+#include <apps/i18n.h>
 #include "../shared/poincare_helpers.h"
 #include <assert.h>
 

--- a/apps/statistics/histogram_controller.cpp
+++ b/apps/statistics/histogram_controller.cpp
@@ -1,5 +1,4 @@
 #include "histogram_controller.h"
-#include "../apps_container.h"
 #include "../shared/poincare_helpers.h"
 #include "../shared/text_helpers.h"
 #include "app.h"

--- a/apps/statistics/histogram_parameter_controller.cpp
+++ b/apps/statistics/histogram_parameter_controller.cpp
@@ -43,7 +43,7 @@ bool HistogramParameterController::setParameterAtIndex(int parameterIndex, doubl
   if (parameterIndex == 0) {
     // The bar width cannot be negative
     if (f <= 0.0f) {
-      app()->displayWarning(I18n::Message::ForbiddenValue);
+      Container::activeApp()->displayWarning(I18n::Message::ForbiddenValue);
       return false;
     }
 
@@ -52,7 +52,7 @@ bool HistogramParameterController::setParameterAtIndex(int parameterIndex, doubl
       if (m_store->firstDrawnBarAbscissa() <= m_store->maxValue(i)+f) {
         break;
       } else if (i == DoublePairStore::k_numberOfSeries - 1) {
-        app()->displayWarning(I18n::Message::ForbiddenValue);
+        Container::activeApp()->displayWarning(I18n::Message::ForbiddenValue);
         return false;
       }
     }
@@ -67,7 +67,7 @@ bool HistogramParameterController::setParameterAtIndex(int parameterIndex, doubl
       }
     }
     if (maxNewNumberOfBars > Store::k_maxNumberOfBars) {
-      app()->displayWarning(I18n::Message::ForbiddenValue);
+      Container::activeApp()->displayWarning(I18n::Message::ForbiddenValue);
       return false;
     }
 
@@ -84,7 +84,7 @@ bool HistogramParameterController::setParameterAtIndex(int parameterIndex, doubl
       }
     }
     if (maxNewNumberOfBars > Store::k_maxNumberOfBars) {
-      app()->displayWarning(I18n::Message::ForbiddenValue);
+      Container::activeApp()->displayWarning(I18n::Message::ForbiddenValue);
       return false;
     }
     // There should be at least one value in the drawn bin
@@ -92,7 +92,7 @@ bool HistogramParameterController::setParameterAtIndex(int parameterIndex, doubl
       if (f <= m_store->maxValue(i)+m_store->barWidth()) {
         break;
       } else if (i == DoublePairStore::k_numberOfSeries - 1) {
-        app()->displayWarning(I18n::Message::ForbiddenValue);
+        Container::activeApp()->displayWarning(I18n::Message::ForbiddenValue);
         return false;
       }
     }

--- a/apps/statistics/multiple_data_view_controller.cpp
+++ b/apps/statistics/multiple_data_view_controller.cpp
@@ -58,7 +58,7 @@ bool MultipleDataViewController::handleEvent(Ion::Events::Event event) {
       multipleDataView()->selectDataView(*m_selectedSeriesIndex);
       highlightSelection();
     } else {
-      app()->setFirstResponder(tabController());
+      Container::activeApp()->setFirstResponder(tabController());
     }
     reloadBannerView();
     return true;

--- a/apps/statistics/store_controller.cpp
+++ b/apps/statistics/store_controller.cpp
@@ -22,7 +22,7 @@ StoreController::StoreController(Responder * parentResponder, InputEventHandlerD
 }
 
 StoreContext * StoreController::storeContext() {
-  m_statisticsContext.setParentContext(const_cast<AppsContainer *>(static_cast<const AppsContainer *>(app()->container()))->globalContext());
+  m_statisticsContext.setParentContext(AppsContainer::sharedAppsContainer()->globalContext());
   return &m_statisticsContext;
 }
 

--- a/apps/suspend_timer.cpp
+++ b/apps/suspend_timer.cpp
@@ -1,16 +1,16 @@
 #include "suspend_timer.h"
 #include "apps_container.h"
 
-SuspendTimer::SuspendTimer(AppsContainer * container) :
-  Timer(k_idleBeforeSuspendDuration/Timer::TickDuration),
-  m_container(container)
+SuspendTimer::SuspendTimer() :
+  Timer(k_idleBeforeSuspendDuration/Timer::TickDuration)
 {
 }
 
 bool SuspendTimer::fire() {
-  /* We could just call m_container->suspend(), but we want to notify all
+  /* We could just call container->suspend(), but we want to notify all
    * responders in the responder chain that the calculator will be switched off,
    * so we use an event to switch off the calculator. */
-  m_container->dispatchEvent(Ion::Events::OnOff);
+  AppsContainer * container = AppsContainer::sharedAppsContainer();
+  container->dispatchEvent(Ion::Events::OnOff);
   return false;
 }

--- a/apps/suspend_timer.h
+++ b/apps/suspend_timer.h
@@ -3,15 +3,12 @@
 
 #include <escher.h>
 
-class AppsContainer;
-
 class SuspendTimer : public Timer {
 public:
-  SuspendTimer(AppsContainer * container);
+  SuspendTimer();
 private:
   constexpr static int k_idleBeforeSuspendDuration = 5*60*1000; // In miliseconds
   bool fire() override;
-  AppsContainer * m_container;
 };
 
 #endif

--- a/apps/usb/app.cpp
+++ b/apps/usb/app.cpp
@@ -13,7 +13,7 @@ I18n::Message App::Descriptor::upperName() {
 }
 
 App * App::Snapshot::unpack(Container * container) {
-  return new (container->currentAppBuffer()) App(container, this);
+  return new (container->currentAppBuffer()) App(this);
 }
 
 App::Descriptor * App::Snapshot::descriptor() {
@@ -21,8 +21,8 @@ App::Descriptor * App::Snapshot::descriptor() {
   return &descriptor;
 }
 
-App::App(Container * container, Snapshot * snapshot) :
-  ::App(container, snapshot, &m_usbConnectedController)
+App::App(Snapshot * snapshot) :
+  ::App(snapshot, &m_usbConnectedController)
 {
 }
 

--- a/apps/usb/app.cpp
+++ b/apps/usb/app.cpp
@@ -1,5 +1,5 @@
 #include "app.h"
-#include "../apps_container.h"
+#include <apps/i18n.h>
 #include <assert.h>
 
 namespace USB {

--- a/apps/usb/app.h
+++ b/apps/usb/app.h
@@ -20,7 +20,7 @@ public:
   };
   bool processEvent(Ion::Events::Event) override;
 private:
-  App(Container * container, Snapshot * snapshot);
+  App(Snapshot * snapshot);
   USBConnectedController m_usbConnectedController;
 };
 

--- a/apps/variable_box_controller.cpp
+++ b/apps/variable_box_controller.cpp
@@ -211,7 +211,7 @@ bool VariableBoxController::selectLeaf(int selectedRow) {
 
   // Handle the text
   sender()->handleEventWithText(nameToHandle);
-  app()->dismissModalViewController();
+  Container::activeApp()->dismissModalViewController();
   return true;
 }
 

--- a/escher/include/escher.h
+++ b/escher/include/escher.h
@@ -3,7 +3,6 @@
 
 #include <escher/alternate_empty_view_controller.h>
 #include <escher/alternate_empty_view_delegate.h>
-#include <escher/app.h>
 #include <escher/bank_view_controller.h>
 #include <escher/buffer_text_view.h>
 #include <escher/button.h>

--- a/escher/include/escher/app.h
+++ b/escher/include/escher/app.h
@@ -72,8 +72,5 @@ private:
   WarningController m_warningController;
 };
 
-// Make sure App * app() is reachable by anyone including only app.h
-#include <escher/container.h>
-
 #endif
 

--- a/escher/include/escher/app.h
+++ b/escher/include/escher/app.h
@@ -65,7 +65,7 @@ public:
   virtual int numberOfTimers();
   virtual Timer * timerAtIndex(int i);
 protected:
-  App(Container * container, Snapshot * snapshot, ViewController * rootViewController, I18n::Message warningMessage = (I18n::Message)0);
+  App(Snapshot * snapshot, ViewController * rootViewController, I18n::Message warningMessage = (I18n::Message)0);
   ModalViewController m_modalViewController;
 private:
   Responder * m_firstResponder;

--- a/escher/include/escher/app.h
+++ b/escher/include/escher/app.h
@@ -46,7 +46,7 @@ public:
   /* The destructor has to be virtual. Otherwise calling a destructor on an
    * App * pointing to a Derived App would have undefined behaviour. */
   virtual ~App() = default;
-  Snapshot * snapshot();
+  Snapshot * snapshot() const { return m_snapshot; }
   void setFirstResponder(Responder * responder);
   Responder * firstResponder();
   virtual bool processEvent(Ion::Events::Event event);

--- a/escher/include/escher/app.h
+++ b/escher/include/escher/app.h
@@ -8,6 +8,7 @@
 #include <escher/timer.h>
 #include <escher/view_controller.h>
 #include <escher/warning_controller.h>
+#include <ion/storage.h>
 
 /* An app is fed events and outputs drawing calls.
  *
@@ -70,6 +71,9 @@ private:
   Snapshot * m_snapshot;
   WarningController m_warningController;
 };
+
+// Make sure App * app() is reachable by anyone including only app.h
+#include <escher/container.h>
 
 #endif
 

--- a/escher/include/escher/app.h
+++ b/escher/include/escher/app.h
@@ -57,7 +57,6 @@ public:
     KDCoordinate topMargin = 0, KDCoordinate leftMargin = 0, KDCoordinate bottomMargin = 0, KDCoordinate rightMargin = 0);
   void dismissModalViewController();
   void displayWarning(I18n::Message warningMessage1, I18n::Message warningMessage2 = (I18n::Message) 0, bool specialExitKeys = false);
-  const Container * container() const;
   uint8_t m_magic; // Poor man's RTTI
 
   virtual void didBecomeActive(Window * window);
@@ -69,7 +68,6 @@ protected:
   App(Container * container, Snapshot * snapshot, ViewController * rootViewController, I18n::Message warningMessage = (I18n::Message)0);
   ModalViewController m_modalViewController;
 private:
-  Container * m_container;
   Responder * m_firstResponder;
   Snapshot * m_snapshot;
   WarningController m_warningController;

--- a/escher/include/escher/app.h
+++ b/escher/include/escher/app.h
@@ -45,7 +45,6 @@ public:
   /* The destructor has to be virtual. Otherwise calling a destructor on an
    * App * pointing to a Derived App would have undefined behaviour. */
   virtual ~App() = default;
-  constexpr static uint8_t Magic = 0xA8;
   Snapshot * snapshot();
   void setFirstResponder(Responder * responder);
   Responder * firstResponder();
@@ -57,7 +56,6 @@ public:
     KDCoordinate topMargin = 0, KDCoordinate leftMargin = 0, KDCoordinate bottomMargin = 0, KDCoordinate rightMargin = 0);
   void dismissModalViewController();
   void displayWarning(I18n::Message warningMessage1, I18n::Message warningMessage2 = (I18n::Message) 0, bool specialExitKeys = false);
-  uint8_t m_magic; // Poor man's RTTI
 
   virtual void didBecomeActive(Window * window);
   virtual void willBecomeInactive();

--- a/escher/include/escher/button_row_controller.h
+++ b/escher/include/escher/button_row_controller.h
@@ -6,7 +6,6 @@
 #include <escher/invocation.h>
 #include <escher/i18n.h>
 #include <escher/button.h>
-#include <escher/app.h>
 #include <assert.h>
 
 class ButtonRowDelegate;
@@ -48,7 +47,7 @@ private:
     View * subviewAtIndex(int index) override;
     void layoutSubviews() override;
     void drawRect(KDContext * ctx, KDRect rect) const override;
-    bool setSelectedButton(int selectedButton, App * app);
+    bool setSelectedButton(int selectedButton);
     int selectedButton() const { return m_selectedButton; }
     ViewController * mainViewController() const { return m_mainViewController; }
     ButtonRowDelegate * buttonRowDelegate() const { return m_delegate; }

--- a/escher/include/escher/container.h
+++ b/escher/include/escher/container.h
@@ -47,4 +47,8 @@ private:
   static Container * s_sharedContainer;
 };
 
+App * app() {
+  return Container::sharedContainer()->activeApp();
+}
+
 #endif

--- a/escher/include/escher/container.h
+++ b/escher/include/escher/container.h
@@ -17,7 +17,10 @@
 
 class Container : public RunLoop {
 public:
-  static App * activeApp() { return s_activeApp; }
+  static App * activeApp() {
+    assert(s_activeApp);
+    return s_activeApp;
+  }
   Container();
   virtual ~Container();
   Container(const Container& other) = delete;

--- a/escher/include/escher/container.h
+++ b/escher/include/escher/container.h
@@ -30,13 +30,13 @@ public:
   virtual bool switchTo(App::Snapshot * snapshot);
 protected:
   virtual Window * window() = 0;
+  static App * s_activeApp;
 private:
   void step();
   int numberOfTimers() override;
   Timer * timerAtIndex(int i) override;
   virtual int numberOfContainerTimers();
   virtual Timer * containerTimerAtIndex(int i);
-  static App * s_activeApp;
 };
 
 inline App * app() {

--- a/escher/include/escher/container.h
+++ b/escher/include/escher/container.h
@@ -17,6 +17,10 @@
 
 class Container : public RunLoop {
 public:
+  static Container * sharedContainer() {
+    assert(s_sharedContainer);
+    return s_sharedContainer;
+  }
   Container();
   virtual ~Container();
   Container(const Container& other) = delete;
@@ -30,6 +34,9 @@ public:
   virtual bool switchTo(App::Snapshot * snapshot);
 protected:
   virtual Window * window() = 0;
+  void setSharedContainer(Container * container) {
+    s_sharedContainer = container;
+  }
 private:
   void step();
   int numberOfTimers() override;
@@ -37,6 +44,7 @@ private:
   virtual int numberOfContainerTimers();
   virtual Timer * containerTimerAtIndex(int i);
   App * m_activeApp;
+  static Container * s_sharedContainer;
 };
 
 #endif

--- a/escher/include/escher/container.h
+++ b/escher/include/escher/container.h
@@ -18,10 +18,6 @@
 class Container : public RunLoop {
 public:
   static App * activeApp() { return s_activeApp; }
-  static Container * sharedContainer() {
-    assert(s_sharedContainer);
-    return s_sharedContainer;
-  }
   Container();
   virtual ~Container();
   Container(const Container& other) = delete;
@@ -34,9 +30,6 @@ public:
   virtual bool switchTo(App::Snapshot * snapshot);
 protected:
   virtual Window * window() = 0;
-  void setSharedContainer(Container * container) {
-    s_sharedContainer = container;
-  }
 private:
   void step();
   int numberOfTimers() override;
@@ -44,11 +37,10 @@ private:
   virtual int numberOfContainerTimers();
   virtual Timer * containerTimerAtIndex(int i);
   static App * s_activeApp;
-  static Container * s_sharedContainer;
 };
 
 inline App * app() {
-  return Container::sharedContainer()->activeApp();
+  return Container::activeApp();
 }
 
 #endif

--- a/escher/include/escher/container.h
+++ b/escher/include/escher/container.h
@@ -29,7 +29,7 @@ public:
   Container& operator=(Container&& other) = delete;
   virtual void * currentAppBuffer() = 0;
   virtual void run();
-  App * activeApp();
+  App * activeApp() { return m_activeApp; }
   virtual bool dispatchEvent(Ion::Events::Event event) override;
   virtual bool switchTo(App::Snapshot * snapshot);
 protected:

--- a/escher/include/escher/container.h
+++ b/escher/include/escher/container.h
@@ -42,8 +42,4 @@ private:
   virtual Timer * containerTimerAtIndex(int i);
 };
 
-inline App * app() {
-  return Container::activeApp();
-}
-
 #endif

--- a/escher/include/escher/container.h
+++ b/escher/include/escher/container.h
@@ -17,6 +17,7 @@
 
 class Container : public RunLoop {
 public:
+  static App * activeApp() { return s_activeApp; }
   static Container * sharedContainer() {
     assert(s_sharedContainer);
     return s_sharedContainer;
@@ -29,7 +30,6 @@ public:
   Container& operator=(Container&& other) = delete;
   virtual void * currentAppBuffer() = 0;
   virtual void run();
-  App * activeApp() { return m_activeApp; }
   virtual bool dispatchEvent(Ion::Events::Event event) override;
   virtual bool switchTo(App::Snapshot * snapshot);
 protected:
@@ -43,7 +43,7 @@ private:
   Timer * timerAtIndex(int i) override;
   virtual int numberOfContainerTimers();
   virtual Timer * containerTimerAtIndex(int i);
-  App * m_activeApp;
+  static App * s_activeApp;
   static Container * s_sharedContainer;
 };
 

--- a/escher/include/escher/container.h
+++ b/escher/include/escher/container.h
@@ -47,7 +47,7 @@ private:
   static Container * s_sharedContainer;
 };
 
-App * app() {
+inline App * app() {
   return Container::sharedContainer()->activeApp();
 }
 

--- a/escher/include/escher/input_event_handler.h
+++ b/escher/include/escher/input_event_handler.h
@@ -1,17 +1,16 @@
 #ifndef ESCHER_INPUT_EVENT_HANDLER_H
 #define ESCHER_INPUT_EVENT_HANDLER_H
 
-#include <ion.h>
+#include <ion/events.h>
 
 class InputEventHandlerDelegate;
-class App;
 
 class InputEventHandler {
 public:
   InputEventHandler(InputEventHandlerDelegate * inputEventHandlerdelegate) : m_inputEventHandlerDelegate(inputEventHandlerdelegate) {}
   virtual bool handleEventWithText(const char * text, bool indentation = false, bool forceCursorRightOfText = false) { return false; }
 protected:
-  bool handleBoxEvent(App * app, Ion::Events::Event event);
+  bool handleBoxEvent(Ion::Events::Event event);
   InputEventHandlerDelegate * m_inputEventHandlerDelegate;
 };
 

--- a/escher/include/escher/layout_field_delegate.h
+++ b/escher/include/escher/layout_field_delegate.h
@@ -1,8 +1,8 @@
 #ifndef ESCHER_LAYOUT_FIELD_DELEGATE_H
 #define ESCHER_LAYOUT_FIELD_DELEGATE_H
 
-#include <escher/toolbox.h>
 #include <ion/events.h>
+#include <poincare/layout.h>
 
 class LayoutField;
 

--- a/escher/include/escher/responder.h
+++ b/escher/include/escher/responder.h
@@ -1,9 +1,7 @@
 #ifndef ESCHER_RESPONDER_H
 #define ESCHER_RESPONDER_H
 
-#include <ion.h>
-
-class App;
+#include <ion/events.h>
 
 class Responder {
 public:
@@ -16,7 +14,6 @@ public:
   Responder * parentResponder() const;
   Responder * commonAncestorWith(Responder * responder);
   void setParentResponder(Responder * responder);
-  App * app() const;
 private:
   Responder * m_parentResponder;
 };

--- a/escher/include/escher/selectable_table_view.h
+++ b/escher/include/escher/selectable_table_view.h
@@ -2,7 +2,6 @@
 #define ESCHER_SELECTABLE_TABLE_VIEW_H
 
 #include <escher/table_view.h>
-#include <escher/app.h>
 #include <escher/selectable_table_view_data_source.h>
 #include <escher/selectable_table_view_delegate.h>
 #include <escher/table_view_data_source.h>

--- a/escher/include/escher/text_field_delegate.h
+++ b/escher/include/escher/text_field_delegate.h
@@ -1,6 +1,8 @@
 #ifndef ESCHER_TEXT_FIELD_DELEGATE_H
 #define ESCHER_TEXT_FIELD_DELEGATE_H
 
+#include <ion/events.h>
+
 class TextField;
 
 class TextFieldDelegate {

--- a/escher/include/escher/warning_controller.h
+++ b/escher/include/escher/warning_controller.h
@@ -1,10 +1,10 @@
 #ifndef ESCHER_WARNING_CONTROLLER_H
 #define ESCHER_WARNING_CONTROLLER_H
 
-#include <escher/view_controller.h>
+#include <escher/i18n.h>
 #include <escher/message_text_view.h>
 #include <escher/solid_color_view.h>
-#include <escher/i18n.h>
+#include <escher/view_controller.h>
 
 class WarningController : public ViewController {
 public:

--- a/escher/src/alternate_empty_view_controller.cpp
+++ b/escher/src/alternate_empty_view_controller.cpp
@@ -1,5 +1,5 @@
 #include <escher/alternate_empty_view_controller.h>
-#include <escher/app.h>
+#include <escher/container.h>
 #include <assert.h>
 
 /* ContentView */

--- a/escher/src/alternate_empty_view_controller.cpp
+++ b/escher/src/alternate_empty_view_controller.cpp
@@ -67,7 +67,7 @@ bool AlternateEmptyViewController::handleEvent(Ion::Events::Event event) {
 
 void AlternateEmptyViewController::didBecomeFirstResponder() {
   if (!m_contentView.alternateEmptyViewDelegate()->isEmpty()) {
-    app()->setFirstResponder(m_contentView.mainViewController());
+    Container::activeApp()->setFirstResponder(m_contentView.mainViewController());
   }
 }
 

--- a/escher/src/app.cpp
+++ b/escher/src/app.cpp
@@ -101,7 +101,6 @@ void App::displayWarning(I18n::Message warningMessage1, I18n::Message warningMes
 
 void App::didBecomeActive(Window * window) {
   View * view = m_modalViewController.view();
-  assert(m_modalViewController.app() == this);
   m_modalViewController.initView();
   window->setContentView(view);
   m_modalViewController.viewWillAppear();

--- a/escher/src/app.cpp
+++ b/escher/src/app.cpp
@@ -31,7 +31,6 @@ void App::Snapshot::tidy() {
 
 App::App(Snapshot * snapshot, ViewController * rootViewController, I18n::Message warningMessage) :
   Responder(nullptr),
-  m_magic(Magic),
   m_modalViewController(this, rootViewController),
   m_firstResponder(nullptr),
   m_snapshot(snapshot),

--- a/escher/src/app.cpp
+++ b/escher/src/app.cpp
@@ -33,7 +33,6 @@ App::App(Container * container, Snapshot * snapshot, ViewController * rootViewCo
   Responder(nullptr),
   m_magic(Magic),
   m_modalViewController(this, rootViewController),
-  m_container(container),
   m_firstResponder(nullptr),
   m_snapshot(snapshot),
   m_warningController(this, warningMessage)
@@ -99,10 +98,6 @@ void App::dismissModalViewController() {
 void App::displayWarning(I18n::Message warningMessage1, I18n::Message warningMessage2, bool specialExitKeys) {
   m_warningController.setLabel(warningMessage1, warningMessage2, specialExitKeys);
   displayModalViewController(&m_warningController, 0.5f, 0.5f);
-}
-
-const Container * App::container() const {
-  return m_container;
 }
 
 void App::didBecomeActive(Window * window) {

--- a/escher/src/app.cpp
+++ b/escher/src/app.cpp
@@ -29,7 +29,7 @@ void App::Snapshot::reset() {
 void App::Snapshot::tidy() {
 }
 
-App::App(Container * container, Snapshot * snapshot, ViewController * rootViewController, I18n::Message warningMessage) :
+App::App(Snapshot * snapshot, ViewController * rootViewController, I18n::Message warningMessage) :
   Responder(nullptr),
   m_magic(Magic),
   m_modalViewController(this, rootViewController),

--- a/escher/src/app.cpp
+++ b/escher/src/app.cpp
@@ -38,10 +38,6 @@ App::App(Snapshot * snapshot, ViewController * rootViewController, I18n::Message
 {
 }
 
-App::Snapshot * App::snapshot() {
-  return m_snapshot;
-}
-
 bool App::processEvent(Ion::Events::Event event) {
   Responder * responder = m_firstResponder;
   bool didHandleEvent = false;

--- a/escher/src/bank_view_controller.cpp
+++ b/escher/src/bank_view_controller.cpp
@@ -1,5 +1,5 @@
 #include <escher/bank_view_controller.h>
-#include <escher/app.h>
+#include <escher/container.h>
 
 BankViewController::BankViewController(Responder * parentViewController) :
   ViewController(parentViewController),

--- a/escher/src/bank_view_controller.cpp
+++ b/escher/src/bank_view_controller.cpp
@@ -14,14 +14,14 @@ void BankViewController::setActiveIndex(int i) {
   }
   ViewController * upcomingVC = childAtIndex(i);
   upcomingVC->viewWillAppear();
-  app()->setFirstResponder(upcomingVC);
+  Container::activeApp()->setFirstResponder(upcomingVC);
   childAtIndex(m_activeIndex)->viewDidDisappear();
   m_activeIndex = i;
   m_view.setSubview(upcomingVC->view());
 }
 
 void BankViewController::didEnterResponderChain(Responder * previousResponder) {
-  app()->setFirstResponder(activeViewController());
+  Container::activeApp()->setFirstResponder(activeViewController());
 }
 
 void BankViewController::initView() {

--- a/escher/src/button_row_controller.cpp
+++ b/escher/src/button_row_controller.cpp
@@ -1,4 +1,5 @@
 #include <escher/button_row_controller.h>
+#include <escher/app.h>
 #include <escher/palette.h>
 #include <cmath>
 
@@ -141,7 +142,7 @@ void ButtonRowController::ContentView::drawRect(KDContext * ctx, KDRect rect) co
   }
 }
 
-bool ButtonRowController::ContentView::setSelectedButton(int selectedButton, App * application) {
+bool ButtonRowController::ContentView::setSelectedButton(int selectedButton) {
   if (selectedButton < -1 || selectedButton >= numberOfButtons() || selectedButton == m_selectedButton) {
     return false;
   }
@@ -153,7 +154,7 @@ bool ButtonRowController::ContentView::setSelectedButton(int selectedButton, App
   if (m_selectedButton >= 0) {
     Button * button = buttonAtIndex(selectedButton);
     button->setHighlighted(true);
-    application->setFirstResponder(button);
+    app()->setFirstResponder(button);
     return true;
   }
   return false;
@@ -178,8 +179,7 @@ int ButtonRowController::selectedButton() {
 }
 
 bool ButtonRowController::setSelectedButton(int selectedButton) {
-  App * application = app();
-  return m_contentView.setSelectedButton(selectedButton, application);
+  return m_contentView.setSelectedButton(selectedButton);
 }
 
 void ButtonRowController::setMessageOfButtonAtIndex(I18n::Message message, int index) {

--- a/escher/src/button_row_controller.cpp
+++ b/escher/src/button_row_controller.cpp
@@ -154,7 +154,7 @@ bool ButtonRowController::ContentView::setSelectedButton(int selectedButton) {
   if (m_selectedButton >= 0) {
     Button * button = buttonAtIndex(selectedButton);
     button->setHighlighted(true);
-    app()->setFirstResponder(button);
+    Container::activeApp()->setFirstResponder(button);
     return true;
   }
   return false;
@@ -171,7 +171,7 @@ const char * ButtonRowController::title() {
 }
 
 void ButtonRowController::didBecomeFirstResponder(){
-  app()->setFirstResponder(m_contentView.mainViewController());
+  Container::activeApp()->setFirstResponder(m_contentView.mainViewController());
 }
 
 int ButtonRowController::selectedButton() {

--- a/escher/src/button_row_controller.cpp
+++ b/escher/src/button_row_controller.cpp
@@ -1,5 +1,5 @@
 #include <escher/button_row_controller.h>
-#include <escher/app.h>
+#include <escher/container.h>
 #include <escher/palette.h>
 #include <cmath>
 

--- a/escher/src/container.cpp
+++ b/escher/src/container.cpp
@@ -40,10 +40,6 @@ bool Container::switchTo(App::Snapshot * snapshot) {
   return true;
 }
 
-App * Container::activeApp() {
-  return m_activeApp;
-}
-
 bool Container::dispatchEvent(Ion::Events::Event event) {
   if (event == Ion::Events::TimerFire ) {
     window()->redraw();

--- a/escher/src/container.cpp
+++ b/escher/src/container.cpp
@@ -8,7 +8,6 @@ Container::Container() :
 
 // Initialize private static member
 App * Container::s_activeApp = nullptr;
-Container * Container::s_sharedContainer = nullptr;
 
 Container::~Container() {
   if (s_activeApp) {

--- a/escher/src/container.cpp
+++ b/escher/src/container.cpp
@@ -7,6 +7,9 @@ Container::Container() :
 {
 }
 
+// Initialize private static member
+Container * Container::s_sharedContainer = nullptr;
+
 Container::~Container() {
   if (m_activeApp) {
     m_activeApp->~App();

--- a/escher/src/editable_text_cell.cpp
+++ b/escher/src/editable_text_cell.cpp
@@ -1,5 +1,5 @@
 #include <escher/editable_text_cell.h>
-#include <escher/app.h>
+#include <escher/container.h>
 #include <escher/palette.h>
 #include <assert.h>
 

--- a/escher/src/editable_text_cell.cpp
+++ b/escher/src/editable_text_cell.cpp
@@ -51,7 +51,7 @@ void EditableTextCell::layoutSubviews() {
 }
 
 void EditableTextCell::didBecomeFirstResponder() {
-  app()->setFirstResponder(&m_textField);
+  Container::activeApp()->setFirstResponder(&m_textField);
 }
 
 KDSize EditableTextCell::minimalSizeForOptimalDisplay() const {

--- a/escher/src/even_odd_editable_text_cell.cpp
+++ b/escher/src/even_odd_editable_text_cell.cpp
@@ -1,5 +1,5 @@
 #include <escher/even_odd_editable_text_cell.h>
-#include <escher/app.h>
+#include <escher/container.h>
 #include <assert.h>
 
 EvenOddEditableTextCell::EvenOddEditableTextCell(Responder * parentResponder, InputEventHandlerDelegate * inputEventHandlerDelegate, TextFieldDelegate * delegate, char * draftTextBuffer, const KDFont * font, float horizontalAlignment, float verticalAlignment, KDCoordinate topMargin, KDCoordinate rightMargin, KDCoordinate bottomMargin, KDCoordinate leftMargin) :

--- a/escher/src/even_odd_editable_text_cell.cpp
+++ b/escher/src/even_odd_editable_text_cell.cpp
@@ -37,5 +37,5 @@ void EvenOddEditableTextCell::layoutSubviews() {
 }
 
 void EvenOddEditableTextCell::didBecomeFirstResponder() {
-  app()->setFirstResponder(&m_editableCell);
+  Container::activeApp()->setFirstResponder(&m_editableCell);
 }

--- a/escher/src/input_event_handler.cpp
+++ b/escher/src/input_event_handler.cpp
@@ -1,6 +1,6 @@
 #include <escher/input_event_handler.h>
 #include <escher/input_event_handler_delegate.h>
-#include <escher/app.h>
+#include <escher/container.h>
 #include <escher/toolbox.h>
 #include <escher/metric.h>
 

--- a/escher/src/input_event_handler.cpp
+++ b/escher/src/input_event_handler.cpp
@@ -12,7 +12,7 @@ bool InputEventHandler::handleBoxEvent(Ion::Events::Event event) {
   }
   if (box) {
     box->setSender(this);
-    app()->displayModalViewController(box, 0.f, 0.f, Metric::PopUpTopMargin, Metric::PopUpLeftMargin, 0, Metric::PopUpRightMargin);
+    Container::activeApp()->displayModalViewController(box, 0.f, 0.f, Metric::PopUpTopMargin, Metric::PopUpLeftMargin, 0, Metric::PopUpRightMargin);
     return true;
   }
   return false;

--- a/escher/src/input_event_handler.cpp
+++ b/escher/src/input_event_handler.cpp
@@ -4,7 +4,7 @@
 #include <escher/toolbox.h>
 #include <escher/metric.h>
 
-bool InputEventHandler::handleBoxEvent(App * app, Ion::Events::Event event) {
+bool InputEventHandler::handleBoxEvent(Ion::Events::Event event) {
   NestedMenuController * box = nullptr;
   if (m_inputEventHandlerDelegate) {
     box = event == Ion::Events::Toolbox ? m_inputEventHandlerDelegate->toolboxForInputEventHandler(this) : box;
@@ -12,7 +12,7 @@ bool InputEventHandler::handleBoxEvent(App * app, Ion::Events::Event event) {
   }
   if (box) {
     box->setSender(this);
-    app->displayModalViewController(box, 0.f, 0.f, Metric::PopUpTopMargin, Metric::PopUpLeftMargin, 0, Metric::PopUpRightMargin);
+    app()->displayModalViewController(box, 0.f, 0.f, Metric::PopUpTopMargin, Metric::PopUpLeftMargin, 0, Metric::PopUpRightMargin);
     return true;
   }
   return false;

--- a/escher/src/input_view_controller.cpp
+++ b/escher/src/input_view_controller.cpp
@@ -11,7 +11,7 @@ InputViewController::ExpressionFieldController::ExpressionFieldController(Respon
 }
 
 void InputViewController::ExpressionFieldController::didBecomeFirstResponder() {
-  app()->setFirstResponder(&m_expressionField);
+  Container::activeApp()->setFirstResponder(&m_expressionField);
 }
 
 InputViewController::InputViewController(Responder * parentResponder, ViewController * child, InputEventHandlerDelegate * inputEventHandlerDelegate, TextFieldDelegate * textFieldDelegate, LayoutFieldDelegate * layoutFieldDelegate) :

--- a/escher/src/input_view_controller.cpp
+++ b/escher/src/input_view_controller.cpp
@@ -1,5 +1,5 @@
 #include <escher/input_view_controller.h>
-#include <escher/app.h>
+#include <escher/container.h>
 #include <escher/palette.h>
 #include <assert.h>
 

--- a/escher/src/layout_field.cpp
+++ b/escher/src/layout_field.cpp
@@ -174,7 +174,7 @@ bool LayoutField::privateHandleEvent(Ion::Events::Event event) {
   if (m_delegate && m_delegate->layoutFieldDidReceiveEvent(this, event)) {
     return true;
   }
-  if (handleBoxEvent(app(), event)) {
+  if (handleBoxEvent(event)) {
     if (!isEditing()) {
       setEditing(true);
     }

--- a/escher/src/message_table_cell_with_editable_text.cpp
+++ b/escher/src/message_table_cell_with_editable_text.cpp
@@ -1,6 +1,6 @@
 #include <escher/message_table_cell_with_editable_text.h>
 #include <escher/palette.h>
-#include <escher/app.h>
+#include <escher/container.h>
 
 MessageTableCellWithEditableText::MessageTableCellWithEditableText(Responder * parentResponder, InputEventHandlerDelegate * inputEventHandlerDelegate, TextFieldDelegate * textFieldDelegate, char * draftTextBuffer, I18n::Message message) :
   Responder(parentResponder),

--- a/escher/src/message_table_cell_with_editable_text.cpp
+++ b/escher/src/message_table_cell_with_editable_text.cpp
@@ -19,7 +19,7 @@ const char * MessageTableCellWithEditableText::editedText() const {
 }
 
 void MessageTableCellWithEditableText::didBecomeFirstResponder() {
-  app()->setFirstResponder(&m_textField);
+  Container::activeApp()->setFirstResponder(&m_textField);
 }
 
 bool MessageTableCellWithEditableText::isEditing() {

--- a/escher/src/modal_view_controller.cpp
+++ b/escher/src/modal_view_controller.cpp
@@ -136,9 +136,6 @@ void ModalViewController::dismissModalViewController() {
 }
 
 void ModalViewController::didBecomeFirstResponder() {
-  if (m_contentView.isDisplayingModal()) {
-    app()->setFirstResponder(m_currentModalViewController);
-  }
   app()->setFirstResponder(m_regularViewController);
 }
 

--- a/escher/src/modal_view_controller.cpp
+++ b/escher/src/modal_view_controller.cpp
@@ -117,11 +117,11 @@ void ModalViewController::displayModalViewController(ViewController * vc, float 
   KDCoordinate topMargin, KDCoordinate leftMargin, KDCoordinate bottomMargin, KDCoordinate rightMargin) {
   m_currentModalViewController = vc;
   vc->setParentResponder(this);
-  m_previousResponder = app()->firstResponder();
+  m_previousResponder = Container::activeApp()->firstResponder();
   m_currentModalViewController->initView();
   m_contentView.presentModalView(vc->view(), verticalAlignment, horizontalAlignment, topMargin, leftMargin, bottomMargin, rightMargin);
   m_currentModalViewController->viewWillAppear();
-  app()->setFirstResponder(vc);
+  Container::activeApp()->setFirstResponder(vc);
 }
 
 void ModalViewController::reloadModalViewController() {
@@ -130,13 +130,13 @@ void ModalViewController::reloadModalViewController() {
 
 void ModalViewController::dismissModalViewController() {
   m_currentModalViewController->viewDidDisappear();
-  app()->setFirstResponder(m_previousResponder);
+  Container::activeApp()->setFirstResponder(m_previousResponder);
   m_contentView.dismissModalView();
   m_currentModalViewController = nullptr;
 }
 
 void ModalViewController::didBecomeFirstResponder() {
-  app()->setFirstResponder(m_regularViewController);
+  Container::activeApp()->setFirstResponder(m_regularViewController);
 }
 
 bool ModalViewController::handleEvent(Ion::Events::Event event) {

--- a/escher/src/modal_view_controller.cpp
+++ b/escher/src/modal_view_controller.cpp
@@ -1,5 +1,5 @@
 #include <escher/modal_view_controller.h>
-#include <escher/app.h>
+#include <escher/container.h>
 #include <assert.h>
 
 ModalViewController::ContentView::ContentView() :

--- a/escher/src/modal_view_controller.cpp
+++ b/escher/src/modal_view_controller.cpp
@@ -136,7 +136,9 @@ void ModalViewController::dismissModalViewController() {
 }
 
 void ModalViewController::didBecomeFirstResponder() {
-  Container::activeApp()->setFirstResponder(m_regularViewController);
+  Container::activeApp()->setFirstResponder(
+    isDisplayingModal() ? m_currentModalViewController : m_regularViewController
+  );
 }
 
 bool ModalViewController::handleEvent(Ion::Events::Event event) {

--- a/escher/src/nested_menu_controller.cpp
+++ b/escher/src/nested_menu_controller.cpp
@@ -1,4 +1,5 @@
 #include <escher/nested_menu_controller.h>
+#include <escher/app.h>
 #include <escher/metric.h>
 #include <assert.h>
 #include <string.h>

--- a/escher/src/nested_menu_controller.cpp
+++ b/escher/src/nested_menu_controller.cpp
@@ -79,7 +79,7 @@ View * NestedMenuController::ListController::view() {
 void NestedMenuController::ListController::didBecomeFirstResponder() {
   m_selectableTableView->reloadData();
   m_selectableTableView->selectCellAtLocation(0, m_firstSelectedRow);
-  app()->setFirstResponder(m_selectableTableView);
+  Container::activeApp()->setFirstResponder(m_selectableTableView);
 }
 
 void NestedMenuController::ListController::setFirstSelectedRow(int firstSelectedRow) {
@@ -103,7 +103,7 @@ bool NestedMenuController::handleEvent(Ion::Events::Event event) {
 }
 
 void NestedMenuController::didBecomeFirstResponder() {
-  app()->setFirstResponder(&m_listController);
+  Container::activeApp()->setFirstResponder(&m_listController);
 }
 
 void NestedMenuController::viewWillAppear() {
@@ -155,7 +155,7 @@ bool NestedMenuController::handleEventForRow(Ion::Events::Event event, int rowIn
 bool NestedMenuController::selectSubMenu(int selectedRow) {
   m_stack.push(selectedRow, m_selectableTableView.contentOffset().y());
   m_listController.setFirstSelectedRow(0);
-  app()->setFirstResponder(&m_listController);
+  Container::activeApp()->setFirstResponder(&m_listController);
   return true;
 }
 
@@ -165,6 +165,6 @@ bool NestedMenuController::returnToPreviousMenu() {
   m_listController.setFirstSelectedRow(state.selectedRow());
   KDPoint scroll = m_selectableTableView.contentOffset();
   m_selectableTableView.setContentOffset(KDPoint(scroll.x(), state.verticalScroll()));
-  app()->setFirstResponder(&m_listController);
+  Container::activeApp()->setFirstResponder(&m_listController);
   return true;
 }

--- a/escher/src/nested_menu_controller.cpp
+++ b/escher/src/nested_menu_controller.cpp
@@ -1,5 +1,5 @@
 #include <escher/nested_menu_controller.h>
-#include <escher/app.h>
+#include <escher/container.h>
 #include <escher/metric.h>
 #include <assert.h>
 #include <string.h>

--- a/escher/src/responder.cpp
+++ b/escher/src/responder.cpp
@@ -69,10 +69,6 @@ App * Responder::app() const {
   while (rootResponder->parentResponder() != nullptr) {
     rootResponder = rootResponder->parentResponder();
   }
-  /* If we used RTTI we could use a dynamic_cast, which would be a lot more
-   * safe, as such:
-   * return dynamic_cast<App *>(rootResponder); */
    App * result = (App *)rootResponder;
-   assert(result->m_magic == App::Magic); // Poor man's RTTI
   return result;
 }

--- a/escher/src/responder.cpp
+++ b/escher/src/responder.cpp
@@ -61,7 +61,3 @@ Responder * Responder::commonAncestorWith(Responder * responder) {
   }
   return s;
 }
-
-App * Responder::app() const {
-  return Container::sharedContainer()->activeApp();
-}

--- a/escher/src/responder.cpp
+++ b/escher/src/responder.cpp
@@ -1,6 +1,5 @@
 #include <escher/responder.h>
-#include <escher/app.h>
-#include <escher/metric.h>
+#include <escher/container.h>
 #include <assert.h>
 
 Responder::Responder(Responder * parentResponder) :
@@ -63,12 +62,6 @@ Responder * Responder::commonAncestorWith(Responder * responder) {
   return s;
 }
 
-/* We assume the app is the root parent. */
 App * Responder::app() const {
-  const Responder * rootResponder = this;
-  while (rootResponder->parentResponder() != nullptr) {
-    rootResponder = rootResponder->parentResponder();
-  }
-   App * result = (App *)rootResponder;
-  return result;
+  return Container::sharedContainer()->activeApp();
 }

--- a/escher/src/selectable_table_view.cpp
+++ b/escher/src/selectable_table_view.cpp
@@ -1,5 +1,5 @@
 #include <escher/selectable_table_view.h>
-#include <escher/app.h>
+#include <escher/container.h>
 #include <escher/clipboard.h>
 #include <escher/metric.h>
 #include <assert.h>

--- a/escher/src/selectable_table_view.cpp
+++ b/escher/src/selectable_table_view.cpp
@@ -104,11 +104,7 @@ bool SelectableTableView::selectCellAtLocation(int i, int j, bool setFirstRespon
   if (cell) {
     // Update first responder
     if ((i != previousX || j != previousY) && setFirstResponder) {
-      if (cell->responder()) {
-        app()->setFirstResponder(cell->responder());
-      } else {
-        app()->setFirstResponder(this);
-      }
+      Container::activeApp()->setFirstResponder(cell->responder() ? cell->responder() : this);
     }
   }
 

--- a/escher/src/selectable_table_view.cpp
+++ b/escher/src/selectable_table_view.cpp
@@ -1,4 +1,5 @@
 #include <escher/selectable_table_view.h>
+#include <escher/app.h>
 #include <escher/clipboard.h>
 #include <escher/metric.h>
 #include <assert.h>

--- a/escher/src/stack_view_controller.cpp
+++ b/escher/src/stack_view_controller.cpp
@@ -2,7 +2,7 @@ extern "C" {
 #include <assert.h>
 }
 #include <escher/stack_view_controller.h>
-#include <escher/app.h>
+#include <escher/container.h>
 #include <escher/metric.h>
 
 StackViewController::ControllerView::ControllerView() :

--- a/escher/src/stack_view_controller.cpp
+++ b/escher/src/stack_view_controller.cpp
@@ -137,12 +137,12 @@ void StackViewController::setupActiveViewController() {
   m_view.setContentView(vc->view());
   vc->viewWillAppear();
   vc->setParentResponder(this);
-  app()->setFirstResponder(vc);
+  Container::activeApp()->setFirstResponder(vc);
 }
 
 void StackViewController::didBecomeFirstResponder() {
   ViewController * vc = m_childrenFrame[m_numberOfChildren-1].viewController();
-  app()->setFirstResponder(vc);
+  Container::activeApp()->setFirstResponder(vc);
 }
 
 bool StackViewController::handleEvent(Ion::Events::Event event) {

--- a/escher/src/tab_view_controller.cpp
+++ b/escher/src/tab_view_controller.cpp
@@ -3,7 +3,7 @@ extern "C" {
 }
 #include <escher/tab_view_controller.h>
 #include <escher/metric.h>
-#include <escher/app.h>
+#include <escher/container.h>
 
 TabViewController::ContentView::ContentView() :
   View(),

--- a/escher/src/tab_view_controller.cpp
+++ b/escher/src/tab_view_controller.cpp
@@ -75,14 +75,12 @@ int TabViewController::activeTab() const {
 }
 
 bool TabViewController::handleEvent(Ion::Events::Event event) {
-  if (event == Ion::Events::Back) {
-    if (app()->firstResponder() != this) {
-      app()->setFirstResponder(this);
+  App * app = Container::activeApp();
+  if (app->firstResponder() != this) {
+    if (event == Ion::Events::Back) {
+      app->setFirstResponder(this);
       return true;
     }
-    return false;
-  }
-  if (app()->firstResponder() != this) {
     return false;
   }
   if (event == Ion::Events::Left) {
@@ -116,7 +114,7 @@ void TabViewController::setActiveTab(int8_t i) {
     m_children[i]->viewWillAppear();
     m_view.m_tabView.setActiveIndex(i);
   }
-  app()->setFirstResponder(activeVC);
+  Container::activeApp()->setFirstResponder(activeVC);
   if (i  != m_dataSource->activeTab()) {
     m_children[m_dataSource->activeTab()]->viewDidDisappear();
     m_dataSource->setActiveTab(i);
@@ -132,7 +130,7 @@ void TabViewController::setSelectedTab(int8_t i) {
 }
 
 void TabViewController::didEnterResponderChain(Responder * previousResponder) {
-  app()->setFirstResponder(activeViewController());
+  Container::activeApp()->setFirstResponder(activeViewController());
 }
 
 void TabViewController::didBecomeFirstResponder() {

--- a/escher/src/text_area.cpp
+++ b/escher/src/text_area.cpp
@@ -1,4 +1,3 @@
-#include <escher/app.h>
 #include <escher/text_area.h>
 #include <escher/clipboard.h>
 #include <escher/text_input_helpers.h>
@@ -97,7 +96,7 @@ bool TextArea::handleEventWithText(const char * text, bool indentation, bool for
 bool TextArea::handleEvent(Ion::Events::Event event) {
   if (m_delegate != nullptr && m_delegate->textAreaDidReceiveEvent(this, event)) {
     return true;
-  } else if (handleBoxEvent(app(), event)) {
+  } else if (handleBoxEvent(event)) {
     return true;
   } else if (event == Ion::Events::Left) {
     return TextInput::moveCursorLeft();

--- a/escher/src/text_area.cpp
+++ b/escher/src/text_area.cpp
@@ -1,3 +1,4 @@
+#include <escher/app.h>
 #include <escher/text_area.h>
 #include <escher/clipboard.h>
 #include <escher/text_input_helpers.h>

--- a/escher/src/text_field.cpp
+++ b/escher/src/text_field.cpp
@@ -1,4 +1,3 @@
-#include <escher/app.h>
 #include <escher/text_field.h>
 #include <escher/text_input_helpers.h>
 #include <escher/clipboard.h>
@@ -278,7 +277,7 @@ void TextField::setEditing(bool isEditing, bool reinitDrafBuffer) {
 
 bool TextField::privateHandleEvent(Ion::Events::Event event) {
   // Handle Toolbox or Var event
-  if (handleBoxEvent(app(), event)) {
+  if (handleBoxEvent(event)) {
     if (!isEditing()) {
       setEditing(true);
     }

--- a/escher/src/text_field.cpp
+++ b/escher/src/text_field.cpp
@@ -1,3 +1,4 @@
+#include <escher/app.h>
 #include <escher/text_field.h>
 #include <escher/text_input_helpers.h>
 #include <escher/clipboard.h>

--- a/escher/src/text_input.cpp
+++ b/escher/src/text_input.cpp
@@ -1,4 +1,6 @@
 #include <escher/text_input.h>
+#include <ion/unicode/utf8_decoder.h>
+#include <ion/unicode/utf8_helper.h>
 #include <assert.h>
 
 /* TextInput::ContentView */

--- a/escher/src/warning_controller.cpp
+++ b/escher/src/warning_controller.cpp
@@ -1,5 +1,5 @@
 #include <escher/warning_controller.h>
-#include <escher/app.h>
+#include <escher/container.h>
 
 static inline KDCoordinate maxCoordinate(KDCoordinate x, KDCoordinate y) { return x > y ? x : y; }
 

--- a/escher/src/warning_controller.cpp
+++ b/escher/src/warning_controller.cpp
@@ -83,6 +83,6 @@ bool WarningController::handleEvent(Ion::Events::Event event) {
   if (event == Ion::Events::USBPlug || event == Ion::Events::USBEnumeration) {
     return false;
   }
-  app()->dismissModalViewController();
+  Container::activeApp()->dismissModalViewController();
   return true;
 }


### PR DESCRIPTION
The `app()` may now be accessed from Escher and from every `App`.
- In Escher, a global `app()` function is defined in [app.h](https://github.com/numworks/epsilon/blob/master/escher/include/escher/app.h) (actually in [container.h](https://github.com/numworks/epsilon/blob/master/escher/include/escher/app.h)) in the global namespace (Escher is not namespaced).
- In every `App` (except those in `Shared`), a global `app()` function is defined in app.h in the corresponding namespace, say `Graph` for `Graph::App`. Hence there is **no need to cast** the `app()` anymore.

Those `app()` functions are defined thanks to new static (it is indeed assumed that there is only one `(Apps)Container` instance) methods
  - `sharedContainer()` in the `Container` class of Escher and
  - `sharedAppContainer()` in the `AppsContainer` derived class.
More precisely, the Container class holds a static member variable `s_sharedContainer` that is initialized in the method `AppsContainer::run()`, that is after the construction of the `AppsContainer` and of all the `App`s. This means that **the `app()` functions must not be called during the construction of an `App`**.

The `Responder::app()` and `App::container()` methods have been removed.

From now on, an `App` and its members may be accessed directly through `app()` instead of passing pointers from constructors to constructors, up to the classes where they are needed.