### PR TITLE
[poincare/normcdf2] Fix shallowReduce (mu and var indexes were wrong)

### DIFF
--- a/poincare/include/poincare/norm_cdf2.h
+++ b/poincare/include/poincare/norm_cdf2.h
@@ -22,6 +22,8 @@ public:
   Type type() const override { return Type::NormCDF2; }
   Sign sign(Context * context) const override { return Sign::Positive; }
   Expression setSign(Sign s, ReductionContext reductionContext) override;
+  int muIndex() const override { return 2; }
+  int varIndex() const override { return 3; }
 
 private:
   // Layout

--- a/poincare/include/poincare/normal_distribution_function.h
+++ b/poincare/include/poincare/normal_distribution_function.h
@@ -8,6 +8,9 @@ namespace Poincare {
 // NormalDistributionFunctions are NormCDF, NormCDF2, InvNorm and NormPDF
 
 class NormalDistributionFunctionNode : public ExpressionNode {
+public:
+  virtual int muIndex() const { return 1; }
+  virtual int varIndex() const { return 2; }
 private:
   // Simplication
   Expression shallowReduce(ReductionContext reductionContext) override;
@@ -19,6 +22,10 @@ class NormalDistributionFunction : public Expression {
 public:
   NormalDistributionFunction(const NormalDistributionFunctionNode * n) : Expression(n) {}
   Expression shallowReduce(Context * context, bool * stopReduction = nullptr);
+private:
+  int muIndex() const { return node()->muIndex(); }
+  int varIndex() const { return node()->varIndex(); }
+  NormalDistributionFunctionNode * node() const { return static_cast<NormalDistributionFunctionNode *>(Expression::node()); }
 };
 
 }

--- a/poincare/src/normal_distribution_function.cpp
+++ b/poincare/src/normal_distribution_function.cpp
@@ -19,8 +19,8 @@ Expression NormalDistributionFunction::shallowReduce(Context * context, bool * s
     }
   }
 
-  Expression mu = childAtIndex(1);
-  Expression var = childAtIndex(2);
+  Expression mu = childAtIndex(muIndex());
+  Expression var = childAtIndex(varIndex());
 
   // Check mu and var
   bool muAndVarOK = false;

--- a/poincare/test/simplification.cpp
+++ b/poincare/test/simplification.cpp
@@ -1082,4 +1082,7 @@ QUIZ_CASE(poincare_probability) {
   assert_parsed_expression_simplify_to("invnorm(3/4,2,random())", "invnorm(3/4,2,random())"); // random can be 0
   assert_parsed_expression_simplify_to("invnorm(0.5,2,0)", Undefined::Name());
   assert_parsed_expression_simplify_to("invnorm(0.5,2,-1)", Undefined::Name());
+  assert_parsed_expression_simplify_to("normcdf(2,0,1)", "normcdf(2,0,1)");
+  assert_parsed_expression_simplify_to("normcdf2(1,2,0,1)", "normcdf2(1,2,0,1)");
+  assert_parsed_expression_simplify_to("normpdf(2,0,1)", "normpdf(2,0,1)");
 }


### PR DESCRIPTION
normcdf2(1,2,0,1) was shallowReduced to undef in the Calculation app