### PR TITLE
[poincare/randint] Fix randint simplification

### DIFF
--- a/poincare/include/poincare/randint.h
+++ b/poincare/include/poincare/randint.h
@@ -6,6 +6,7 @@
 namespace Poincare {
 
 class RandintNode /*final*/ : public ExpressionNode  {
+  friend class Randint;
 public:
 
   // TreeNode
@@ -33,7 +34,7 @@ private:
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return templateApproximate<double>(context, complexFormat, angleUnit);
   }
-  template <typename T> Evaluation<T> templateApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
+  template <typename T> Evaluation<T> templateApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit, bool * inputIsUndefined = nullptr) const;
   // Simplification
   Expression shallowReduce(ReductionContext reductionContext) override;
   LayoutShape leftLayoutShape() const override { return LayoutShape::MoreLetters; };

--- a/poincare/src/randint.cpp
+++ b/poincare/src/randint.cpp
@@ -49,21 +49,16 @@ Expression Randint::shallowReduce(ExpressionNode::ReductionContext reductionCont
   if (e.isUndefined()) {
     return e;
   }
-  float eval = approximateToScalar<float>(reductionContext.context() , reductionContext.complexFormat() , reductionContext.angleUnit() );
+  double eval = approximateToScalar<double>(reductionContext.context() , reductionContext.complexFormat() , reductionContext.angleUnit() );
   if (std::isnan(eval)) {
     /* The result might be NAN because we are reducing a function's expression
      * which depends on x. We thus do not want to replace too early with
      * undefined. */
     return *this;
   }
-  Expression result;
-  if (std::isinf(eval)) {
-    result = Infinity::Builder(eval < 0);
-  } else {
-    result = Rational::Builder(Integer((int)eval));
-  }
+  Expression result = Number::DecimalNumber(eval);
   replaceWithInPlace(result);
-  return result;
+  return result.shallowReduce(reductionContext);
 }
 
 }

--- a/poincare/src/randint.cpp
+++ b/poincare/src/randint.cpp
@@ -36,7 +36,20 @@ template <typename T> Evaluation<T> RandintNode::templateApproximate(Context * c
   }
   T a = aInput.toScalar();
   T b = bInput.toScalar();
-  if (std::isnan(a) || std::isnan(b) || a != std::round(a) || b != std::round(b) || a > b || std::isinf(a) || std::isinf(b)) {
+  /* randint is undefined if:
+   * - one of the bounds is NAN or INF
+   * - the last bound is lesser than the first one
+   * - one of the input cannot be represented by an integer
+   *   (here we don't test a != std::round(a) because we want the inputs to
+   *   hold all digits so to be representable as an int)
+   * - the range between bounds is too large to be covered by all double between
+   *   0 and 1 - we can't map the integers of the range with all representable
+   *   double numbers from 0 to 1.
+   *  */
+  if (std::isnan(a) || std::isnan(b) || std::isinf(a) || std::isinf(b)
+      || a > b
+      || a != (int)a || b != (int)b
+      || (Expression::Epsilon<T>()*(b+1.0-a) > 1.0)) {
     return Complex<T>::Undefined();
   }
   T result = std::floor(Random::random<T>()*(b+1.0-a)+a);

--- a/poincare/test/simplification.cpp
+++ b/poincare/test/simplification.cpp
@@ -337,6 +337,8 @@ QUIZ_CASE(poincare_simplification_randint) {
   assert_parsed_expression_simplify_to("randint(1, inf)", "undef");
   assert_parsed_expression_simplify_to("randint(-inf, 3)", "undef");
   assert_parsed_expression_simplify_to("randint(4, 3)", "undef");
+  assert_parsed_expression_simplify_to("randint(2, 23345678909876545678)", "undef");
+  assert_parsed_expression_simplify_to("randint(123456789876543, 123456789876543+10)", "undef");
 }
 
 QUIZ_CASE(poincare_simplification_function) {


### PR DESCRIPTION
When reducing f(x)=randint(floor(x),floor(10x)), the randint
simplification would give undef because x is undefined at the time of
the reduction