### PR TITLE
Remove LTO warnings

### DIFF
--- a/ion/src/device/n0110/drivers/board.cpp
+++ b/ion/src/device/n0110/drivers/board.cpp
@@ -5,7 +5,8 @@
 #include <regs/regs.h>
 #include <ion.h>
 
-extern void * InitialisationVector;
+typedef void(*ISR)(void);
+extern ISR InitialisationVector[];
 
 // Public Ion methods
 

--- a/ion/src/device/shared/usb/dfu_relocated.cpp
+++ b/ion/src/device/shared/usb/dfu_relocated.cpp
@@ -4,7 +4,7 @@
 #include <drivers/cache.h>
 #include "../drivers/timing.h"
 
-extern char _stack_end;
+extern const void * _stack_end;
 extern char _dfu_bootloader_flash_start;
 extern char _dfu_bootloader_flash_end;
 

--- a/liba/include/stdbool.h
+++ b/liba/include/stdbool.h
@@ -3,7 +3,7 @@
 
 #ifndef __cplusplus
 
-typedef char bool;
+typedef _Bool bool;
 
 #define true 1
 #define false 0


### PR DESCRIPTION
When building with LTO (which is on by default), the compiler makes sure all type definitions are coherent. We had a few mismatches (`char` vs `_Bool`, `void *` vs `char *`).

Mismatching types had the same size, so in practice this shouldn't have had any negative impact aside from the nasty warnings at link time.