### PR TITLE
Use --gc-sections linker flag even when building with LTO

### DIFF
--- a/scripts/toolchain.arm-gcc.mak
+++ b/scripts/toolchain.arm-gcc.mak
@@ -20,7 +20,7 @@ endif
 
 ifeq ($(LTO),1)
 # Use link-time optimization if LTO=1
-SFLAGS += -flto
+SFLAGS += -flto -Wl,--gc-sections
 else
 # Otherwise, just get rid of unused symbols
 LDFLAGS += -Wl,--gc-sections


### PR DESCRIPTION
I noticed that --gc-sections is missing from the link flags in LTO mode. Adding it to match the non-LTO link flags saves more than 1 KB on my N0110 builds.