### PR TITLE
Code app: use a 32 KB Python heap instead of a 16 KB one

### DIFF
--- a/apps/code/app.h
+++ b/apps/code/app.h
@@ -74,7 +74,7 @@ private:
    * buffer here and we give to controllers that load Python environment. We
    * also memoize the last Python user to avoid re-initiating MicroPython when
    * unneeded. */
-  static constexpr int k_pythonHeapSize = 16384;
+  static constexpr int k_pythonHeapSize = 32768;
   char m_pythonHeap[k_pythonHeapSize];
   const void * m_pythonUser;
 


### PR DESCRIPTION
The Code app isn't the one with the largest size in RAM. As other apps stand at the time of this writing, this leaves room for expanding the Python heap without further reducing the general heap (section .heap), and thereby making the N0100/N0110 able to deal with larger (more accurately, "less small"...) scripts *relevant for school usage*.
See https://ti-pla.net/t22951 for the whole discussion. 32 KB still isn't enough, but at least, it will make Epsilon's MicroPython interpreter able to deal with scripts larger than those the 83PCE + TI-Python Adapter / 83PCE EP can deal with.