### PR TITLE
[apps/code] Fix sandbox and input clash

### DIFF
--- a/apps/code/console_controller.cpp
+++ b/apps/code/console_controller.cpp
@@ -93,6 +93,11 @@ const char * ConsoleController::inputText(const char * prompt) {
   AppsContainer * appsContainer = AppsContainer::sharedAppsContainer();
   m_inputRunLoopActive = true;
 
+  // Hide the sandbox if it is displayed
+  if (sandboxIsDisplayed()) {
+    hideSandbox();
+  }
+
   const char * promptText = prompt;
   char * s = const_cast<char *>(prompt);
 


### PR DESCRIPTION
The command "squares()%input()" followed by text, OK, and a backspace
event broke an assertion on the consoleStore number of lines.