### PR TITLE
Some post version 12 cleaning

### DIFF
--- a/apps/graph/Makefile
+++ b/apps/graph/Makefile
@@ -3,7 +3,7 @@ app_headers += apps/graph/app.h
 
 app_graph_src = $(addprefix apps/graph/,\
   app.cpp \
-  cartesian_function_store.cpp \
+  continuous_function_store.cpp \
   graph/banner_view.cpp \
   graph/calculation_graph_controller.cpp \
   graph/calculation_parameter_controller.cpp \

--- a/apps/graph/app.cpp
+++ b/apps/graph/app.cpp
@@ -33,7 +33,7 @@ App * App::Snapshot::unpack(Container * container) {
 
 void App::Snapshot::reset() {
   Shared::FunctionApp::Snapshot::reset();
-  for (int i = 0; i < Shared::CartesianFunction::k_numberOfPlotTypes; i++) {
+  for (int i = 0; i < Shared::ContinuousFunction::k_numberOfPlotTypes; i++) {
     m_interval[i].reset();
   }
 }

--- a/apps/graph/app.cpp
+++ b/apps/graph/app.cpp
@@ -62,7 +62,7 @@ App::App(Snapshot * snapshot) :
   m_listFooter(&m_listHeader, &m_listController, &m_listController, ButtonRowController::Position::Bottom, ButtonRowController::Style::EmbossedGrey),
   m_listHeader(&m_listStackViewController, &m_listFooter, &m_listController),
   m_listStackViewController(&m_tabViewController, &m_listHeader),
-  m_graphController(&m_graphAlternateEmptyViewController, this, snapshot->functionStore(), snapshot->graphRange(), snapshot->cursor(), snapshot->indexFunctionSelectedByCursor(), snapshot->modelVersion(), snapshot->rangeVersion(), snapshot->angleUnitVersion(), &m_graphHeader),
+  m_graphController(&m_graphAlternateEmptyViewController, this, snapshot->graphRange(), snapshot->cursor(), snapshot->indexFunctionSelectedByCursor(), snapshot->modelVersion(), snapshot->rangeVersion(), snapshot->angleUnitVersion(), &m_graphHeader),
   m_graphAlternateEmptyViewController(&m_graphHeader, &m_graphController, &m_graphController),
   m_graphHeader(&m_graphStackViewController, &m_graphAlternateEmptyViewController, &m_graphController),
   m_graphStackViewController(&m_tabViewController, &m_graphHeader),

--- a/apps/graph/app.cpp
+++ b/apps/graph/app.cpp
@@ -43,14 +43,6 @@ App::Descriptor * App::Snapshot::descriptor() {
   return &descriptor;
 }
 
-CartesianFunctionStore * App::Snapshot::functionStore() {
-  return &m_functionStore;
-}
-
-InteractiveCurveViewRange * App::Snapshot::graphRange() {
-  return &m_graphRange;
-}
-
 void App::Snapshot::tidy() {
   m_functionStore.tidy();
   m_graphRange.setDelegate(nullptr);

--- a/apps/graph/app.h
+++ b/apps/graph/app.h
@@ -44,7 +44,7 @@ public:
   }
   CodePoint XNT() override;
   NestedMenuController * variableBoxForInputEventHandler(InputEventHandler * textInput) override;
-  CartesianFunctionStore * functionStore() override { return static_cast<CartesianFunctionStore *>(Shared::FunctionApp::functionStore()); }
+  CartesianFunctionStore * functionStore() override { return snapshot()->functionStore(); }
   Shared::Interval * intervalForType(Shared::CartesianFunction::PlotType plotType) {
     return snapshot()->intervalForType(plotType);
   }

--- a/apps/graph/app.h
+++ b/apps/graph/app.h
@@ -2,7 +2,7 @@
 #define GRAPH_APP_H
 
 #include <escher.h>
-#include "cartesian_function_store.h"
+#include "continuous_function_store.h"
 #include "graph/graph_controller.h"
 #include "list/list_controller.h"
 #include "values/values_controller.h"

--- a/apps/graph/app.h
+++ b/apps/graph/app.h
@@ -27,14 +27,14 @@ public:
     Descriptor * descriptor() override;
     ContinuousFunctionStore * functionStore() override { return &m_functionStore; }
     Shared::InteractiveCurveViewRange * graphRange() { return &m_graphRange; }
-    Shared::Interval * intervalForType(Shared::CartesianFunction::PlotType plotType) {
+    Shared::Interval * intervalForType(Shared::ContinuousFunction::PlotType plotType) {
       return m_interval + static_cast<size_t>(plotType);
     }
   private:
     void tidy() override;
     ContinuousFunctionStore m_functionStore;
     Shared::InteractiveCurveViewRange m_graphRange;
-    Shared::Interval m_interval[Shared::CartesianFunction::k_numberOfPlotTypes];
+    Shared::Interval m_interval[Shared::ContinuousFunction::k_numberOfPlotTypes];
   };
   static App * app() {
     return static_cast<App *>(Container::activeApp());
@@ -45,7 +45,7 @@ public:
   CodePoint XNT() override;
   NestedMenuController * variableBoxForInputEventHandler(InputEventHandler * textInput) override;
   ContinuousFunctionStore * functionStore() override { return snapshot()->functionStore(); }
-  Shared::Interval * intervalForType(Shared::CartesianFunction::PlotType plotType) {
+  Shared::Interval * intervalForType(Shared::ContinuousFunction::PlotType plotType) {
     return snapshot()->intervalForType(plotType);
   }
   ValuesController * valuesController() override {

--- a/apps/graph/app.h
+++ b/apps/graph/app.h
@@ -25,8 +25,8 @@ public:
     App * unpack(Container * container) override;
     void reset() override;
     Descriptor * descriptor() override;
-    CartesianFunctionStore * functionStore() override;
-    Shared::InteractiveCurveViewRange * graphRange();
+    CartesianFunctionStore * functionStore() override { return &m_functionStore; }
+    Shared::InteractiveCurveViewRange * graphRange() { return &m_graphRange; }
     Shared::Interval * intervalForType(Shared::CartesianFunction::PlotType plotType) {
       return m_interval + static_cast<size_t>(plotType);
     }

--- a/apps/graph/app.h
+++ b/apps/graph/app.h
@@ -25,14 +25,14 @@ public:
     App * unpack(Container * container) override;
     void reset() override;
     Descriptor * descriptor() override;
-    CartesianFunctionStore * functionStore() override { return &m_functionStore; }
+    ContinuousFunctionStore * functionStore() override { return &m_functionStore; }
     Shared::InteractiveCurveViewRange * graphRange() { return &m_graphRange; }
     Shared::Interval * intervalForType(Shared::CartesianFunction::PlotType plotType) {
       return m_interval + static_cast<size_t>(plotType);
     }
   private:
     void tidy() override;
-    CartesianFunctionStore m_functionStore;
+    ContinuousFunctionStore m_functionStore;
     Shared::InteractiveCurveViewRange m_graphRange;
     Shared::Interval m_interval[Shared::CartesianFunction::k_numberOfPlotTypes];
   };
@@ -44,7 +44,7 @@ public:
   }
   CodePoint XNT() override;
   NestedMenuController * variableBoxForInputEventHandler(InputEventHandler * textInput) override;
-  CartesianFunctionStore * functionStore() override { return snapshot()->functionStore(); }
+  ContinuousFunctionStore * functionStore() override { return snapshot()->functionStore(); }
   Shared::Interval * intervalForType(Shared::CartesianFunction::PlotType plotType) {
     return snapshot()->intervalForType(plotType);
   }

--- a/apps/graph/cartesian_function_store.cpp
+++ b/apps/graph/cartesian_function_store.cpp
@@ -9,7 +9,7 @@ using namespace Shared;
 
 namespace Graph {
 
-int CartesianFunctionStore::numberOfActiveFunctionsOfType(CartesianFunction::PlotType plotType) const {
+int ContinuousFunctionStore::numberOfActiveFunctionsOfType(CartesianFunction::PlotType plotType) const {
   int count = 0;
   for (int i = 0; i < numberOfActiveFunctions(); i++) {
     Ion::Storage::Record record = activeRecordAtIndex(i);
@@ -19,7 +19,7 @@ int CartesianFunctionStore::numberOfActiveFunctionsOfType(CartesianFunction::Plo
   return count;
 }
 
-Ion::Storage::Record CartesianFunctionStore::activeRecordOfTypeAtIndex(CartesianFunction::PlotType plotType, int index) const {
+Ion::Storage::Record ContinuousFunctionStore::activeRecordOfTypeAtIndex(CartesianFunction::PlotType plotType, int index) const {
   int count = 0;
   Ion::Storage::Record record;
   for (int i = 0; i < numberOfActiveFunctions(); i++) {
@@ -35,19 +35,19 @@ Ion::Storage::Record CartesianFunctionStore::activeRecordOfTypeAtIndex(Cartesian
   return record;
 }
 
-Ion::Storage::Record::ErrorStatus CartesianFunctionStore::addEmptyModel() {
+Ion::Storage::Record::ErrorStatus ContinuousFunctionStore::addEmptyModel() {
   Ion::Storage::Record::ErrorStatus error;
   CartesianFunction newModel = CartesianFunction::NewModel(&error);
   return error;
 }
 
-ExpressionModelHandle * CartesianFunctionStore::setMemoizedModelAtIndex(int cacheIndex, Ion::Storage::Record record) const {
+ExpressionModelHandle * ContinuousFunctionStore::setMemoizedModelAtIndex(int cacheIndex, Ion::Storage::Record record) const {
   assert(cacheIndex >= 0 && cacheIndex < maxNumberOfMemoizedModels());
   m_functions[cacheIndex] = CartesianFunction(record);
   return &m_functions[cacheIndex];
 }
 
-ExpressionModelHandle * CartesianFunctionStore::memoizedModelAtIndex(int cacheIndex) const {
+ExpressionModelHandle * ContinuousFunctionStore::memoizedModelAtIndex(int cacheIndex) const {
   assert(cacheIndex >= 0 && cacheIndex < maxNumberOfMemoizedModels());
   return &m_functions[cacheIndex];
 }

--- a/apps/graph/cartesian_function_store.h
+++ b/apps/graph/cartesian_function_store.h
@@ -8,7 +8,7 @@
 
 namespace Graph {
 
-class CartesianFunctionStore : public Shared::FunctionStore {
+class ContinuousFunctionStore : public Shared::FunctionStore {
 public:
   Shared::ExpiringPointer<Shared::CartesianFunction> modelForRecord(Ion::Storage::Record record) const { return Shared::ExpiringPointer<Shared::CartesianFunction>(static_cast<Shared::CartesianFunction *>(privateModelForRecord(record))); }
   int numberOfActiveFunctionsOfType(Shared::CartesianFunction::PlotType plotType) const;

--- a/apps/graph/continuous_function_store.cpp
+++ b/apps/graph/continuous_function_store.cpp
@@ -1,4 +1,4 @@
-#include "cartesian_function_store.h"
+#include "continuous_function_store.h"
 extern "C" {
 #include <assert.h>
 #include <stddef.h>

--- a/apps/graph/continuous_function_store.cpp
+++ b/apps/graph/continuous_function_store.cpp
@@ -9,22 +9,22 @@ using namespace Shared;
 
 namespace Graph {
 
-int ContinuousFunctionStore::numberOfActiveFunctionsOfType(CartesianFunction::PlotType plotType) const {
+int ContinuousFunctionStore::numberOfActiveFunctionsOfType(ContinuousFunction::PlotType plotType) const {
   int count = 0;
   for (int i = 0; i < numberOfActiveFunctions(); i++) {
     Ion::Storage::Record record = activeRecordAtIndex(i);
-    ExpiringPointer<CartesianFunction> function = modelForRecord(record);
+    ExpiringPointer<ContinuousFunction> function = modelForRecord(record);
     count += (plotType == function->plotType());
   }
   return count;
 }
 
-Ion::Storage::Record ContinuousFunctionStore::activeRecordOfTypeAtIndex(CartesianFunction::PlotType plotType, int index) const {
+Ion::Storage::Record ContinuousFunctionStore::activeRecordOfTypeAtIndex(ContinuousFunction::PlotType plotType, int index) const {
   int count = 0;
   Ion::Storage::Record record;
   for (int i = 0; i < numberOfActiveFunctions(); i++) {
     record = activeRecordAtIndex(i);
-    ExpiringPointer<CartesianFunction> function = modelForRecord(record);
+    ExpiringPointer<ContinuousFunction> function = modelForRecord(record);
     if (plotType == function->plotType()) {
       if (count == index) {
         break;
@@ -37,13 +37,13 @@ Ion::Storage::Record ContinuousFunctionStore::activeRecordOfTypeAtIndex(Cartesia
 
 Ion::Storage::Record::ErrorStatus ContinuousFunctionStore::addEmptyModel() {
   Ion::Storage::Record::ErrorStatus error;
-  CartesianFunction newModel = CartesianFunction::NewModel(&error);
+  ContinuousFunction newModel = ContinuousFunction::NewModel(&error);
   return error;
 }
 
 ExpressionModelHandle * ContinuousFunctionStore::setMemoizedModelAtIndex(int cacheIndex, Ion::Storage::Record record) const {
   assert(cacheIndex >= 0 && cacheIndex < maxNumberOfMemoizedModels());
-  m_functions[cacheIndex] = CartesianFunction(record);
+  m_functions[cacheIndex] = ContinuousFunction(record);
   return &m_functions[cacheIndex];
 }
 

--- a/apps/graph/continuous_function_store.cpp
+++ b/apps/graph/continuous_function_store.cpp
@@ -9,32 +9,6 @@ using namespace Shared;
 
 namespace Graph {
 
-int ContinuousFunctionStore::numberOfActiveFunctionsOfType(ContinuousFunction::PlotType plotType) const {
-  int count = 0;
-  for (int i = 0; i < numberOfActiveFunctions(); i++) {
-    Ion::Storage::Record record = activeRecordAtIndex(i);
-    ExpiringPointer<ContinuousFunction> function = modelForRecord(record);
-    count += (plotType == function->plotType());
-  }
-  return count;
-}
-
-Ion::Storage::Record ContinuousFunctionStore::activeRecordOfTypeAtIndex(ContinuousFunction::PlotType plotType, int index) const {
-  int count = 0;
-  Ion::Storage::Record record;
-  for (int i = 0; i < numberOfActiveFunctions(); i++) {
-    record = activeRecordAtIndex(i);
-    ExpiringPointer<ContinuousFunction> function = modelForRecord(record);
-    if (plotType == function->plotType()) {
-      if (count == index) {
-        break;
-      }
-      count++;
-    }
-  }
-  return record;
-}
-
 Ion::Storage::Record::ErrorStatus ContinuousFunctionStore::addEmptyModel() {
   Ion::Storage::Record::ErrorStatus error;
   ContinuousFunction newModel = ContinuousFunction::NewModel(&error);

--- a/apps/graph/continuous_function_store.h
+++ b/apps/graph/continuous_function_store.h
@@ -10,15 +10,15 @@ namespace Graph {
 
 class ContinuousFunctionStore : public Shared::FunctionStore {
 public:
-  Shared::ExpiringPointer<Shared::CartesianFunction> modelForRecord(Ion::Storage::Record record) const { return Shared::ExpiringPointer<Shared::CartesianFunction>(static_cast<Shared::CartesianFunction *>(privateModelForRecord(record))); }
-  int numberOfActiveFunctionsOfType(Shared::CartesianFunction::PlotType plotType) const;
-  Ion::Storage::Record activeRecordOfTypeAtIndex(Shared::CartesianFunction::PlotType plotType, int index) const;
+  Shared::ExpiringPointer<Shared::ContinuousFunction> modelForRecord(Ion::Storage::Record record) const { return Shared::ExpiringPointer<Shared::ContinuousFunction>(static_cast<Shared::ContinuousFunction *>(privateModelForRecord(record))); }
+  int numberOfActiveFunctionsOfType(Shared::ContinuousFunction::PlotType plotType) const;
+  Ion::Storage::Record activeRecordOfTypeAtIndex(Shared::ContinuousFunction::PlotType plotType, int index) const;
 private:
   Ion::Storage::Record::ErrorStatus addEmptyModel() override;
   const char * modelExtension() const override { return Ion::Storage::funcExtension; }
   Shared::ExpressionModelHandle * setMemoizedModelAtIndex(int cacheIndex, Ion::Storage::Record record) const override;
   Shared::ExpressionModelHandle * memoizedModelAtIndex(int cacheIndex) const override;
-  mutable Shared::CartesianFunction m_functions[k_maxNumberOfMemoizedModels];
+  mutable Shared::ContinuousFunction m_functions[k_maxNumberOfMemoizedModels];
 };
 
 }

--- a/apps/graph/continuous_function_store.h
+++ b/apps/graph/continuous_function_store.h
@@ -8,14 +8,22 @@ namespace Graph {
 
 class ContinuousFunctionStore : public Shared::FunctionStore {
 public:
+  int numberOfActiveFunctionsOfType(Shared::ContinuousFunction::PlotType plotType) const {
+    return numberOfModelsSatisfyingTest(&isFunctionActiveOfType, &plotType);
+  }
+  Ion::Storage::Record activeRecordOfTypeAtIndex(Shared::ContinuousFunction::PlotType plotType, int i) const {
+    return recordSatisfyingTestAtIndex(i, &isFunctionActiveOfType, &plotType);
+  }
   Shared::ExpiringPointer<Shared::ContinuousFunction> modelForRecord(Ion::Storage::Record record) const { return Shared::ExpiringPointer<Shared::ContinuousFunction>(static_cast<Shared::ContinuousFunction *>(privateModelForRecord(record))); }
-  int numberOfActiveFunctionsOfType(Shared::ContinuousFunction::PlotType plotType) const;
-  Ion::Storage::Record activeRecordOfTypeAtIndex(Shared::ContinuousFunction::PlotType plotType, int index) const;
 private:
   Ion::Storage::Record::ErrorStatus addEmptyModel() override;
   const char * modelExtension() const override { return Ion::Storage::funcExtension; }
   Shared::ExpressionModelHandle * setMemoizedModelAtIndex(int cacheIndex, Ion::Storage::Record record) const override;
   Shared::ExpressionModelHandle * memoizedModelAtIndex(int cacheIndex) const override;
+  static bool isFunctionActiveOfType(Shared::ExpressionModelHandle * model, void * context) {
+    Shared::ContinuousFunction::PlotType plotType = *static_cast<Shared::ContinuousFunction::PlotType *>(context);
+    return isFunctionActive(model, context) && plotType == static_cast<Shared::ContinuousFunction *>(model)->plotType();
+  }
   mutable Shared::ContinuousFunction m_functions[k_maxNumberOfMemoizedModels];
 };
 

--- a/apps/graph/continuous_function_store.h
+++ b/apps/graph/continuous_function_store.h
@@ -1,10 +1,8 @@
 #ifndef GRAPH_CONTINUOUS_FUNCTION_STORE_H
 #define GRAPH_CONTINUOUS_FUNCTION_STORE_H
 
-#include "../shared/cartesian_function.h"
 #include "../shared/function_store.h"
-#include <stdint.h>
-#include <escher.h>
+#include "../shared/continuous_function.h"
 
 namespace Graph {
 

--- a/apps/graph/continuous_function_store.h
+++ b/apps/graph/continuous_function_store.h
@@ -1,5 +1,5 @@
-#ifndef GRAPH_CARTESIAN_FUNCTION_STORE_H
-#define GRAPH_CARTESIAN_FUNCTION_STORE_H
+#ifndef GRAPH_CONTINUOUS_FUNCTION_STORE_H
+#define GRAPH_CONTINUOUS_FUNCTION_STORE_H
 
 #include "../shared/cartesian_function.h"
 #include "../shared/function_store.h"

--- a/apps/graph/graph/calculation_graph_controller.cpp
+++ b/apps/graph/graph/calculation_graph_controller.cpp
@@ -27,7 +27,7 @@ void CalculationGraphController::viewWillAppear() {
     m_graphView->setBannerView(&m_defaultBannerView);
   } else {
     m_isActive = true;
-    assert(App::app()->functionStore()->modelForRecord(m_record)->plotType() == Shared::CartesianFunction::PlotType::Cartesian);
+    assert(App::app()->functionStore()->modelForRecord(m_record)->plotType() == Shared::ContinuousFunction::PlotType::Cartesian);
     m_cursor->moveTo(pointOfInterest.x1(), pointOfInterest.x1(), pointOfInterest.x2());
     m_graphRange->panToMakePointVisible(m_cursor->x(), m_cursor->y(), cursorTopMarginRatio(), k_cursorRightMarginRatio, cursorBottomMarginRatio(), k_cursorLeftMarginRatio);
     m_bannerView->setNumberOfSubviews(Shared::XYBannerView::k_numberOfSubviews);
@@ -75,7 +75,7 @@ bool CalculationGraphController::moveCursorHorizontally(int direction) {
   if (std::isnan(newPointOfInterest.x1())) {
     return false;
   }
-  assert(App::app()->functionStore()->modelForRecord(m_record)->plotType() == Shared::CartesianFunction::PlotType::Cartesian);
+  assert(App::app()->functionStore()->modelForRecord(m_record)->plotType() == Shared::ContinuousFunction::PlotType::Cartesian);
   m_cursor->moveTo(newPointOfInterest.x1(), newPointOfInterest.x1(), newPointOfInterest.x2());
   return true;
 }

--- a/apps/graph/graph/calculation_graph_controller.cpp
+++ b/apps/graph/graph/calculation_graph_controller.cpp
@@ -53,7 +53,7 @@ Coordinate2D<double> CalculationGraphController::computeNewPointOfInterestFromAb
   return computeNewPointOfInterest(start, step, max, textFieldDelegateApp()->localContext());
 }
 
-CartesianFunctionStore * CalculationGraphController::functionStore() const {
+ContinuousFunctionStore * CalculationGraphController::functionStore() const {
   return App::app()->functionStore();
 }
 

--- a/apps/graph/graph/calculation_graph_controller.h
+++ b/apps/graph/graph/calculation_graph_controller.h
@@ -5,7 +5,7 @@
 #include "banner_view.h"
 #include "../../shared/simple_interactive_curve_view_controller.h"
 #include "../../shared/function_banner_delegate.h"
-#include "../cartesian_function_store.h"
+#include "../continuous_function_store.h"
 
 namespace Graph {
 

--- a/apps/graph/graph/calculation_graph_controller.h
+++ b/apps/graph/graph/calculation_graph_controller.h
@@ -21,7 +21,7 @@ protected:
   BannerView * bannerView() override { return m_bannerView; }
   void reloadBannerView() override;
   Poincare::Coordinate2D<double> computeNewPointOfInterestFromAbscissa(double start, int direction);
-  CartesianFunctionStore * functionStore() const;
+  ContinuousFunctionStore * functionStore() const;
   virtual Poincare::Coordinate2D<double> computeNewPointOfInterest(double start, double step, double max, Poincare::Context * context) = 0;
   GraphView * m_graphView;
   BannerView * m_bannerView;

--- a/apps/graph/graph/calculation_parameter_controller.cpp
+++ b/apps/graph/graph/calculation_parameter_controller.cpp
@@ -117,7 +117,7 @@ void CalculationParameterController::setRecord(Ion::Storage::Record record) {
 }
 
 bool CalculationParameterController::shouldDisplayIntersection() const {
-  CartesianFunctionStore * store = App::app()->functionStore();
+  ContinuousFunctionStore * store = App::app()->functionStore();
   int numberOfCartesianFunctions = store->numberOfActiveFunctionsOfType(Shared::CartesianFunction::PlotType::Cartesian);
   // Intersection row is displayed when all functions are cartesian and there are least two of them
   // TODO: compute intersections between polar/parametric/cartesian functions?

--- a/apps/graph/graph/calculation_parameter_controller.cpp
+++ b/apps/graph/graph/calculation_parameter_controller.cpp
@@ -118,7 +118,7 @@ void CalculationParameterController::setRecord(Ion::Storage::Record record) {
 
 bool CalculationParameterController::shouldDisplayIntersection() const {
   ContinuousFunctionStore * store = App::app()->functionStore();
-  int numberOfCartesianFunctions = store->numberOfActiveFunctionsOfType(Shared::CartesianFunction::PlotType::Cartesian);
+  int numberOfCartesianFunctions = store->numberOfActiveFunctionsOfType(Shared::ContinuousFunction::PlotType::Cartesian);
   // Intersection row is displayed when all functions are cartesian and there are least two of them
   // TODO: compute intersections between polar/parametric/cartesian functions?
   return numberOfCartesianFunctions > 1 && numberOfCartesianFunctions == store->numberOfActiveFunctions();

--- a/apps/graph/graph/calculation_parameter_controller.h
+++ b/apps/graph/graph/calculation_parameter_controller.h
@@ -2,7 +2,6 @@
 #define GRAPH_CALCULATION_PARAMETER_CONTROLLER_H
 
 #include <escher.h>
-#include "../cartesian_function_store.h"
 #include "preimage_parameter_controller.h"
 #include "tangent_graph_controller.h"
 #include "extremum_graph_controller.h"

--- a/apps/graph/graph/curve_parameter_controller.cpp
+++ b/apps/graph/graph/curve_parameter_controller.cpp
@@ -81,8 +81,8 @@ void CurveParameterController::viewWillAppear() {
 }
 
 bool CurveParameterController::shouldDisplayCalculationAndDerivative() const {
-  Shared::ExpiringPointer<CartesianFunction> f = App::app()->functionStore()->modelForRecord(m_record);
-  return f->plotType() == CartesianFunction::PlotType::Cartesian;
+  Shared::ExpiringPointer<ContinuousFunction> f = App::app()->functionStore()->modelForRecord(m_record);
+  return f->plotType() == ContinuousFunction::PlotType::Cartesian;
 }
 
 int CurveParameterController::cellIndex(int visibleCellIndex) const {

--- a/apps/graph/graph/graph_controller.cpp
+++ b/apps/graph/graph/graph_controller.cpp
@@ -9,10 +9,10 @@ namespace Graph {
 static inline float minFloat(float x, float y) { return x < y ? x : y; }
 static inline float maxFloat(float x, float y) { return x > y ? x : y; }
 
-GraphController::GraphController(Responder * parentResponder, ::InputEventHandlerDelegate * inputEventHandlerDelegate, CartesianFunctionStore * functionStore, Shared::InteractiveCurveViewRange * curveViewRange, CurveViewCursor * cursor, int * indexFunctionSelectedByCursor, uint32_t * modelVersion, uint32_t * rangeVersion, Poincare::Preferences::AngleUnit * angleUnitVersion, ButtonRowController * header) :
+GraphController::GraphController(Responder * parentResponder, ::InputEventHandlerDelegate * inputEventHandlerDelegate, Shared::InteractiveCurveViewRange * curveViewRange, CurveViewCursor * cursor, int * indexFunctionSelectedByCursor, uint32_t * modelVersion, uint32_t * rangeVersion, Poincare::Preferences::AngleUnit * angleUnitVersion, ButtonRowController * header) :
   FunctionGraphController(parentResponder, inputEventHandlerDelegate, header, curveViewRange, &m_view, cursor, indexFunctionSelectedByCursor, modelVersion, rangeVersion, angleUnitVersion),
   m_bannerView(this, inputEventHandlerDelegate, this),
-  m_view(functionStore, curveViewRange, m_cursor, &m_bannerView, &m_cursorView),
+  m_view(curveViewRange, m_cursor, &m_bannerView, &m_cursorView),
   m_graphRange(curveViewRange),
   m_curveParameterController(inputEventHandlerDelegate, curveViewRange, &m_bannerView, m_cursor, &m_view, this),
   m_displayDerivativeInBanner(false)

--- a/apps/graph/graph/graph_controller.cpp
+++ b/apps/graph/graph/graph_controller.cpp
@@ -34,7 +34,7 @@ void GraphController::viewWillAppear() {
   selectFunctionWithCursor(indexFunctionSelectedByCursor());
 }
 
-void GraphController::interestingFunctionRange(ExpiringPointer<CartesianFunction> f, float tMin, float tMax, float step, float * xm, float * xM, float * ym, float * yM) const {
+void GraphController::interestingFunctionRange(ExpiringPointer<ContinuousFunction> f, float tMin, float tMax, float step, float * xm, float * xM, float * ym, float * yM) const {
   Poincare::Context * context = textFieldDelegateApp()->localContext();
   const int balancedBound = std::floor((tMax-tMin)/2/step);
   for (int j = -balancedBound; j <= balancedBound ; j++) {
@@ -60,8 +60,8 @@ void GraphController::interestingRanges(float * xm, float * xM, float * ym, floa
   if (displaysNonCartesianFunctions()) {
     const int functionsCount = functionStore()->numberOfActiveFunctions();
     for (int i = 0; i < functionsCount; i++) {
-      ExpiringPointer<CartesianFunction> f = functionStore()->modelForRecord(functionStore()->activeRecordAtIndex(i));
-      if (f->plotType() == CartesianFunction::PlotType::Cartesian) {
+      ExpiringPointer<ContinuousFunction> f = functionStore()->modelForRecord(functionStore()->activeRecordAtIndex(i));
+      if (f->plotType() == ContinuousFunction::PlotType::Cartesian) {
         continue;
       }
       /* Scan x-range from the middle to the extrema in order to get balanced
@@ -86,8 +86,8 @@ void GraphController::interestingRanges(float * xm, float * xM, float * ym, floa
    * missed. */
   const float step = const_cast<GraphController *>(this)->curveView()->pixelWidth() / 2;
   for (int i = 0; i < functionStore()->numberOfActiveFunctions(); i++) {
-    ExpiringPointer<CartesianFunction> f = functionStore()->modelForRecord(functionStore()->activeRecordAtIndex(i));
-    if (f->plotType() != CartesianFunction::PlotType::Cartesian) {
+    ExpiringPointer<ContinuousFunction> f = functionStore()->modelForRecord(functionStore()->activeRecordAtIndex(i));
+    if (f->plotType() != ContinuousFunction::PlotType::Cartesian) {
       continue;
     }
     /* Scan x-range from the middle to the extrema in order to get balanced
@@ -114,7 +114,7 @@ float GraphController::interestingXHalfRange() const {
   Poincare::Context * context = textFieldDelegateApp()->localContext();
   ContinuousFunctionStore * store = functionStore();
   for (int i = 0; i < store->numberOfActiveFunctions(); i++) {
-    ExpiringPointer<CartesianFunction> f = store->modelForRecord(store->activeRecordAtIndex(i));
+    ExpiringPointer<ContinuousFunction> f = store->modelForRecord(store->activeRecordAtIndex(i));
     float fRange = f->expressionReduced(context).characteristicXRange(context, Poincare::Preferences::sharedPreferences()->angleUnit());
     if (!std::isnan(fRange)) {
       characteristicRange = maxFloat(fRange, characteristicRange);
@@ -125,14 +125,14 @@ float GraphController::interestingXHalfRange() const {
 
 void GraphController::selectFunctionWithCursor(int functionIndex) {
   FunctionGraphController::selectFunctionWithCursor(functionIndex);
-  ExpiringPointer<CartesianFunction> f = functionStore()->modelForRecord(functionStore()->activeRecordAtIndex(functionIndex));
+  ExpiringPointer<ContinuousFunction> f = functionStore()->modelForRecord(functionStore()->activeRecordAtIndex(functionIndex));
   m_cursorView.setColor(f->color());
 }
 
 void GraphController::reloadBannerView() {
   Ion::Storage::Record record = functionStore()->activeRecordAtIndex(indexFunctionSelectedByCursor());
   bool displayDerivative = m_displayDerivativeInBanner &&
-    functionStore()->modelForRecord(record)->plotType() == CartesianFunction::PlotType::Cartesian;
+    functionStore()->modelForRecord(record)->plotType() == ContinuousFunction::PlotType::Cartesian;
   m_bannerView.setNumberOfSubviews(Shared::XYBannerView::k_numberOfSubviews + displayDerivative);
   FunctionGraphController::reloadBannerView();
   if (!displayDerivative) {
@@ -148,7 +148,7 @@ bool GraphController::moveCursorHorizontally(int direction) {
 
 int GraphController::closestCurveIndexVertically(bool goingUp, int currentSelectedCurve, Poincare::Context * context) const {
   int nbOfActiveFunctions = functionStore()-> numberOfActiveFunctions();
-  if (functionStore()->numberOfActiveFunctionsOfType(CartesianFunction::PlotType::Cartesian) == nbOfActiveFunctions) {
+  if (functionStore()->numberOfActiveFunctionsOfType(ContinuousFunction::PlotType::Cartesian) == nbOfActiveFunctions) {
     return FunctionGraphController::closestCurveIndexVertically(goingUp, currentSelectedCurve, context);
   }
   int nextActiveFunctionIndex = currentSelectedCurve + (goingUp ? -1 : 1);
@@ -156,8 +156,8 @@ int GraphController::closestCurveIndexVertically(bool goingUp, int currentSelect
 }
 
 double GraphController::defaultCursorT(Ion::Storage::Record record) {
-  ExpiringPointer<CartesianFunction> function = functionStore()->modelForRecord(record);
-  if (function->plotType() == CartesianFunction::PlotType::Cartesian) {
+  ExpiringPointer<ContinuousFunction> function = functionStore()->modelForRecord(record);
+  if (function->plotType() == ContinuousFunction::PlotType::Cartesian) {
     return FunctionGraphController::defaultCursorT(record);
   }
   return function->tMin();
@@ -165,8 +165,8 @@ double GraphController::defaultCursorT(Ion::Storage::Record record) {
 
 bool GraphController::displaysNonCartesianFunctions() const {
   ContinuousFunctionStore * store = functionStore();
-  return store->numberOfActiveFunctionsOfType(CartesianFunction::PlotType::Polar) > 0
-    || store->numberOfActiveFunctionsOfType(CartesianFunction::PlotType::Parametric) > 0;
+  return store->numberOfActiveFunctionsOfType(ContinuousFunction::PlotType::Polar) > 0
+    || store->numberOfActiveFunctionsOfType(ContinuousFunction::PlotType::Parametric) > 0;
 }
 
 bool GraphController::shouldSetDefaultOnModelChange() const {

--- a/apps/graph/graph/graph_controller.cpp
+++ b/apps/graph/graph/graph_controller.cpp
@@ -112,7 +112,7 @@ void GraphController::interestingRanges(float * xm, float * xM, float * ym, floa
 float GraphController::interestingXHalfRange() const {
   float characteristicRange = 0.0f;
   Poincare::Context * context = textFieldDelegateApp()->localContext();
-  CartesianFunctionStore * store = functionStore();
+  ContinuousFunctionStore * store = functionStore();
   for (int i = 0; i < store->numberOfActiveFunctions(); i++) {
     ExpiringPointer<CartesianFunction> f = store->modelForRecord(store->activeRecordAtIndex(i));
     float fRange = f->expressionReduced(context).characteristicXRange(context, Poincare::Preferences::sharedPreferences()->angleUnit());
@@ -164,7 +164,7 @@ double GraphController::defaultCursorT(Ion::Storage::Record record) {
 }
 
 bool GraphController::displaysNonCartesianFunctions() const {
-  CartesianFunctionStore * store = functionStore();
+  ContinuousFunctionStore * store = functionStore();
   return store->numberOfActiveFunctionsOfType(CartesianFunction::PlotType::Polar) > 0
     || store->numberOfActiveFunctionsOfType(CartesianFunction::PlotType::Parametric) > 0;
 }

--- a/apps/graph/graph/graph_controller.h
+++ b/apps/graph/graph/graph_controller.h
@@ -36,7 +36,7 @@ private:
   ContinuousFunctionStore * functionStore() const override { return static_cast<ContinuousFunctionStore *>(Shared::FunctionGraphController::functionStore()); }
   bool displaysNonCartesianFunctions() const;
   bool defautRangeIsNormalized() const override { return displaysNonCartesianFunctions(); }
-  void interestingFunctionRange(Shared::ExpiringPointer<Shared::CartesianFunction> f, float tMin, float tMax, float step, float * xm, float * xM, float * ym, float * yM) const;
+  void interestingFunctionRange(Shared::ExpiringPointer<Shared::ContinuousFunction> f, float tMin, float tMax, float step, float * xm, float * xM, float * ym, float * yM) const;
   bool shouldSetDefaultOnModelChange() const override;
 
   Shared::RoundCursorView m_cursorView;

--- a/apps/graph/graph/graph_controller.h
+++ b/apps/graph/graph/graph_controller.h
@@ -33,7 +33,7 @@ private:
   Shared::InteractiveCurveViewRange * interactiveCurveViewRange() override { return m_graphRange; }
   GraphView * functionGraphView() override { return &m_view; }
   CurveParameterController * curveParameterController() override { return &m_curveParameterController; }
-  CartesianFunctionStore * functionStore() const override { return static_cast<CartesianFunctionStore *>(Shared::FunctionGraphController::functionStore()); }
+  ContinuousFunctionStore * functionStore() const override { return static_cast<ContinuousFunctionStore *>(Shared::FunctionGraphController::functionStore()); }
   bool displaysNonCartesianFunctions() const;
   bool defautRangeIsNormalized() const override { return displaysNonCartesianFunctions(); }
   void interestingFunctionRange(Shared::ExpiringPointer<Shared::CartesianFunction> f, float tMin, float tMax, float step, float * xm, float * xM, float * ym, float * yM) const;

--- a/apps/graph/graph/graph_controller.h
+++ b/apps/graph/graph/graph_controller.h
@@ -9,7 +9,7 @@
 #include "../../shared/curve_view_cursor.h"
 #include "../../shared/round_cursor_view.h"
 #include "../../shared/interactive_curve_view_range.h"
-#include "../cartesian_function_store.h"
+#include "../continuous_function_store.h"
 
 namespace Graph {
 

--- a/apps/graph/graph/graph_controller.h
+++ b/apps/graph/graph/graph_controller.h
@@ -15,7 +15,7 @@ namespace Graph {
 
 class GraphController : public Shared::FunctionGraphController, public GraphControllerHelper {
 public:
-  GraphController(Responder * parentResponder, ::InputEventHandlerDelegate * inputEventHandlerDelegate, CartesianFunctionStore * functionStore, Shared::InteractiveCurveViewRange * curveViewRange, Shared::CurveViewCursor * cursor, int * indexFunctionSelectedByCursor, uint32_t * modelVersion, uint32_t * rangeVersion, Poincare::Preferences::AngleUnit * angleUnitVersion, ButtonRowController * header);
+  GraphController(Responder * parentResponder, ::InputEventHandlerDelegate * inputEventHandlerDelegate, Shared::InteractiveCurveViewRange * curveViewRange, Shared::CurveViewCursor * cursor, int * indexFunctionSelectedByCursor, uint32_t * modelVersion, uint32_t * rangeVersion, Poincare::Preferences::AngleUnit * angleUnitVersion, ButtonRowController * header);
   I18n::Message emptyMessage() override;
   void viewWillAppear() override;
   bool displayDerivativeInBanner() const { return m_displayDerivativeInBanner; }

--- a/apps/graph/graph/graph_controller_helper.cpp
+++ b/apps/graph/graph/graph_controller_helper.cpp
@@ -10,17 +10,17 @@ using namespace Poincare;
 namespace Graph {
 
 bool GraphControllerHelper::privateMoveCursorHorizontally(Shared::CurveViewCursor * cursor, int direction, Shared::InteractiveCurveViewRange * range, int numberOfStepsInGradUnit, Ion::Storage::Record record) {
-  ExpiringPointer<CartesianFunction> function = App::app()->functionStore()->modelForRecord(record);
+  ExpiringPointer<ContinuousFunction> function = App::app()->functionStore()->modelForRecord(record);
   double tCursorPosition = cursor->t();
   double t = tCursorPosition;
   double tMin = function->tMin();
   double tMax = function->tMax();
   double dir = (direction > 0 ? 1.0 : -1.0);
-  CartesianFunction::PlotType type = function->plotType();
-  if (type == CartesianFunction::PlotType::Cartesian) {
+  ContinuousFunction::PlotType type = function->plotType();
+  if (type == ContinuousFunction::PlotType::Cartesian) {
     t+= dir * range->xGridUnit()/numberOfStepsInGradUnit;
   } else {
-    assert(type == CartesianFunction::PlotType::Polar || type == CartesianFunction::PlotType::Parametric);
+    assert(type == ContinuousFunction::PlotType::Polar || type == ContinuousFunction::PlotType::Parametric);
     t += dir * (tMax-tMin)/k_definitionDomainDivisor;
   }
   Coordinate2D<double> xy = function->evaluateXYAtParameter(t, App::app()->localContext());
@@ -29,7 +29,7 @@ bool GraphControllerHelper::privateMoveCursorHorizontally(Shared::CurveViewCurso
 }
 
 void GraphControllerHelper::reloadDerivativeInBannerViewForCursorOnFunction(Shared::CurveViewCursor * cursor, Ion::Storage::Record record) {
-  ExpiringPointer<CartesianFunction> function = App::app()->functionStore()->modelForRecord(record);
+  ExpiringPointer<ContinuousFunction> function = App::app()->functionStore()->modelForRecord(record);
   constexpr size_t bufferSize = FunctionBannerDelegate::k_maxNumberOfCharacters+PrintFloat::bufferSizeForFloatsWithPrecision(Preferences::LargeNumberOfSignificantDigits);
   char buffer[bufferSize];
   const char * space = " ";

--- a/apps/graph/graph/graph_view.cpp
+++ b/apps/graph/graph/graph_view.cpp
@@ -26,8 +26,8 @@ void GraphView::drawRect(KDContext * ctx, KDRect rect) const {
   ContinuousFunctionStore * functionStore = App::app()->functionStore();
   for (int i = 0; i < functionStore->numberOfActiveFunctions(); i++) {
     Ion::Storage::Record record = functionStore->activeRecordAtIndex(i);
-    ExpiringPointer<CartesianFunction> f = functionStore->modelForRecord(record);;
-    Shared::CartesianFunction::PlotType type = f->plotType();
+    ExpiringPointer<ContinuousFunction> f = functionStore->modelForRecord(record);;
+    Shared::ContinuousFunction::PlotType type = f->plotType();
     float tmin = f->tMin();
     float tmax = f->tMax();
     /* The step is a fraction of tmax-tmin. We will evaluate the function at
@@ -44,9 +44,9 @@ void GraphView::drawRect(KDContext * ctx, KDRect rect) const {
     float tstep = (tmax-tmin)/10.0938275501223f;
 
     // Cartesian
-    if (type == Shared::CartesianFunction::PlotType::Cartesian) {
+    if (type == Shared::ContinuousFunction::PlotType::Cartesian) {
       drawCartesianCurve(ctx, rect, tmin, tmax, [](float t, void * model, void * context) {
-            CartesianFunction * f = (CartesianFunction *)model;
+            ContinuousFunction * f = (ContinuousFunction *)model;
             Poincare::Context * c = (Poincare::Context *)context;
             return f->evaluateXYAtParameter(t, c);
           }, f.operator->(), context(), f->color(), record == m_selectedRecord, m_highlightedStart, m_highlightedEnd);
@@ -64,9 +64,9 @@ void GraphView::drawRect(KDContext * ctx, KDRect rect) const {
     }
 
     // Polar
-    if (type == Shared::CartesianFunction::PlotType::Polar) {
+    if (type == Shared::ContinuousFunction::PlotType::Polar) {
       drawCurve(ctx, rect, tmin, tmax, tstep, [](float t, void * model, void * context) {
-          CartesianFunction * f = (CartesianFunction *)model;
+          ContinuousFunction * f = (ContinuousFunction *)model;
           Poincare::Context * c = (Poincare::Context *)context;
           return f->evaluateXYAtParameter(t, c);
         }, f.operator->(), context(), false, f->color());
@@ -74,9 +74,9 @@ void GraphView::drawRect(KDContext * ctx, KDRect rect) const {
     }
 
     // Parametric
-    assert(type == Shared::CartesianFunction::PlotType::Parametric);
+    assert(type == Shared::ContinuousFunction::PlotType::Parametric);
     drawCurve(ctx, rect, tmin, tmax, tstep, [](float t, void * model, void * context) {
-        CartesianFunction * f = (CartesianFunction *)model;
+        ContinuousFunction * f = (ContinuousFunction *)model;
         Poincare::Context * c = (Poincare::Context *)context;
         return f->evaluateXYAtParameter(t, c);
       }, f.operator->(), context(), false, f->color());

--- a/apps/graph/graph/graph_view.cpp
+++ b/apps/graph/graph/graph_view.cpp
@@ -64,18 +64,10 @@ void GraphView::drawRect(KDContext * ctx, KDRect rect) const {
       continue;
     }
 
-    // Polar
-    if (type == Shared::ContinuousFunction::PlotType::Polar) {
-      drawCurve(ctx, rect, tmin, tmax, tstep, [](float t, void * model, void * context) {
-          ContinuousFunction * f = (ContinuousFunction *)model;
-          Poincare::Context * c = (Poincare::Context *)context;
-          return f->evaluateXYAtParameter(t, c);
-        }, f.operator->(), context(), false, f->color());
-      continue;
-    }
-
-    // Parametric
-    assert(type == Shared::ContinuousFunction::PlotType::Parametric);
+    // Polar or parametric
+    assert(
+        type == Shared::ContinuousFunction::PlotType::Polar ||
+        type == Shared::ContinuousFunction::PlotType::Parametric);
     drawCurve(ctx, rect, tmin, tmax, tstep, [](float t, void * model, void * context) {
         ContinuousFunction * f = (ContinuousFunction *)model;
         Poincare::Context * c = (Poincare::Context *)context;

--- a/apps/graph/graph/graph_view.cpp
+++ b/apps/graph/graph/graph_view.cpp
@@ -24,7 +24,8 @@ void GraphView::reload() {
 void GraphView::drawRect(KDContext * ctx, KDRect rect) const {
   FunctionGraphView::drawRect(ctx, rect);
   ContinuousFunctionStore * functionStore = App::app()->functionStore();
-  for (int i = 0; i < functionStore->numberOfActiveFunctions(); i++) {
+  const int activeFunctionsCount = functionStore->numberOfActiveFunctions();
+  for (int i = 0; i < activeFunctionsCount ; i++) {
     Ion::Storage::Record record = functionStore->activeRecordAtIndex(i);
     ExpiringPointer<ContinuousFunction> f = functionStore->modelForRecord(record);;
     Shared::ContinuousFunction::PlotType type = f->plotType();

--- a/apps/graph/graph/graph_view.cpp
+++ b/apps/graph/graph/graph_view.cpp
@@ -23,7 +23,7 @@ void GraphView::reload() {
 
 void GraphView::drawRect(KDContext * ctx, KDRect rect) const {
   FunctionGraphView::drawRect(ctx, rect);
-  CartesianFunctionStore * functionStore = App::app()->functionStore();
+  ContinuousFunctionStore * functionStore = App::app()->functionStore();
   for (int i = 0; i < functionStore->numberOfActiveFunctions(); i++) {
     Ion::Storage::Record record = functionStore->activeRecordAtIndex(i);
     ExpiringPointer<CartesianFunction> f = functionStore->modelForRecord(record);;

--- a/apps/graph/graph/graph_view.cpp
+++ b/apps/graph/graph/graph_view.cpp
@@ -1,14 +1,14 @@
 #include "graph_view.h"
+#include "../app.h"
 #include <assert.h>
 
 using namespace Shared;
 
 namespace Graph {
 
-GraphView::GraphView(CartesianFunctionStore * functionStore, InteractiveCurveViewRange * graphRange,
-  CurveViewCursor * cursor, BannerView * bannerView, CursorView * cursorView) :
+GraphView::GraphView(InteractiveCurveViewRange * graphRange,
+  CurveViewCursor * cursor, Shared::BannerView * bannerView, CursorView * cursorView) :
   FunctionGraphView(graphRange, cursor, bannerView, cursorView),
-  m_functionStore(functionStore),
   m_tangent(false)
 {
 }
@@ -23,9 +23,10 @@ void GraphView::reload() {
 
 void GraphView::drawRect(KDContext * ctx, KDRect rect) const {
   FunctionGraphView::drawRect(ctx, rect);
-  for (int i = 0; i < m_functionStore->numberOfActiveFunctions(); i++) {
-    Ion::Storage::Record record = m_functionStore->activeRecordAtIndex(i);
-    ExpiringPointer<CartesianFunction> f = m_functionStore->modelForRecord(record);;
+  CartesianFunctionStore * functionStore = App::app()->functionStore();
+  for (int i = 0; i < functionStore->numberOfActiveFunctions(); i++) {
+    Ion::Storage::Record record = functionStore->activeRecordAtIndex(i);
+    ExpiringPointer<CartesianFunction> f = functionStore->modelForRecord(record);;
     Shared::CartesianFunction::PlotType type = f->plotType();
     float tmin = f->tMin();
     float tmax = f->tMax();

--- a/apps/graph/graph/graph_view.cpp
+++ b/apps/graph/graph/graph_view.cpp
@@ -1,7 +1,5 @@
 #include "graph_view.h"
-#include <poincare/serialization_helper.h>
 #include <assert.h>
-#include <cmath>
 
 using namespace Shared;
 
@@ -79,22 +77,8 @@ void GraphView::drawRect(KDContext * ctx, KDRect rect) const {
     drawCurve(ctx, rect, tmin, tmax, tstep, [](float t, void * model, void * context) {
         CartesianFunction * f = (CartesianFunction *)model;
         Poincare::Context * c = (Poincare::Context *)context;
-        if (f->isCircularlyDefined(c)) {
-          return Poincare::Coordinate2D<float>(NAN, NAN);
-        }
-        constexpr int bufferSize = CodePoint::MaxCodePointCharLength + 1;
-        char unknownX[bufferSize];
-        Poincare::SerializationHelper::CodePoint(unknownX, bufferSize, UCodePointUnknownX);
-        Poincare::VariableContext variableContext(unknownX, c);
-        variableContext.setApproximationForVariable(t);
-        Poincare::Expression e = f->expressionReduced(c);
-        assert(e.type() == Poincare::ExpressionNode::Type::Matrix
-            && static_cast<Poincare::Matrix&>(e).numberOfRows() == 2
-            && static_cast<Poincare::Matrix&>(e).numberOfColumns() == 1);
-        Poincare::Preferences * preferences = Poincare::Preferences::sharedPreferences();
-        Poincare::Preferences::ComplexFormat complexFormat = Poincare::Expression::UpdatedComplexFormatWithExpressionInput(preferences->complexFormat(), e, c);
-        return Poincare::Coordinate2D<float>(e.childAtIndex(0).approximateToScalar<float>(&variableContext, complexFormat, preferences->angleUnit()), e.childAtIndex(1).approximateToScalar<float>(&variableContext, complexFormat, preferences->angleUnit()));
-        }, f.operator->(), context(), false, f->color());
+        return f->evaluateXYAtParameter(t, c);
+      }, f.operator->(), context(), false, f->color());
   }
 }
 

--- a/apps/graph/graph/graph_view.h
+++ b/apps/graph/graph/graph_view.h
@@ -2,13 +2,12 @@
 #define GRAPH_GRAPH_VIEW_H
 
 #include "../../shared/function_graph_view.h"
-#include "../cartesian_function_store.h"
 
 namespace Graph {
 
 class GraphView : public Shared::FunctionGraphView {
 public:
-  GraphView(CartesianFunctionStore * functionStore, Shared::InteractiveCurveViewRange * graphRange,
+  GraphView(Shared::InteractiveCurveViewRange * graphRange,
     Shared::CurveViewCursor * cursor, Shared::BannerView * bannerView, Shared::CursorView * cursorView);
   void reload() override;
   void drawRect(KDContext * ctx, KDRect rect) const override;
@@ -19,7 +18,6 @@ public:
    * of the graph where the area under the curve is colored. */
   void setAreaHighlightColor(bool highlightColor) override {};
 private:
-  CartesianFunctionStore * m_functionStore;
   bool m_tangent;
 };
 

--- a/apps/graph/graph/intersection_graph_controller.cpp
+++ b/apps/graph/graph/intersection_graph_controller.cpp
@@ -24,12 +24,12 @@ void IntersectionGraphController::reloadBannerView() {
   const char * space = " ";
   const char * legend = "=";
   // 'f(x)=g(x)=', keep 2 chars for '='
-  ExpiringPointer<CartesianFunction> f = functionStore()->modelForRecord(m_record);
+  ExpiringPointer<ContinuousFunction> f = functionStore()->modelForRecord(m_record);
   int numberOfChar = f->nameWithArgument(buffer, bufferSize-2);
   assert(numberOfChar <= bufferSize);
   numberOfChar += strlcpy(buffer+numberOfChar, legend, bufferSize-numberOfChar);
   // keep 1 char for '=';
-  ExpiringPointer<CartesianFunction> g = functionStore()->modelForRecord(m_intersectedRecord);
+  ExpiringPointer<ContinuousFunction> g = functionStore()->modelForRecord(m_intersectedRecord);
   numberOfChar += g->nameWithArgument(buffer+numberOfChar, bufferSize-numberOfChar-1);
   assert(numberOfChar <= bufferSize);
   numberOfChar += strlcpy(buffer+numberOfChar, legend, bufferSize-numberOfChar);
@@ -46,7 +46,7 @@ Poincare::Coordinate2D<double> IntersectionGraphController::computeNewPointOfInt
   for (int i = 0; i < functionStore()->numberOfActiveFunctions(); i++) {
     Ion::Storage::Record record = functionStore()->activeRecordAtIndex(i);
     if (record != m_record) {
-      CartesianFunction f = *(functionStore()->modelForRecord(record));
+      ContinuousFunction f = *(functionStore()->modelForRecord(record));
       Poincare::Coordinate2D<double> intersection = functionStore()->modelForRecord(m_record)->nextIntersectionFrom(start, step, max, context, f.expressionReduced(context), f.tMin(), f.tMax());
       if ((std::isnan(result.x1()) || std::fabs(intersection.x1()-start) < std::fabs(result.x1()-start)) && !std::isnan(intersection.x1())) {
         m_intersectedRecord = record;

--- a/apps/graph/graph/intersection_graph_controller.h
+++ b/apps/graph/graph/intersection_graph_controller.h
@@ -2,7 +2,6 @@
 #define GRAPH_INTERSECTION_GRAPH_CONTROLLER_H
 
 #include "calculation_graph_controller.h"
-#include "../cartesian_function_store.h"
 
 namespace Graph {
 

--- a/apps/graph/graph/tangent_graph_controller.cpp
+++ b/apps/graph/graph/tangent_graph_controller.cpp
@@ -46,8 +46,8 @@ bool TangentGraphController::textFieldDidFinishEditing(TextField * textField, co
   if (myApp->hasUndefinedValue(text, floatBody)) {
     return false;
   }
-  ExpiringPointer<CartesianFunction> function = App::app()->functionStore()->modelForRecord(m_record);
-  assert(function->plotType() == Shared::CartesianFunction::PlotType::Cartesian);
+  ExpiringPointer<ContinuousFunction> function = App::app()->functionStore()->modelForRecord(m_record);
+  assert(function->plotType() == Shared::ContinuousFunction::PlotType::Cartesian);
   double y = function->evaluate2DAtParameter(floatBody, myApp->localContext()).x2();
   m_cursor->moveTo(floatBody, floatBody, y);
   interactiveCurveViewRange()->panToMakePointVisible(m_cursor->x(), m_cursor->y(), cursorTopMarginRatio(), k_cursorRightMarginRatio, cursorBottomMarginRatio(), k_cursorLeftMarginRatio);
@@ -74,7 +74,7 @@ void TangentGraphController::reloadBannerView() {
   constexpr int precision = Preferences::MediumNumberOfSignificantDigits;
   const char * legend = "a=";
   int legendLength = strlcpy(buffer, legend, bufferSize);
-  ExpiringPointer<CartesianFunction> function = App::app()->functionStore()->modelForRecord(m_record);
+  ExpiringPointer<ContinuousFunction> function = App::app()->functionStore()->modelForRecord(m_record);
   double y = function->approximateDerivative(m_cursor->x(), context);
   PoincareHelpers::ConvertFloatToText<double>(y, buffer + legendLength, PrintFloat::bufferSizeForFloatsWithPrecision(precision), precision);
   m_bannerView->aView()->setText(buffer);
@@ -82,7 +82,7 @@ void TangentGraphController::reloadBannerView() {
   legend = "b=";
   legendLength = strlcpy(buffer, legend, bufferSize);
   Shared::TextFieldDelegateApp * myApp = textFieldDelegateApp();
-  assert(function->plotType() == Shared::CartesianFunction::PlotType::Cartesian);
+  assert(function->plotType() == Shared::ContinuousFunction::PlotType::Cartesian);
   y = -y*m_cursor->x()+function->evaluate2DAtParameter(m_cursor->x(), myApp->localContext()).x2();
   PoincareHelpers::ConvertFloatToText<double>(y, buffer + legendLength, PrintFloat::bufferSizeForFloatsWithPrecision(precision), precision);
   m_bannerView->bView()->setText(buffer);

--- a/apps/graph/graph/tangent_graph_controller.h
+++ b/apps/graph/graph/tangent_graph_controller.h
@@ -6,7 +6,6 @@
 #include "graph_controller_helper.h"
 #include "../../shared/simple_interactive_curve_view_controller.h"
 #include "../../shared/function_banner_delegate.h"
-#include "../cartesian_function_store.h"
 
 namespace Graph {
 

--- a/apps/graph/list/domain_parameter_controller.cpp
+++ b/apps/graph/list/domain_parameter_controller.cpp
@@ -31,15 +31,15 @@ void DomainParameterController::willDisplayCellForIndex(HighlightCell * cell, in
     return;
   }
   MessageTableCellWithEditableText * myCell = (MessageTableCellWithEditableText *)cell;
-  Shared::CartesianFunction::PlotType plotType = function()->plotType();
+  Shared::ContinuousFunction::PlotType plotType = function()->plotType();
   switch (plotType) {
-    case Shared::CartesianFunction::PlotType::Cartesian:
+    case Shared::ContinuousFunction::PlotType::Cartesian:
     {
       I18n::Message labels[k_totalNumberOfCell] = {I18n::Message::XMin, I18n::Message::XMax};
       myCell->setMessage(labels[index]);
       break;
     }
-    case Shared::CartesianFunction::PlotType::Parametric:
+    case Shared::ContinuousFunction::PlotType::Parametric:
     {
       I18n::Message labels[k_totalNumberOfCell] = {I18n::Message::TMin, I18n::Message::TMax};
       myCell->setMessage(labels[index]);
@@ -47,7 +47,7 @@ void DomainParameterController::willDisplayCellForIndex(HighlightCell * cell, in
     }
     default:
     {
-      assert(plotType == Shared::CartesianFunction::PlotType::Polar);
+      assert(plotType == Shared::ContinuousFunction::PlotType::Polar);
       I18n::Message labels[k_totalNumberOfCell] = {I18n::Message::ThetaMin, I18n::Message::ThetaMax};
       myCell->setMessage(labels[index]);
       break;
@@ -89,15 +89,15 @@ void DomainParameterController::buttonAction() {
   stack->pop();
 }
 
-Shared::ExpiringPointer<Shared::CartesianFunction> DomainParameterController::function() const {
+Shared::ExpiringPointer<Shared::ContinuousFunction> DomainParameterController::function() const {
   assert(!m_record.isNull());
   App * myApp = App::app();
   return myApp->functionStore()->modelForRecord(m_record);
 }
 
 FloatParameterController<float>::InfinityTolerance DomainParameterController::infinityAllowanceForRow(int row) const {
-  Shared::CartesianFunction::PlotType plotType = function()->plotType();
-  if (plotType == Shared::CartesianFunction::PlotType::Cartesian) {
+  Shared::ContinuousFunction::PlotType plotType = function()->plotType();
+  if (plotType == Shared::ContinuousFunction::PlotType::Cartesian) {
     return row == 0 ? FloatParameterController<float>::InfinityTolerance::MinusInfinity : FloatParameterController<float>::InfinityTolerance::PlusInfinity;
   }
   return FloatParameterController<float>::InfinityTolerance::None;

--- a/apps/graph/list/domain_parameter_controller.h
+++ b/apps/graph/list/domain_parameter_controller.h
@@ -3,7 +3,7 @@
 
 #include <escher/message_table_cell_with_expression.h>
 #include <ion/storage.h>
-#include "../../shared/cartesian_function.h"
+#include "../../shared/continuous_function.h"
 #include "../../shared/expiring_pointer.h"
 #include "../../shared/float_parameter_controller.h"
 

--- a/apps/graph/list/domain_parameter_controller.h
+++ b/apps/graph/list/domain_parameter_controller.h
@@ -30,7 +30,7 @@ private:
   float parameterAtIndex(int index) override;
   void buttonAction() override;
   InfinityTolerance infinityAllowanceForRow(int row) const override;
-  Shared::ExpiringPointer<Shared::CartesianFunction> function() const;
+  Shared::ExpiringPointer<Shared::ContinuousFunction> function() const;
   MessageTableCellWithEditableText m_domainCells[k_totalNumberOfCell];
   Ion::Storage::Record m_record;
 };

--- a/apps/graph/list/list_controller.cpp
+++ b/apps/graph/list/list_controller.cpp
@@ -189,7 +189,7 @@ void ListController::setFunctionNameInTextField(ExpiringPointer<CartesianFunctio
   textField->setText(bufferName);
 }
 
-CartesianFunctionStore * ListController::modelStore() {
+ContinuousFunctionStore * ListController::modelStore() {
   return App::app()->functionStore();
 }
 

--- a/apps/graph/list/list_controller.cpp
+++ b/apps/graph/list/list_controller.cpp
@@ -118,7 +118,7 @@ bool ListController::textFieldDidAbortEditing(TextField * textField) {
   // Put the name column back to normal size
   computeTitlesColumnWidth();
   selectableTableView()->reloadData();
-  ExpiringPointer<Function> function = modelStore()->modelForRecord(modelStore()->recordAtIndex(selectedRow()));
+  ExpiringPointer<CartesianFunction> function = modelStore()->modelForRecord(modelStore()->recordAtIndex(selectedRow()));
   setFunctionNameInTextField(function, textField);
   m_selectableTableView.selectedCell()->setHighlighted(true);
   Container::activeApp()->setFirstResponder(&m_selectableTableView);
@@ -165,7 +165,7 @@ void ListController::willDisplayTitleCellAtIndex(HighlightCell * cell, int j) {
   titleCell->setBaseline(baseline(j));
   if (!titleCell->isEditing()) {
     // Set name and color if the name is not being edited
-    ExpiringPointer<Function> function = modelStore()->modelForRecord(modelStore()->recordAtIndex(j));
+    ExpiringPointer<CartesianFunction> function = modelStore()->modelForRecord(modelStore()->recordAtIndex(j));
     setFunctionNameInTextField(function, titleCell->textField());
     KDColor functionNameColor = function->isActive() ? function->color() : Palette::GreyDark;
     titleCell->setColor(functionNameColor);
@@ -177,16 +177,20 @@ void ListController::willDisplayExpressionCellAtIndex(HighlightCell * cell, int 
   assert(j >= 0 && j < modelStore()->numberOfModels());
   Shared::FunctionListController::willDisplayExpressionCellAtIndex(cell, j);
   FunctionExpressionCell * myCell = (FunctionExpressionCell *)cell;
-  ExpiringPointer<Function> f = modelStore()->modelForRecord(modelStore()->recordAtIndex(j));
+  ExpiringPointer<CartesianFunction> f = modelStore()->modelForRecord(modelStore()->recordAtIndex(j));
   KDColor textColor = f->isActive() ? KDColorBlack : Palette::GreyDark;
   myCell->setTextColor(textColor);
 }
 
-void ListController::setFunctionNameInTextField(ExpiringPointer<Function> function, TextField * textField) {
+void ListController::setFunctionNameInTextField(ExpiringPointer<CartesianFunction> function, TextField * textField) {
   assert(textField != nullptr);
   char bufferName[BufferTextView::k_maxNumberOfChar];
   function->nameWithArgument(bufferName, BufferTextView::k_maxNumberOfChar);
   textField->setText(bufferName);
+}
+
+CartesianFunctionStore * ListController::modelStore() {
+  return App::app()->functionStore();
 }
 
 }

--- a/apps/graph/list/list_controller.cpp
+++ b/apps/graph/list/list_controller.cpp
@@ -54,7 +54,7 @@ bool ListController::textFieldDidFinishEditing(TextField * textField, const char
   char baseName[maxBaseNameSize];
   if (textLength <= argumentLength) {
     // The user entered an empty name. Use a default function name.
-    CartesianFunction::DefaultName(baseName, maxBaseNameSize);
+    ContinuousFunction::DefaultName(baseName, maxBaseNameSize);
     /* We don't need to update the textfield edited text here because we are
      * sure that the default name is compliant. It will thus lead to the end of
      * edition and its content will be reloaded by willDisplayTitleCellAtIndex. */
@@ -118,7 +118,7 @@ bool ListController::textFieldDidAbortEditing(TextField * textField) {
   // Put the name column back to normal size
   computeTitlesColumnWidth();
   selectableTableView()->reloadData();
-  ExpiringPointer<CartesianFunction> function = modelStore()->modelForRecord(modelStore()->recordAtIndex(selectedRow()));
+  ExpiringPointer<ContinuousFunction> function = modelStore()->modelForRecord(modelStore()->recordAtIndex(selectedRow()));
   setFunctionNameInTextField(function, textField);
   m_selectableTableView.selectedCell()->setHighlighted(true);
   Container::activeApp()->setFirstResponder(&m_selectableTableView);
@@ -165,7 +165,7 @@ void ListController::willDisplayTitleCellAtIndex(HighlightCell * cell, int j) {
   titleCell->setBaseline(baseline(j));
   if (!titleCell->isEditing()) {
     // Set name and color if the name is not being edited
-    ExpiringPointer<CartesianFunction> function = modelStore()->modelForRecord(modelStore()->recordAtIndex(j));
+    ExpiringPointer<ContinuousFunction> function = modelStore()->modelForRecord(modelStore()->recordAtIndex(j));
     setFunctionNameInTextField(function, titleCell->textField());
     KDColor functionNameColor = function->isActive() ? function->color() : Palette::GreyDark;
     titleCell->setColor(functionNameColor);
@@ -177,12 +177,12 @@ void ListController::willDisplayExpressionCellAtIndex(HighlightCell * cell, int 
   assert(j >= 0 && j < modelStore()->numberOfModels());
   Shared::FunctionListController::willDisplayExpressionCellAtIndex(cell, j);
   FunctionExpressionCell * myCell = (FunctionExpressionCell *)cell;
-  ExpiringPointer<CartesianFunction> f = modelStore()->modelForRecord(modelStore()->recordAtIndex(j));
+  ExpiringPointer<ContinuousFunction> f = modelStore()->modelForRecord(modelStore()->recordAtIndex(j));
   KDColor textColor = f->isActive() ? KDColorBlack : Palette::GreyDark;
   myCell->setTextColor(textColor);
 }
 
-void ListController::setFunctionNameInTextField(ExpiringPointer<CartesianFunction> function, TextField * textField) {
+void ListController::setFunctionNameInTextField(ExpiringPointer<ContinuousFunction> function, TextField * textField) {
   assert(textField != nullptr);
   char bufferName[BufferTextView::k_maxNumberOfChar];
   function->nameWithArgument(bufferName, BufferTextView::k_maxNumberOfChar);

--- a/apps/graph/list/list_controller.h
+++ b/apps/graph/list/list_controller.h
@@ -4,7 +4,7 @@
 #include <escher.h>
 #include "list_parameter_controller.h"
 #include "text_field_function_title_cell.h"
-#include "../cartesian_function_store.h"
+#include "../continuous_function_store.h"
 #include <apps/shared/function_expression_cell.h>
 #include <apps/shared/function_list_controller.h>
 #include <apps/shared/text_field_delegate.h>

--- a/apps/graph/list/list_controller.h
+++ b/apps/graph/list/list_controller.h
@@ -29,7 +29,7 @@ private:
   HighlightCell * expressionCells(int index) override;
   void willDisplayTitleCellAtIndex(HighlightCell * cell, int j) override;
   void willDisplayExpressionCellAtIndex(HighlightCell * cell, int j) override;
-  void setFunctionNameInTextField(Shared::ExpiringPointer<Shared::CartesianFunction> function, TextField * textField);
+  void setFunctionNameInTextField(Shared::ExpiringPointer<Shared::ContinuousFunction> function, TextField * textField);
   ContinuousFunctionStore * modelStore() override;
   TextFieldFunctionTitleCell m_functionTitleCells[k_maxNumberOfDisplayableRows];
   Shared::FunctionExpressionCell m_expressionCells[k_maxNumberOfDisplayableRows];

--- a/apps/graph/list/list_controller.h
+++ b/apps/graph/list/list_controller.h
@@ -29,7 +29,8 @@ private:
   HighlightCell * expressionCells(int index) override;
   void willDisplayTitleCellAtIndex(HighlightCell * cell, int j) override;
   void willDisplayExpressionCellAtIndex(HighlightCell * cell, int j) override;
-  void setFunctionNameInTextField(Shared::ExpiringPointer<Shared::Function> function, TextField * textField);
+  void setFunctionNameInTextField(Shared::ExpiringPointer<Shared::CartesianFunction> function, TextField * textField);
+  CartesianFunctionStore * modelStore() override;
   TextFieldFunctionTitleCell m_functionTitleCells[k_maxNumberOfDisplayableRows];
   Shared::FunctionExpressionCell m_expressionCells[k_maxNumberOfDisplayableRows];
   ListParameterController m_parameterController;

--- a/apps/graph/list/list_controller.h
+++ b/apps/graph/list/list_controller.h
@@ -30,7 +30,7 @@ private:
   void willDisplayTitleCellAtIndex(HighlightCell * cell, int j) override;
   void willDisplayExpressionCellAtIndex(HighlightCell * cell, int j) override;
   void setFunctionNameInTextField(Shared::ExpiringPointer<Shared::CartesianFunction> function, TextField * textField);
-  CartesianFunctionStore * modelStore() override;
+  ContinuousFunctionStore * modelStore() override;
   TextFieldFunctionTitleCell m_functionTitleCells[k_maxNumberOfDisplayableRows];
   Shared::FunctionExpressionCell m_expressionCells[k_maxNumberOfDisplayableRows];
   ListParameterController m_parameterController;

--- a/apps/graph/list/list_parameter_controller.cpp
+++ b/apps/graph/list/list_parameter_controller.cpp
@@ -54,7 +54,7 @@ void ListParameterController::willDisplayCellForIndex(HighlightCell * cell, int 
   if ((cell == &m_typeCell || cell == &m_functionDomain) && !m_record.isNull()) {
     App * myApp = App::app();
     assert(!m_record.isNull());
-    Shared::ExpiringPointer<Shared::CartesianFunction> function = myApp->functionStore()->modelForRecord(m_record);
+    Shared::ExpiringPointer<Shared::ContinuousFunction> function = myApp->functionStore()->modelForRecord(m_record);
     if (cell == &m_typeCell) {
       m_typeCell.setMessage(I18n::Message::CurveType);
       int row = static_cast<int>(function->plotType());

--- a/apps/graph/list/type_parameter_controller.cpp
+++ b/apps/graph/list/type_parameter_controller.cpp
@@ -20,10 +20,10 @@ void TypeParameterController::didBecomeFirstResponder() {
 bool TypeParameterController::handleEvent(Ion::Events::Event event) {
   if (event == Ion::Events::OK || event == Ion::Events::EXE) {
     assert(!m_record.isNull());
-    Shared::CartesianFunction::PlotType plotType = static_cast<Shared::CartesianFunction::PlotType>(selectedRow());
+    Shared::ContinuousFunction::PlotType plotType = static_cast<Shared::ContinuousFunction::PlotType>(selectedRow());
     App * myApp = App::app();
     assert(!m_record.isNull());
-    Shared::ExpiringPointer<Shared::CartesianFunction> function = myApp->functionStore()->modelForRecord(m_record);
+    Shared::ExpiringPointer<Shared::ContinuousFunction> function = myApp->functionStore()->modelForRecord(m_record);
     function->setPlotType(plotType, Poincare::Preferences::sharedPreferences()->angleUnit());
     StackViewController * stack = stackController();
     stack->pop();
@@ -44,7 +44,7 @@ const char * TypeParameterController::title() {
 void TypeParameterController::viewWillAppear() {
   App * myApp = App::app();
   assert(!m_record.isNull());
-  Shared::ExpiringPointer<Shared::CartesianFunction> function = myApp->functionStore()->modelForRecord(m_record);
+  Shared::ExpiringPointer<Shared::ContinuousFunction> function = myApp->functionStore()->modelForRecord(m_record);
   int row = static_cast<int>(function->plotType());
   selectCellAtLocation(0, row);
   m_selectableTableView.reloadData();

--- a/apps/graph/values/derivative_parameter_controller.cpp
+++ b/apps/graph/values/derivative_parameter_controller.cpp
@@ -81,7 +81,7 @@ KDCoordinate DerivativeParameterController::cellHeight() {
   return Metric::ParameterCellHeight;
 }
 
-CartesianFunctionStore * DerivativeParameterController::functionStore() {
+ContinuousFunctionStore * DerivativeParameterController::functionStore() {
   return App::app()->functionStore();
 }
 

--- a/apps/graph/values/derivative_parameter_controller.h
+++ b/apps/graph/values/derivative_parameter_controller.h
@@ -25,7 +25,7 @@ public:
     m_record = record;
   }
 private:
-  CartesianFunctionStore * functionStore();
+  ContinuousFunctionStore * functionStore();
 #if COPY_COLUMN
   constexpr static int k_totalNumberOfCell = 2;
 #else

--- a/apps/graph/values/derivative_parameter_controller.h
+++ b/apps/graph/values/derivative_parameter_controller.h
@@ -2,7 +2,7 @@
 #define GRAPH_DERIVATIVE_PARAM_CONTROLLER_H
 
 #include <escher.h>
-#include "../cartesian_function_store.h"
+#include "../continuous_function_store.h"
 
 namespace Graph {
 

--- a/apps/graph/values/function_parameter_controller.cpp
+++ b/apps/graph/values/function_parameter_controller.cpp
@@ -69,7 +69,7 @@ void FunctionParameterController::willDisplayCellForIndex(HighlightCell * cell, 
   }
 }
 
-ExpiringPointer<CartesianFunction> FunctionParameterController::function() {
+ExpiringPointer<ContinuousFunction> FunctionParameterController::function() {
   return App::app()->functionStore()->modelForRecord(m_record);
 }
 

--- a/apps/graph/values/function_parameter_controller.h
+++ b/apps/graph/values/function_parameter_controller.h
@@ -19,7 +19,7 @@ public:
   void willDisplayCellForIndex(HighlightCell * cell, int index) override;
   void viewWillAppear() override;
 private:
-  Shared::ExpiringPointer<Shared::CartesianFunction> function();
+  Shared::ExpiringPointer<Shared::ContinuousFunction> function();
 #if COPY_COLUMN
   constexpr static int k_totalNumberOfCell = 2;
 #else

--- a/apps/graph/values/function_parameter_controller.h
+++ b/apps/graph/values/function_parameter_controller.h
@@ -2,7 +2,7 @@
 #define GRAPH_FUNCTION_PARAM_CONTROLLER_H
 
 #include "../../shared/expiring_pointer.h"
-#include "../../shared/cartesian_function.h"
+#include "../../shared/continuous_function.h"
 #include "../../shared/values_function_parameter_controller.h"
 
 namespace Graph {

--- a/apps/graph/values/interval_parameter_selector_controller.cpp
+++ b/apps/graph/values/interval_parameter_selector_controller.cpp
@@ -34,7 +34,7 @@ bool IntervalParameterSelectorController::handleEvent(Ion::Events::Event event) 
   if (event == Ion::Events::OK || event == Ion::Events::EXE || event == Ion::Events::Right) {
     StackViewController * stack = (StackViewController *)parentResponder();
     Shared::IntervalParameterController * controller = App::app()->valuesController()->intervalParameterController();
-    Shared::CartesianFunction::PlotType plotType = plotTypeAtRow(selectedRow());
+    Shared::ContinuousFunction::PlotType plotType = plotTypeAtRow(selectedRow());
     controller->setTitle(messageForType(plotType));
     setStartEndMessages(controller, plotType);
     controller->setInterval(App::app()->intervalForType(plotType));
@@ -47,9 +47,9 @@ bool IntervalParameterSelectorController::handleEvent(Ion::Events::Event event) 
 int IntervalParameterSelectorController::numberOfRows() const {
   int rowCount = 0;
   int plotTypeIndex = 0;
-  Shared::CartesianFunction::PlotType plotType;
-  while (plotTypeIndex < Shared::CartesianFunction::k_numberOfPlotTypes) {
-    plotType = static_cast<Shared::CartesianFunction::PlotType>(plotTypeIndex);
+  Shared::ContinuousFunction::PlotType plotType;
+  while (plotTypeIndex < Shared::ContinuousFunction::k_numberOfPlotTypes) {
+    plotType = static_cast<Shared::ContinuousFunction::PlotType>(plotTypeIndex);
     bool plotTypeIsShown = App::app()->functionStore()->numberOfActiveFunctionsOfType(plotType) > 0;
     rowCount += plotTypeIsShown;
     plotTypeIndex++;
@@ -63,21 +63,21 @@ HighlightCell * IntervalParameterSelectorController::reusableCell(int index) {
 }
 
 int IntervalParameterSelectorController::reusableCellCount() const {
-  return Shared::CartesianFunction::k_numberOfPlotTypes;
+  return Shared::ContinuousFunction::k_numberOfPlotTypes;
 }
 
 void IntervalParameterSelectorController::willDisplayCellForIndex(HighlightCell * cell, int index) {
   assert(0 <= index && index < numberOfRows());
-  Shared::CartesianFunction::PlotType plotType = plotTypeAtRow(index);
+  Shared::ContinuousFunction::PlotType plotType = plotTypeAtRow(index);
   static_cast<MessageTableCellWithChevron *>(cell)->setMessage(messageForType(plotType));
 }
 
-Shared::CartesianFunction::PlotType IntervalParameterSelectorController::plotTypeAtRow(int j) const {
+Shared::ContinuousFunction::PlotType IntervalParameterSelectorController::plotTypeAtRow(int j) const {
   int rowCount = 0;
   int plotTypeIndex = 0;
-  Shared::CartesianFunction::PlotType plotType;
-  while (plotTypeIndex < Shared::CartesianFunction::k_numberOfPlotTypes) {
-    plotType = static_cast<Shared::CartesianFunction::PlotType>(plotTypeIndex);
+  Shared::ContinuousFunction::PlotType plotType;
+  while (plotTypeIndex < Shared::ContinuousFunction::k_numberOfPlotTypes) {
+    plotType = static_cast<Shared::ContinuousFunction::PlotType>(plotTypeIndex);
     bool plotTypeIsShown = App::app()->functionStore()->numberOfActiveFunctionsOfType(plotType) > 0;
     if (plotTypeIsShown && rowCount == j) {
       break;
@@ -89,8 +89,8 @@ Shared::CartesianFunction::PlotType IntervalParameterSelectorController::plotTyp
   return plotType;
 }
 
-I18n::Message IntervalParameterSelectorController::messageForType(Shared::CartesianFunction::PlotType plotType) {
-  constexpr I18n::Message message[Shared::CartesianFunction::k_numberOfPlotTypes] = {
+I18n::Message IntervalParameterSelectorController::messageForType(Shared::ContinuousFunction::PlotType plotType) {
+  constexpr I18n::Message message[Shared::ContinuousFunction::k_numberOfPlotTypes] = {
     I18n::Message::IntervalX,
     I18n::Message::IntervalTheta,
     I18n::Message::IntervalT
@@ -98,13 +98,13 @@ I18n::Message IntervalParameterSelectorController::messageForType(Shared::Cartes
   return message[static_cast<size_t>(plotType)];
 }
 
-void IntervalParameterSelectorController::setStartEndMessages(Shared::IntervalParameterController * controller, Shared::CartesianFunction::PlotType plotType) {
-  if (plotType == Shared::CartesianFunction::PlotType::Cartesian) {
+void IntervalParameterSelectorController::setStartEndMessages(Shared::IntervalParameterController * controller, Shared::ContinuousFunction::PlotType plotType) {
+  if (plotType == Shared::ContinuousFunction::PlotType::Cartesian) {
     controller->setStartEndMessages(I18n::Message::XStart, I18n::Message::XEnd);
-  } else if (plotType == Shared::CartesianFunction::PlotType::Polar) {
+  } else if (plotType == Shared::ContinuousFunction::PlotType::Polar) {
     controller->setStartEndMessages(I18n::Message::ThetaStart, I18n::Message::ThetaEnd);
   } else {
-    assert(plotType == Shared::CartesianFunction::PlotType::Parametric);
+    assert(plotType == Shared::ContinuousFunction::PlotType::Parametric);
     controller->setStartEndMessages(I18n::Message::TStart, I18n::Message::TEnd);
   }
 }

--- a/apps/graph/values/interval_parameter_selector_controller.h
+++ b/apps/graph/values/interval_parameter_selector_controller.h
@@ -20,11 +20,11 @@ public:
   int reusableCellCount() const override;
   HighlightCell * reusableCell(int index) override;
   void willDisplayCellForIndex(HighlightCell * cell, int index) override;
-  void setStartEndMessages(Shared::IntervalParameterController * controller, Shared::CartesianFunction::PlotType plotType);
+  void setStartEndMessages(Shared::IntervalParameterController * controller, Shared::ContinuousFunction::PlotType plotType);
 private:
-  Shared::CartesianFunction::PlotType plotTypeAtRow(int j) const;
-  I18n::Message messageForType(Shared::CartesianFunction::PlotType plotType);
-  MessageTableCellWithChevron m_intervalParameterCell[Shared::CartesianFunction::k_numberOfPlotTypes];
+  Shared::ContinuousFunction::PlotType plotTypeAtRow(int j) const;
+  I18n::Message messageForType(Shared::ContinuousFunction::PlotType plotType);
+  MessageTableCellWithChevron m_intervalParameterCell[Shared::ContinuousFunction::k_numberOfPlotTypes];
   SelectableTableView m_selectableTableView;
 };
 

--- a/apps/graph/values/interval_parameter_selector_controller.h
+++ b/apps/graph/values/interval_parameter_selector_controller.h
@@ -2,8 +2,8 @@
 #define GRAPH_INTERVAL_PARAMETER_SELECTOR_CONTROLLER
 
 #include <escher.h>
-#include "../../shared/cartesian_function.h"
 #include <apps/shared/interval_parameter_controller.h>
+#include "../../shared/continuous_function.h"
 
 namespace Graph {
 

--- a/apps/graph/values/values_controller.h
+++ b/apps/graph/values/values_controller.h
@@ -1,7 +1,7 @@
 #ifndef GRAPH_VALUES_CONTROLLER_H
 #define GRAPH_VALUES_CONTROLLER_H
 
-#include "../cartesian_function_store.h"
+#include "../continuous_function_store.h"
 #include "../../shared/buffer_function_title_cell.h"
 #include "../../shared/hideable_even_odd_buffer_text_cell.h"
 #include "../../shared/values_controller.h"

--- a/apps/graph/values/values_controller.h
+++ b/apps/graph/values/values_controller.h
@@ -46,7 +46,7 @@ private:
   int maxNumberOfCells() override;
   int maxNumberOfFunctions() override;
   double evaluationOfAbscissaAtColumn(double abscissa, int columnIndex) override;
-  CartesianFunctionStore * functionStore() const override { return static_cast<CartesianFunctionStore *>(Shared::ValuesController::functionStore()); }
+  ContinuousFunctionStore * functionStore() const override { return static_cast<ContinuousFunctionStore *>(Shared::ValuesController::functionStore()); }
   Shared::BufferFunctionTitleCell * functionTitleCells(int j) override;
   EvenOddBufferTextCell * floatCells(int j) override;
   int abscissaCellsCount() const override { return k_maxNumberOfAbscissaCells; }

--- a/apps/graph/values/values_controller.h
+++ b/apps/graph/values/values_controller.h
@@ -32,7 +32,7 @@ public:
   void tableViewDidChangeSelection(SelectableTableView * t, int previousSelectedCellX, int previousSelectedCellY, bool withinTemporarySelection = false) override;
 private:
   constexpr static int k_maxNumberOfFunctions = 5;
-  constexpr static int k_maxNumberOfAbscissaCells = Shared::CartesianFunction::k_numberOfPlotTypes * k_maxNumberOfRows;
+  constexpr static int k_maxNumberOfAbscissaCells = Shared::ContinuousFunction::k_numberOfPlotTypes * k_maxNumberOfRows;
   constexpr static int k_maxNumberOfCells = k_maxNumberOfFunctions * k_maxNumberOfRows;
 
   void setStartEndMessages(Shared::IntervalParameterController * controller, int column) override;
@@ -42,7 +42,7 @@ private:
   int numberOfColumnsForRecord(Ion::Storage::Record record) const;
   Shared::Interval * intervalAtColumn(int columnIndex) override;
   I18n::Message valuesParameterMessageAtColumn(int columnIndex) const override;
-  Shared::CartesianFunction::PlotType plotTypeAtColumn(int * i) const;
+  Shared::ContinuousFunction::PlotType plotTypeAtColumn(int * i) const;
   int maxNumberOfCells() override;
   int maxNumberOfFunctions() override;
   double evaluationOfAbscissaAtColumn(double abscissa, int columnIndex) override;
@@ -51,14 +51,14 @@ private:
   EvenOddBufferTextCell * floatCells(int j) override;
   int abscissaCellsCount() const override { return k_maxNumberOfAbscissaCells; }
   EvenOddEditableTextCell * abscissaCells(int j) override { assert (j >= 0 && j < k_maxNumberOfAbscissaCells); return &m_abscissaCells[j]; }
-  int abscissaTitleCellsCount() const override { return Shared::CartesianFunction::k_numberOfPlotTypes; }
+  int abscissaTitleCellsCount() const override { return Shared::ContinuousFunction::k_numberOfPlotTypes; }
   EvenOddMessageTextCell * abscissaTitleCells(int j) override { assert (j >= 0 && j < abscissaTitleCellsCount()); return &m_abscissaTitleCells[j]; }
   ViewController * functionParameterController() override;
 
-  mutable int m_numberOfColumnsForType[Shared::CartesianFunction::k_numberOfPlotTypes];
+  mutable int m_numberOfColumnsForType[Shared::ContinuousFunction::k_numberOfPlotTypes];
   Shared::BufferFunctionTitleCell m_functionTitleCells[k_maxNumberOfFunctions];
   Shared::HideableEvenOddBufferTextCell m_floatCells[k_maxNumberOfCells];
-  AbscissaTitleCell m_abscissaTitleCells[Shared::CartesianFunction::k_numberOfPlotTypes];
+  AbscissaTitleCell m_abscissaTitleCells[Shared::ContinuousFunction::k_numberOfPlotTypes];
   Shared::StoreCell m_abscissaCells[k_maxNumberOfAbscissaCells];
   FunctionParameterController m_functionParameterController;
   Shared::IntervalParameterController m_intervalParameterController;

--- a/apps/sequence/app.h
+++ b/apps/sequence/app.h
@@ -46,7 +46,7 @@ public:
   // NestedMenuController * variableBoxForInputEventHandler(InputEventHandler * textInput) override;
   CodePoint XNT() override { return 'n'; }
   SequenceContext * localContext() override;
-  SequenceStore * functionStore() override { return static_cast<SequenceStore *>(Shared::FunctionApp::functionStore()); }
+  SequenceStore * functionStore() override { return snapshot()->functionStore(); }
   Shared::Interval * interval() { return snapshot()->interval(); }
   ValuesController * valuesController() override {
     return &m_valuesController;

--- a/apps/sequence/list/list_controller.cpp
+++ b/apps/sequence/list/list_controller.cpp
@@ -87,9 +87,9 @@ void ListController::selectPreviousNewSequenceCell() {
 void ListController::editExpression(int sequenceDefinition, Ion::Events::Event event) {
   Ion::Storage::Record record = modelStore()->recordAtIndex(modelIndexForRow(selectedRow()));
   Sequence * sequence = modelStore()->modelForRecord(record);
-  char * initialText = nullptr;
-  char initialTextContent[TextField::maxBufferSize()];
+  InputViewController * inputController = Shared::FunctionApp::app()->inputViewController();
   if (event == Ion::Events::OK || event == Ion::Events::EXE) {
+    char initialTextContent[Constant::MaxSerializedExpressionSize];
     switch (sequenceDefinition) {
       case 0:
         sequence->text(initialTextContent, sizeof(initialTextContent));
@@ -101,14 +101,13 @@ void ListController::editExpression(int sequenceDefinition, Ion::Events::Event e
         sequence->secondInitialConditionText(initialTextContent, sizeof(initialTextContent));
         break;
     }
-    initialText = initialTextContent;
+    inputController->setTextBody(initialTextContent);
   }
-  InputViewController * inputController = Shared::FunctionApp::app()->inputViewController();
   // Invalidate the sequences context cache
   App::app()->localContext()->resetCache();
   switch (sequenceDefinition) {
     case 0:
-      inputController->edit(this, event, this, initialText,
+      inputController->edit(this, event, this,
         [](void * context, void * sender){
         ListController * myController = static_cast<ListController *>(context);
         InputViewController * myInputViewController = (InputViewController *)sender;
@@ -120,7 +119,7 @@ void ListController::editExpression(int sequenceDefinition, Ion::Events::Event e
       });
       break;
   case 1:
-    inputController->edit(this, event, this, initialText,
+    inputController->edit(this, event, this,
       [](void * context, void * sender){
       ListController * myController = static_cast<ListController *>(context);
       InputViewController * myInputViewController = (InputViewController *)sender;
@@ -132,7 +131,7 @@ void ListController::editExpression(int sequenceDefinition, Ion::Events::Event e
     });
     break;
   default:
-    inputController->edit(this, event, this, initialText,
+    inputController->edit(this, event, this,
       [](void * context, void * sender){
       ListController * myController = static_cast<ListController *>(context);
       InputViewController * myInputViewController = (InputViewController *)sender;

--- a/apps/sequence/list/list_controller.cpp
+++ b/apps/sequence/list/list_controller.cpp
@@ -291,4 +291,8 @@ bool ListController::removeModelRow(Ion::Storage::Record record) {
   return true;
 }
 
+SequenceStore * ListController::modelStore() {
+  return App::app()->functionStore();
+}
+
 }

--- a/apps/sequence/list/list_controller.cpp
+++ b/apps/sequence/list/list_controller.cpp
@@ -230,10 +230,6 @@ int ListController::modelIndexForRow(int j) {
   return sequenceIndex;
 }
 
-bool ListController::isAddEmptyRow(int j) {
-  return modelStore()->numberOfModels() < modelStore()->maxNumberOfModels() && j == numberOfRows() - 1;
-}
-
 int ListController::sequenceDefinitionForRow(int j) {
   if (j < 0) {
     return j;

--- a/apps/sequence/list/list_controller.cpp
+++ b/apps/sequence/list/list_controller.cpp
@@ -40,8 +40,7 @@ int ListController::numberOfExpressionRows() const {
 
 KDCoordinate ListController::expressionRowHeight(int j) {
   KDCoordinate defaultHeight = Metric::StoreRowHeight;
-  if (modelStore()->numberOfModels() < modelStore()->maxNumberOfModels() && j == numberOfRows() - 1) {
-    // Add sequence row
+  if (isAddEmptyRow(j)) {
     return defaultHeight;
   }
   Sequence * sequence = modelStore()->modelForRecord(modelStore()->recordAtIndex(modelIndexForRow(j)));

--- a/apps/sequence/list/list_controller.h
+++ b/apps/sequence/list/list_controller.h
@@ -40,7 +40,7 @@ private:
   void reinitSelectedExpression(Shared::ExpiringPointer<Shared::ExpressionModelHandle> model) override;
   void editExpression(Ion::Events::Event event) override;
   bool removeModelRow(Ion::Storage::Record record) override;
-  SequenceStore * modelStore() override { return static_cast<SequenceStore *>(Shared::FunctionListController::modelStore()); }
+  SequenceStore * modelStore() override;
   constexpr static int k_maxNumberOfRows = 3*MaxNumberOfSequences;
   SequenceTitleCell m_sequenceTitleCells[k_maxNumberOfRows];
   Shared::FunctionExpressionCell m_expressionCells[k_maxNumberOfRows];

--- a/apps/sequence/list/list_controller.h
+++ b/apps/sequence/list/list_controller.h
@@ -35,7 +35,6 @@ private:
   void willDisplayTitleCellAtIndex(HighlightCell * cell, int j) override;
   void willDisplayExpressionCellAtIndex(HighlightCell * cell, int j) override;
   int modelIndexForRow(int j) override;
-  bool isAddEmptyRow(int j) override;
   int sequenceDefinitionForRow(int j);
   void addEmptyModel() override;
   void reinitSelectedExpression(Shared::ExpiringPointer<Shared::ExpressionModelHandle> model) override;

--- a/apps/sequence/sequence.cpp
+++ b/apps/sequence/sequence.cpp
@@ -104,14 +104,11 @@ bool Sequence::isDefined() {
 
 bool Sequence::isEmpty() {
   RecordDataBuffer * data = recordData();
-  switch (type()) {
-    case Type::Explicit:
-      return Function::isEmpty();
-    case Type::SingleRecurrence:
-      return Function::isEmpty() && data->initialConditionSize(0) == 0;
-    default:
-      return Function::isEmpty() && data->initialConditionSize(0) == 0 && data->initialConditionSize(1) == 0;
-  }
+  Type type = data->type();
+  return Function::isEmpty() &&
+    (type == Type::Explicit ||
+      (data->initialConditionSize(0) == 0 &&
+        (type == Type::SingleRecurrence || data->initialConditionSize(1) == 0)));
 }
 
 template<typename T>

--- a/apps/sequence/sequence.cpp
+++ b/apps/sequence/sequence.cpp
@@ -91,7 +91,7 @@ Poincare::Layout Sequence::nameLayout() {
 }
 
 bool Sequence::isDefined() {
-  SequenceRecordDataBuffer * data = recordData();
+  RecordDataBuffer * data = recordData();
   switch (type()) {
     case Type::Explicit:
       return value().size > metaDataSize();
@@ -103,7 +103,7 @@ bool Sequence::isDefined() {
 }
 
 bool Sequence::isEmpty() {
-  SequenceRecordDataBuffer * data = recordData();
+  RecordDataBuffer * data = recordData();
   switch (type()) {
     case Type::Explicit:
       return Function::isEmpty();
@@ -195,10 +195,10 @@ Expression Sequence::sumBetweenBounds(double start, double end, Poincare::Contex
   return Poincare::Sum::Builder(expressionReduced(context).clone(), Poincare::Symbol::Builder(UCodePointUnknownX), Poincare::Float<double>::Builder(start), Poincare::Float<double>::Builder(end)); // Sum takes ownership of args
 }
 
-Sequence::SequenceRecordDataBuffer * Sequence::recordData() const {
+Sequence::RecordDataBuffer * Sequence::recordData() const {
   assert(!isNull());
   Ion::Storage::Record::Data d = value();
-  return reinterpret_cast<SequenceRecordDataBuffer *>(const_cast<void *>(d.buffer));
+  return reinterpret_cast<RecordDataBuffer *>(const_cast<void *>(d.buffer));
 }
 
 /* Sequence Model */
@@ -227,13 +227,13 @@ void Sequence::SequenceModel::updateNewDataWithExpression(Ion::Storage::Record *
 /* Definition Handle*/
 
 void * Sequence::DefinitionModel::expressionAddress(const Ion::Storage::Record * record) const {
-  return (char *)record->value().buffer+sizeof(SequenceRecordDataBuffer);
+  return (char *)record->value().buffer+sizeof(RecordDataBuffer);
 }
 
 size_t Sequence::DefinitionModel::expressionSize(const Ion::Storage::Record * record) const {
   Ion::Storage::Record::Data data = record->value();
-  SequenceRecordDataBuffer * dataBuffer = static_cast<const Sequence *>(record)->recordData();
-  return data.size-sizeof(SequenceRecordDataBuffer) - dataBuffer->initialConditionSize(0) - dataBuffer->initialConditionSize(1);
+  RecordDataBuffer * dataBuffer = static_cast<const Sequence *>(record)->recordData();
+  return data.size-sizeof(RecordDataBuffer) - dataBuffer->initialConditionSize(0) - dataBuffer->initialConditionSize(1);
 }
 
 void Sequence::DefinitionModel::buildName(Sequence * sequence) {
@@ -258,7 +258,7 @@ void Sequence::DefinitionModel::buildName(Sequence * sequence) {
 
 void * Sequence::InitialConditionModel::expressionAddress(const Ion::Storage::Record * record) const {
   Ion::Storage::Record::Data data = record->value();
-  SequenceRecordDataBuffer * dataBuffer = static_cast<const Sequence *>(record)->recordData();
+  RecordDataBuffer * dataBuffer = static_cast<const Sequence *>(record)->recordData();
   size_t offset = conditionIndex() == 0 ? data.size - dataBuffer->initialConditionSize(0) - dataBuffer->initialConditionSize(1) : data.size - dataBuffer->initialConditionSize(1) ;
   return (char *)data.buffer+offset;
 }

--- a/apps/sequence/sequence.cpp
+++ b/apps/sequence/sequence.cpp
@@ -189,6 +189,7 @@ T Sequence::approximateToNextRank(int n, SequenceContext * sqctx) const {
 }
 
 Expression Sequence::sumBetweenBounds(double start, double end, Poincare::Context * context) const {
+  assert(std::round(start) == start && std::round(end) == end);
   return Poincare::Sum::Builder(expressionReduced(context).clone(), Poincare::Symbol::Builder(UCodePointUnknownX), Poincare::Float<double>::Builder(start), Poincare::Float<double>::Builder(end)); // Sum takes ownership of args
 }
 

--- a/apps/sequence/sequence.h
+++ b/apps/sequence/sequence.h
@@ -73,11 +73,11 @@ private:
 
   /* SequenceRecordDataBuffer is the layout of the data buffer of Record
    * representing a Sequence. See comment in
-   * Shared::Function::FunctionRecordDataBuffer about packing. */
-  class SequenceRecordDataBuffer : public FunctionRecordDataBuffer {
+   * Shared::Function::RecordDataBuffer about packing. */
+  class SequenceRecordDataBuffer : public Shared::Function::RecordDataBuffer {
   public:
     SequenceRecordDataBuffer(KDColor color) :
-      FunctionRecordDataBuffer(color),
+      Shared::Function::RecordDataBuffer(color),
       m_type(Type::Explicit),
       m_initialRank(0),
       m_initialConditionSizes{0,0}
@@ -99,7 +99,7 @@ private:
     Type m_type;
     uint8_t m_initialRank;
 #if __EMSCRIPTEN__
-    // See comment about emscripten alignement in Shared::Function::FunctionRecordDataBuffer
+    // See comment about emscripten alignement in Shared::Function::RecordDataBuffer
     static_assert(sizeof(emscripten_align1_short) == sizeof(uint16_t), "emscripten_align1_short should have the same size as uint16_t");
     emscripten_align1_short m_initialConditionSizes[2] __attribute__((packed));
 #else

--- a/apps/sequence/sequence.h
+++ b/apps/sequence/sequence.h
@@ -71,12 +71,12 @@ public:
 private:
   constexpr static const KDFont * k_layoutFont = KDFont::LargeFont;
 
-  /* SequenceRecordDataBuffer is the layout of the data buffer of Record
+  /* RecordDataBuffer is the layout of the data buffer of Record
    * representing a Sequence. See comment in
    * Shared::Function::RecordDataBuffer about packing. */
-  class SequenceRecordDataBuffer : public Shared::Function::RecordDataBuffer {
+  class RecordDataBuffer : public Shared::Function::RecordDataBuffer {
   public:
-    SequenceRecordDataBuffer(KDColor color) :
+    RecordDataBuffer(KDColor color) :
       Shared::Function::RecordDataBuffer(color),
       m_type(Type::Explicit),
       m_initialRank(0),
@@ -149,9 +149,9 @@ private:
   };
 
   template<typename T> T templatedApproximateAtAbscissa(T x, SequenceContext * sqctx) const;
-  size_t metaDataSize() const override { return sizeof(SequenceRecordDataBuffer); }
+  size_t metaDataSize() const override { return sizeof(RecordDataBuffer); }
   const Shared::ExpressionModel * model() const override { return &m_definition; }
-  SequenceRecordDataBuffer * recordData() const;
+  RecordDataBuffer * recordData() const;
   DefinitionModel m_definition;
   FirstInitialConditionModel m_firstInitialCondition;
   SecondInitialConditionModel m_secondInitialCondition;

--- a/apps/sequence/sequence_store.cpp
+++ b/apps/sequence/sequence_store.cpp
@@ -32,7 +32,7 @@ Ion::Storage::Record::ErrorStatus SequenceStore::addEmptyModel() {
   assert(name);
   // Choose the corresponding color
   KDColor color = Palette::DataColor[nameIndex];
-  Sequence::SequenceRecordDataBuffer data(color);
+  Sequence::RecordDataBuffer data(color);
   // m_sequences
   return Ion::Storage::sharedStorage()->createRecordWithExtension(name, modelExtension(), &data, sizeof(data));
 }

--- a/apps/sequence/values/values_controller.cpp
+++ b/apps/sequence/values/values_controller.cpp
@@ -64,8 +64,8 @@ bool ValuesController::setDataAtLocation(double floatBody, int columnIndex, int 
 }
 
 double ValuesController::evaluationOfAbscissaAtColumn(double abscissa, int columnIndex) {
-  Shared::ExpiringPointer<Shared::Function> function = functionStore()->modelForRecord(recordAtColumn(columnIndex));
-  Poincare::Coordinate2D<double> xy = function->evaluateXYAtParameter(abscissa, textFieldDelegateApp()->localContext());
+  Shared::ExpiringPointer<Sequence> sequence = functionStore()->modelForRecord(recordAtColumn(columnIndex));
+  Poincare::Coordinate2D<double> xy = sequence->evaluateXYAtParameter(abscissa, textFieldDelegateApp()->localContext());
   return xy.x2();
 }
 

--- a/apps/shared/Makefile
+++ b/apps/shared/Makefile
@@ -1,5 +1,5 @@
 app_shared_test_src = $(addprefix apps/shared/,\
-  cartesian_function.cpp\
+  continuous_function.cpp\
   curve_view_range.cpp \
   double_pair_store.cpp \
   expression_model.cpp \

--- a/apps/shared/cartesian_function.cpp
+++ b/apps/shared/cartesian_function.cpp
@@ -58,7 +58,7 @@ CartesianFunction CartesianFunction::NewModel(Ion::Storage::Record::ErrorStatus 
   // Create the record
   char nameBuffer[SymbolAbstract::k_maxNameSize];
   int numberOfColors = sizeof(Palette::DataColor)/sizeof(KDColor);
-  CartesianFunctionRecordDataBuffer data(Palette::DataColor[s_colorIndex++ % numberOfColors]);
+  RecordDataBuffer data(Palette::DataColor[s_colorIndex++ % numberOfColors]);
   if (baseName == nullptr) {
     DefaultName(nameBuffer, SymbolAbstract::k_maxNameSize);
     baseName = nameBuffer;
@@ -261,17 +261,17 @@ void CartesianFunction::setTMax(float tMax) {
 }
 
 void * CartesianFunction::Model::expressionAddress(const Ion::Storage::Record * record) const {
-  return (char *)record->value().buffer+sizeof(CartesianFunctionRecordDataBuffer);
+  return (char *)record->value().buffer+sizeof(RecordDataBuffer);
 }
 
 size_t CartesianFunction::Model::expressionSize(const Ion::Storage::Record * record) const {
-  return record->value().size-sizeof(CartesianFunctionRecordDataBuffer);
+  return record->value().size-sizeof(RecordDataBuffer);
 }
 
-CartesianFunction::CartesianFunctionRecordDataBuffer * CartesianFunction::recordData() const {
+CartesianFunction::RecordDataBuffer * CartesianFunction::recordData() const {
   assert(!isNull());
   Ion::Storage::Record::Data d = value();
-  return reinterpret_cast<CartesianFunctionRecordDataBuffer *>(const_cast<void *>(d.buffer));
+  return reinterpret_cast<RecordDataBuffer *>(const_cast<void *>(d.buffer));
 }
 
 template<typename T>

--- a/apps/shared/cartesian_function.cpp
+++ b/apps/shared/cartesian_function.cpp
@@ -22,7 +22,7 @@ namespace Shared {
 static inline double maxDouble(double x, double y) { return x > y ? x : y; }
 static inline double minDouble(double x, double y) { return x < y ? x : y; }
 
-void CartesianFunction::DefaultName(char buffer[], size_t bufferSize) {
+void ContinuousFunction::DefaultName(char buffer[], size_t bufferSize) {
   constexpr int k_maxNumberOfDefaultLetterNames = 4;
   static constexpr const char k_defaultLetterNames[k_maxNumberOfDefaultLetterNames] = {
     'f', 'g', 'h', 'p'
@@ -53,7 +53,7 @@ void CartesianFunction::DefaultName(char buffer[], size_t bufferSize) {
   assert(currentNumberLength >= 0 && currentNumberLength < availableBufferSize);
 }
 
-CartesianFunction CartesianFunction::NewModel(Ion::Storage::Record::ErrorStatus * error, const char * baseName) {
+ContinuousFunction ContinuousFunction::NewModel(Ion::Storage::Record::ErrorStatus * error, const char * baseName) {
   static int s_colorIndex = 0;
   // Create the record
   char nameBuffer[SymbolAbstract::k_maxNameSize];
@@ -67,14 +67,14 @@ CartesianFunction CartesianFunction::NewModel(Ion::Storage::Record::ErrorStatus 
 
   // Return if error
   if (*error != Ion::Storage::Record::ErrorStatus::None) {
-    return CartesianFunction();
+    return ContinuousFunction();
   }
 
-  // Return the CartesianFunction withthe new record
-  return CartesianFunction(Ion::Storage::sharedStorage()->recordBaseNamedWithExtension(baseName, Ion::Storage::funcExtension));
+  // Return the ContinuousFunction withthe new record
+  return ContinuousFunction(Ion::Storage::sharedStorage()->recordBaseNamedWithExtension(baseName, Ion::Storage::funcExtension));
 }
 
-int CartesianFunction::derivativeNameWithArgument(char * buffer, size_t bufferSize) {
+int ContinuousFunction::derivativeNameWithArgument(char * buffer, size_t bufferSize) {
   // Fill buffer with f(x). Keep size for derivative sign.
   int derivativeSize = UTF8Decoder::CharSizeOfCodePoint('\'');
   int numberOfChars = nameWithArgument(buffer, bufferSize - derivativeSize);
@@ -88,7 +88,7 @@ int CartesianFunction::derivativeNameWithArgument(char * buffer, size_t bufferSi
   return numberOfChars + derivativeSize;
 }
 
-Poincare::Expression CartesianFunction::expressionReduced(Poincare::Context * context) const {
+Poincare::Expression ContinuousFunction::expressionReduced(Poincare::Context * context) const {
   Poincare::Expression result = ExpressionModelHandle::expressionReduced(context);
   if (plotType() == PlotType::Parametric && (
       result.type() != Poincare::ExpressionNode::Type::Matrix ||
@@ -100,11 +100,11 @@ Poincare::Expression CartesianFunction::expressionReduced(Poincare::Context * co
   return result;
 }
 
-I18n::Message CartesianFunction::parameterMessageName() const {
+I18n::Message ContinuousFunction::parameterMessageName() const {
   return ParameterMessageForPlotType(plotType());
 }
 
-CodePoint CartesianFunction::symbol() const {
+CodePoint ContinuousFunction::symbol() const {
   switch (plotType()) {
   case PlotType::Cartesian:
     return 'x';
@@ -116,11 +116,11 @@ CodePoint CartesianFunction::symbol() const {
   }
 }
 
-CartesianFunction::PlotType CartesianFunction::plotType() const {
+ContinuousFunction::PlotType ContinuousFunction::plotType() const {
   return recordData()->plotType();
 }
 
-void CartesianFunction::setPlotType(PlotType newPlotType, Poincare::Preferences::AngleUnit angleUnit) {
+void ContinuousFunction::setPlotType(PlotType newPlotType, Poincare::Preferences::AngleUnit angleUnit) {
   PlotType currentPlotType = plotType();
   if (newPlotType == currentPlotType) {
     return;
@@ -174,7 +174,7 @@ void CartesianFunction::setPlotType(PlotType newPlotType, Poincare::Preferences:
   }
 }
 
-I18n::Message CartesianFunction::ParameterMessageForPlotType(PlotType plotType) {
+I18n::Message ContinuousFunction::ParameterMessageForPlotType(PlotType plotType) {
   if (plotType == PlotType::Cartesian) {
     return I18n::Message::X;
   }
@@ -186,7 +186,7 @@ I18n::Message CartesianFunction::ParameterMessageForPlotType(PlotType plotType) 
 }
 
 template <typename T>
-Poincare::Coordinate2D<T> CartesianFunction::privateEvaluateXYAtParameter(T t, Poincare::Context * context) const {
+Poincare::Coordinate2D<T> ContinuousFunction::privateEvaluateXYAtParameter(T t, Poincare::Context * context) const {
   Coordinate2D<T> x1x2 = templatedApproximateAtParameter(t, context);
   PlotType type = plotType();
   if (type == PlotType::Cartesian || type == PlotType::Parametric) {
@@ -206,15 +206,15 @@ Poincare::Coordinate2D<T> CartesianFunction::privateEvaluateXYAtParameter(T t, P
   return Coordinate2D<T>(x1x2.x2() * std::cos(angle), x1x2.x2() * std::sin(angle));
 }
 
-bool CartesianFunction::displayDerivative() const {
+bool ContinuousFunction::displayDerivative() const {
   return recordData()->displayDerivative();
 }
 
-void CartesianFunction::setDisplayDerivative(bool display) {
+void ContinuousFunction::setDisplayDerivative(bool display) {
   return recordData()->setDisplayDerivative(display);
 }
 
-int CartesianFunction::printValue(double cursorT, double cursorX, double cursorY, char * buffer, int bufferSize, int precision, Poincare::Context * context) {
+int ContinuousFunction::printValue(double cursorT, double cursorX, double cursorY, char * buffer, int bufferSize, int precision, Poincare::Context * context) {
   PlotType type = plotType();
   if (type == PlotType::Cartesian) {
     return Function::printValue(cursorT, cursorX, cursorY, buffer, bufferSize, precision, context);
@@ -232,7 +232,7 @@ int CartesianFunction::printValue(double cursorT, double cursorX, double cursorY
   return result;
 }
 
-double CartesianFunction::approximateDerivative(double x, Poincare::Context * context) const {
+double ContinuousFunction::approximateDerivative(double x, Poincare::Context * context) const {
   assert(plotType() == PlotType::Cartesian);
   if (x < tMin() || x > tMax()) {
     return NAN;
@@ -244,38 +244,38 @@ double CartesianFunction::approximateDerivative(double x, Poincare::Context * co
   return PoincareHelpers::ApproximateToScalar<double>(derivative, context);
 }
 
-float CartesianFunction::tMin() const {
+float ContinuousFunction::tMin() const {
   return recordData()->tMin();
 }
 
-float CartesianFunction::tMax() const {
+float ContinuousFunction::tMax() const {
   return recordData()->tMax();
 }
 
-void CartesianFunction::setTMin(float tMin) {
+void ContinuousFunction::setTMin(float tMin) {
   recordData()->setTMin(tMin);
 }
 
-void CartesianFunction::setTMax(float tMax) {
+void ContinuousFunction::setTMax(float tMax) {
   recordData()->setTMax(tMax);
 }
 
-void * CartesianFunction::Model::expressionAddress(const Ion::Storage::Record * record) const {
+void * ContinuousFunction::Model::expressionAddress(const Ion::Storage::Record * record) const {
   return (char *)record->value().buffer+sizeof(RecordDataBuffer);
 }
 
-size_t CartesianFunction::Model::expressionSize(const Ion::Storage::Record * record) const {
+size_t ContinuousFunction::Model::expressionSize(const Ion::Storage::Record * record) const {
   return record->value().size-sizeof(RecordDataBuffer);
 }
 
-CartesianFunction::RecordDataBuffer * CartesianFunction::recordData() const {
+ContinuousFunction::RecordDataBuffer * ContinuousFunction::recordData() const {
   assert(!isNull());
   Ion::Storage::Record::Data d = value();
   return reinterpret_cast<RecordDataBuffer *>(const_cast<void *>(d.buffer));
 }
 
 template<typename T>
-Coordinate2D<T> CartesianFunction::templatedApproximateAtParameter(T t, Poincare::Context * context) const {
+Coordinate2D<T> ContinuousFunction::templatedApproximateAtParameter(T t, Poincare::Context * context) const {
   if (isCircularlyDefined(context) || t < tMin() || t > tMax()) {
     return Coordinate2D<T>(plotType() == PlotType::Cartesian ? t : NAN, NAN);
   }
@@ -296,19 +296,19 @@ Coordinate2D<T> CartesianFunction::templatedApproximateAtParameter(T t, Poincare
       PoincareHelpers::ApproximateWithValueForSymbol(e.childAtIndex(1), unknown, t, context));
 }
 
-Coordinate2D<double> CartesianFunction::nextMinimumFrom(double start, double step, double max, Context * context) const {
+Coordinate2D<double> ContinuousFunction::nextMinimumFrom(double start, double step, double max, Context * context) const {
   return nextPointOfInterestFrom(start, step, max, context, [](Expression e, char * symbol, double start, double step, double max, Context * context) { return PoincareHelpers::NextMinimum(e, symbol, start, step, max, context); });
 }
 
-Coordinate2D<double> CartesianFunction::nextMaximumFrom(double start, double step, double max, Context * context) const {
+Coordinate2D<double> ContinuousFunction::nextMaximumFrom(double start, double step, double max, Context * context) const {
   return nextPointOfInterestFrom(start, step, max, context, [](Expression e, char * symbol, double start, double step, double max, Context * context) { return PoincareHelpers::NextMaximum(e, symbol, start, step, max, context); });
 }
 
-Coordinate2D<double> CartesianFunction::nextRootFrom(double start, double step, double max, Context * context) const {
+Coordinate2D<double> ContinuousFunction::nextRootFrom(double start, double step, double max, Context * context) const {
   return nextPointOfInterestFrom(start, step, max, context, [](Expression e, char * symbol, double start, double step, double max, Context * context) { return Coordinate2D<double>(PoincareHelpers::NextRoot(e, symbol, start, step, max, context), 0.0); });
 }
 
-Coordinate2D<double> CartesianFunction::nextIntersectionFrom(double start, double step, double max, Poincare::Context * context, Poincare::Expression e, double eDomainMin, double eDomainMax) const {
+Coordinate2D<double> ContinuousFunction::nextIntersectionFrom(double start, double step, double max, Poincare::Context * context, Poincare::Expression e, double eDomainMin, double eDomainMax) const {
   assert(plotType() == PlotType::Cartesian);
   constexpr int bufferSize = CodePoint::MaxCodePointCharLength + 1;
   char unknownX[bufferSize];
@@ -325,7 +325,7 @@ Coordinate2D<double> CartesianFunction::nextIntersectionFrom(double start, doubl
   return PoincareHelpers::NextIntersection(expressionReduced(context), unknownX, start, step, max, context, e);
 }
 
-Coordinate2D<double> CartesianFunction::nextPointOfInterestFrom(double start, double step, double max, Context * context, ComputePointOfInterest compute) const {
+Coordinate2D<double> ContinuousFunction::nextPointOfInterestFrom(double start, double step, double max, Context * context, ComputePointOfInterest compute) const {
   assert(plotType() == PlotType::Cartesian);
   constexpr int bufferSize = CodePoint::MaxCodePointCharLength + 1;
   char unknownX[bufferSize];
@@ -340,7 +340,7 @@ Coordinate2D<double> CartesianFunction::nextPointOfInterestFrom(double start, do
   return compute(expressionReduced(context), unknownX, start, step, max, context);
 }
 
-Poincare::Expression CartesianFunction::sumBetweenBounds(double start, double end, Poincare::Context * context) const {
+Poincare::Expression ContinuousFunction::sumBetweenBounds(double start, double end, Poincare::Context * context) const {
   assert(plotType() == PlotType::Cartesian);
   start = maxDouble(start, tMin());
   end = minDouble(end, tMax());
@@ -350,7 +350,7 @@ Poincare::Expression CartesianFunction::sumBetweenBounds(double start, double en
    * the derivative table. */
 }
 
-template Coordinate2D<float> CartesianFunction::templatedApproximateAtParameter<float>(float, Poincare::Context *) const;
-template Coordinate2D<double> CartesianFunction::templatedApproximateAtParameter<double>(double, Poincare::Context *) const;
+template Coordinate2D<float> ContinuousFunction::templatedApproximateAtParameter<float>(float, Poincare::Context *) const;
+template Coordinate2D<double> ContinuousFunction::templatedApproximateAtParameter<double>(double, Poincare::Context *) const;
 
 }

--- a/apps/shared/cartesian_function.cpp
+++ b/apps/shared/cartesian_function.cpp
@@ -1,5 +1,4 @@
 #include "cartesian_function.h"
-#include "expression_model_store.h"
 #include "poincare_helpers.h"
 #include <apps/constant.h>
 #include <poincare/derivative.h>
@@ -10,6 +9,7 @@
 #include <poincare/serialization_helper.h>
 #include <poincare/trigonometry.h>
 #include <escher/palette.h>
+#include <ion/unicode/utf8_helper.h>
 #include <ion/unicode/utf8_decoder.h>
 #include <apps/i18n.h>
 #include <float.h>

--- a/apps/shared/cartesian_function.h
+++ b/apps/shared/cartesian_function.h
@@ -72,11 +72,11 @@ private:
   template <typename T> Poincare::Coordinate2D<T> privateEvaluateXYAtParameter(T t, Poincare::Context * context) const;
   /* CartesianFunctionRecordDataBuffer is the layout of the data buffer of Record
    * representing a CartesianFunction. See comment on
-   * Shared::Function::FunctionRecordDataBuffer about packing. */
-  class __attribute__((packed)) CartesianFunctionRecordDataBuffer : public FunctionRecordDataBuffer {
+   * Shared::Function::RecordDataBuffer about packing. */
+  class __attribute__((packed)) CartesianFunctionRecordDataBuffer : public Function::RecordDataBuffer {
   public:
     CartesianFunctionRecordDataBuffer(KDColor color) :
-      FunctionRecordDataBuffer(color),
+      Function::RecordDataBuffer(color),
       m_plotType(PlotType::Cartesian),
       m_domain(-INFINITY, INFINITY),
       m_displayDerivative(false)

--- a/apps/shared/cartesian_function.h
+++ b/apps/shared/cartesian_function.h
@@ -70,12 +70,12 @@ private:
   typedef Poincare::Coordinate2D<double> (*ComputePointOfInterest)(Poincare::Expression e, char * symbol, double start, double step, double max, Poincare::Context * context);
   Poincare::Coordinate2D<double> nextPointOfInterestFrom(double start, double step, double max, Poincare::Context * context, ComputePointOfInterest compute) const;
   template <typename T> Poincare::Coordinate2D<T> privateEvaluateXYAtParameter(T t, Poincare::Context * context) const;
-  /* CartesianFunctionRecordDataBuffer is the layout of the data buffer of Record
+  /* RecordDataBuffer is the layout of the data buffer of Record
    * representing a CartesianFunction. See comment on
    * Shared::Function::RecordDataBuffer about packing. */
-  class __attribute__((packed)) CartesianFunctionRecordDataBuffer : public Function::RecordDataBuffer {
+  class __attribute__((packed)) RecordDataBuffer : public Function::RecordDataBuffer {
   public:
-    CartesianFunctionRecordDataBuffer(KDColor color) :
+    RecordDataBuffer(KDColor color) :
       Function::RecordDataBuffer(color),
       m_plotType(PlotType::Cartesian),
       m_domain(-INFINITY, INFINITY),
@@ -103,9 +103,9 @@ private:
   private:
     size_t expressionSize(const Ion::Storage::Record * record) const override;
   };
-  size_t metaDataSize() const override { return sizeof(CartesianFunctionRecordDataBuffer); }
+  size_t metaDataSize() const override { return sizeof(RecordDataBuffer); }
   const ExpressionModel * model() const override { return &m_model; }
-  CartesianFunctionRecordDataBuffer * recordData() const;
+  RecordDataBuffer * recordData() const;
   template<typename T> Poincare::Coordinate2D<T> templatedApproximateAtParameter(T t, Poincare::Context * context) const;
   Model m_model;
 };

--- a/apps/shared/cartesian_function.h
+++ b/apps/shared/cartesian_function.h
@@ -1,6 +1,14 @@
 #ifndef SHARED_CARTESIAN_FUNCTION_H
 #define SHARED_CARTESIAN_FUNCTION_H
 
+/* Although the considered functions are not generally continuous
+ * mathematically speaking, the present class is named ContinuousFunction to
+ * mark the difference with the Sequence class.
+ *
+ * We could not simply name it Function, since such a class already exists:
+ * it is the base class of ContinuousFunction and Sequence.
+ */
+
 #include "global_context.h"
 #include "function.h"
 #include "range_1D.h"
@@ -9,11 +17,11 @@
 
 namespace Shared {
 
-class CartesianFunction : public Function {
+class ContinuousFunction : public Function {
 public:
   static void DefaultName(char buffer[], size_t bufferSize);
-  static CartesianFunction NewModel(Ion::Storage::Record::ErrorStatus * error, const char * baseName = nullptr);
-  CartesianFunction(Ion::Storage::Record record = Record()) :
+  static ContinuousFunction NewModel(Ion::Storage::Record::ErrorStatus * error, const char * baseName = nullptr);
+  ContinuousFunction(Ion::Storage::Record record = Record()) :
     Function(record)
   {}
   I18n::Message parameterMessageName() const override;
@@ -71,7 +79,7 @@ private:
   Poincare::Coordinate2D<double> nextPointOfInterestFrom(double start, double step, double max, Poincare::Context * context, ComputePointOfInterest compute) const;
   template <typename T> Poincare::Coordinate2D<T> privateEvaluateXYAtParameter(T t, Poincare::Context * context) const;
   /* RecordDataBuffer is the layout of the data buffer of Record
-   * representing a CartesianFunction. See comment on
+   * representing a ContinuousFunction. See comment on
    * Shared::Function::RecordDataBuffer about packing. */
   class __attribute__((packed)) RecordDataBuffer : public Function::RecordDataBuffer {
   public:

--- a/apps/shared/continuous_function.cpp
+++ b/apps/shared/continuous_function.cpp
@@ -1,4 +1,4 @@
-#include "cartesian_function.h"
+#include "continuous_function.h"
 #include "poincare_helpers.h"
 #include <apps/constant.h>
 #include <poincare/derivative.h>

--- a/apps/shared/continuous_function.h
+++ b/apps/shared/continuous_function.h
@@ -1,5 +1,5 @@
-#ifndef SHARED_CARTESIAN_FUNCTION_H
-#define SHARED_CARTESIAN_FUNCTION_H
+#ifndef SHARED_CONTINUOUS_FUNCTION_H
+#define SHARED_CONTINUOUS_FUNCTION_H
 
 /* Although the considered functions are not generally continuous
  * mathematically speaking, the present class is named ContinuousFunction to

--- a/apps/shared/expression_model_list_controller.cpp
+++ b/apps/shared/expression_model_list_controller.cpp
@@ -223,16 +223,15 @@ void ExpressionModelListController::reinitSelectedExpression(ExpiringPointer<Exp
 }
 
 void ExpressionModelListController::editExpression(Ion::Events::Event event) {
-  char * initialText = nullptr;
-  constexpr int initialTextContentMaxSize = Constant::MaxSerializedExpressionSize;
-  char initialTextContent[initialTextContentMaxSize];
   if (event == Ion::Events::OK || event == Ion::Events::EXE) {
     Ion::Storage::Record record = modelStore()->recordAtIndex(modelIndexForRow(selectedRow()));
     ExpiringPointer<ExpressionModelHandle> model = modelStore()->modelForRecord(record);
+    constexpr size_t initialTextContentMaxSize = Constant::MaxSerializedExpressionSize;
+    char initialTextContent[initialTextContentMaxSize];
     model->text(initialTextContent, initialTextContentMaxSize);
-    initialText = initialTextContent;
+    inputController()->setTextBody(initialTextContent);
   }
-  inputController()->edit(this, event, this, initialText,
+  inputController()->edit(this, event, this,
       [](void * context, void * sender){
         ExpressionModelListController * myController = static_cast<ExpressionModelListController *>(context);
         InputViewController * myInputViewController = (InputViewController *)sender;

--- a/apps/shared/expression_model_list_controller.cpp
+++ b/apps/shared/expression_model_list_controller.cpp
@@ -146,6 +146,10 @@ int ExpressionModelListController::numberOfExpressionRows() const {
   return modelsCount + (modelsCount == store->maxNumberOfModels() ? 0 : 1);
 }
 
+bool ExpressionModelListController::isAddEmptyRow(int j) {
+  return j == numberOfExpressionRows() - 1 && modelStore()->numberOfModels() != modelStore()->maxNumberOfModels();
+}
+
 KDCoordinate ExpressionModelListController::expressionRowHeight(int j) {
   if (isAddEmptyRow(j)) {
     return Metric::StoreRowHeight;
@@ -252,10 +256,6 @@ bool ExpressionModelListController::removeModelRow(Ion::Storage::Record record) 
   modelStore()->removeModel(record);
   didChangeModelsList();
   return true;
-}
-
-bool ExpressionModelListController::isAddEmptyRow(int j) {
-  return j == modelStore()->numberOfModels();
 }
 
 void ExpressionModelListController::resetMemoizationForIndex(int index) {

--- a/apps/shared/expression_model_list_controller.h
+++ b/apps/shared/expression_model_list_controller.h
@@ -16,6 +16,7 @@ protected:
   void tableViewDidChangeSelection(SelectableTableView * t, int previousSelectedCellX, int previousSelectedCellY, bool withinTemporarySelection) override;
   // TableViewDataSource
   virtual int numberOfExpressionRows() const;
+  bool isAddEmptyRow(int j);
   KDCoordinate memoizedRowHeight(int j);
   KDCoordinate memoizedCumulatedHeightFromIndex(int j);
   int memoizedIndexFromCumulatedHeight(KDCoordinate offsetY);
@@ -30,7 +31,6 @@ protected:
   virtual bool editSelectedRecordWithText(const char * text);
   virtual bool removeModelRow(Ion::Storage::Record record);
   virtual int modelIndexForRow(int j) { return j; }
-  virtual bool isAddEmptyRow(int j);
   // ViewController
   virtual SelectableTableView * selectableTableView() = 0;
   virtual ExpressionModelStore * modelStore() = 0;

--- a/apps/shared/expression_model_store.cpp
+++ b/apps/shared/expression_model_store.cpp
@@ -43,12 +43,13 @@ void ExpressionModelStore::tidy() {
 int ExpressionModelStore::numberOfModelsSatisfyingTest(ModelTest test) const {
   int count = 0;
   int index = 0;
+  Ion::Storage::Record record;
   do {
-    ExpressionModelHandle * m = privateModelForRecord(recordAtIndex(index++));
-    if (m->isNull()) {
+    record = recordAtIndex(index++);
+    if (record.isNull()) {
       break;
     }
-    if (test(m)) {
+    if (test(privateModelForRecord(record))) {
       count++;
     }
   } while (true);
@@ -62,12 +63,11 @@ Ion::Storage::Record ExpressionModelStore::recordSatisfyingTestAtIndex(int i, Mo
   Ion::Storage::Record record;
   do {
     record = recordAtIndex(index++);
-    ExpressionModelHandle * m = privateModelForRecord(record);
-    if (m->isNull()) {
+    if (record.isNull()) {
       assert(false);
       break;
     }
-    if (test(m)) {
+    if (test(privateModelForRecord(record))) {
       if (i == count) {
         break;
       }

--- a/apps/shared/expression_model_store.cpp
+++ b/apps/shared/expression_model_store.cpp
@@ -40,7 +40,7 @@ void ExpressionModelStore::tidy() {
   resetMemoizedModelsExceptRecord();
 }
 
-int ExpressionModelStore::numberOfModelsSatisfyingTest(ModelTest test) const {
+int ExpressionModelStore::numberOfModelsSatisfyingTest(ModelTest test, void * context) const {
   int count = 0;
   int index = 0;
   Ion::Storage::Record record;
@@ -49,15 +49,15 @@ int ExpressionModelStore::numberOfModelsSatisfyingTest(ModelTest test) const {
     if (record.isNull()) {
       break;
     }
-    if (test(privateModelForRecord(record))) {
+    if (test(privateModelForRecord(record), context)) {
       count++;
     }
   } while (true);
   return count;
 }
 
-Ion::Storage::Record ExpressionModelStore::recordSatisfyingTestAtIndex(int i, ModelTest test) const {
-  assert(0 <= i && i < numberOfModelsSatisfyingTest(test));
+Ion::Storage::Record ExpressionModelStore::recordSatisfyingTestAtIndex(int i, ModelTest test, void * context) const {
+  assert(0 <= i && i < numberOfModelsSatisfyingTest(test, context));
   int count = 0;
   int index = 0;
   Ion::Storage::Record record;
@@ -67,7 +67,7 @@ Ion::Storage::Record ExpressionModelStore::recordSatisfyingTestAtIndex(int i, Mo
       assert(false);
       break;
     }
-    if (test(privateModelForRecord(record))) {
+    if (test(privateModelForRecord(record), context)) {
       if (i == count) {
         break;
       }

--- a/apps/shared/expression_model_store.cpp
+++ b/apps/shared/expression_model_store.cpp
@@ -54,13 +54,12 @@ int ExpressionModelStore::numberOfModelsSatisfyingTest(ModelTest test) const {
 }
 
 Ion::Storage::Record ExpressionModelStore::recordSatisfyingTestAtIndex(int i, ModelTest test) const {
-  assert(i >= 0 && i < numberOfDefinedModels());
+  assert(0 <= i && i < numberOfModelsSatisfyingTest(test));
   int index = 0;
   int currentModelIndex = 0;
   Ion::Storage::Record r = recordAtIndex(currentModelIndex++);
   ExpressionModelHandle * m = privateModelForRecord(r);
   while (!m->isNull()) {
-    assert(currentModelIndex <= numberOfModels());
     if (test(m)) {
       if (i == index) {
         return r;

--- a/apps/shared/expression_model_store.cpp
+++ b/apps/shared/expression_model_store.cpp
@@ -41,37 +41,37 @@ void ExpressionModelStore::tidy() {
 }
 
 int ExpressionModelStore::numberOfModelsSatisfyingTest(ModelTest test) const {
-  int result = 0;
-  int i = 0;
+  int count = 0;
+  int index = 0;
   do {
-    ExpressionModelHandle * m = privateModelForRecord(recordAtIndex(i++));
+    ExpressionModelHandle * m = privateModelForRecord(recordAtIndex(index++));
     if (m->isNull()) {
       break;
     }
     if (test(m)) {
-      result++;
+      count++;
     }
   } while (true);
-  return result;
+  return count;
 }
 
 Ion::Storage::Record ExpressionModelStore::recordSatisfyingTestAtIndex(int i, ModelTest test) const {
   assert(0 <= i && i < numberOfModelsSatisfyingTest(test));
+  int count = 0;
   int index = 0;
-  int currentModelIndex = 0;
   Ion::Storage::Record record;
   do {
-    record = recordAtIndex(currentModelIndex++);
+    record = recordAtIndex(index++);
     ExpressionModelHandle * m = privateModelForRecord(record);
     if (m->isNull()) {
       assert(false);
       break;
     }
     if (test(m)) {
-      if (i == index) {
+      if (i == count) {
         break;
       }
-      index++;
+      count++;
     }
   } while (true);
   return record;

--- a/apps/shared/expression_model_store.cpp
+++ b/apps/shared/expression_model_store.cpp
@@ -53,7 +53,7 @@ int ExpressionModelStore::numberOfModelsSatisfyingTest(ModelTest test) const {
   return result;
 }
 
-Ion::Storage::Record ExpressionModelStore::recordStatifyingTestAtIndex(int i, ModelTest test) const {
+Ion::Storage::Record ExpressionModelStore::recordSatisfyingTestAtIndex(int i, ModelTest test) const {
   assert(i >= 0 && i < numberOfDefinedModels());
   int index = 0;
   int currentModelIndex = 0;

--- a/apps/shared/expression_model_store.cpp
+++ b/apps/shared/expression_model_store.cpp
@@ -43,13 +43,15 @@ void ExpressionModelStore::tidy() {
 int ExpressionModelStore::numberOfModelsSatisfyingTest(ModelTest test) const {
   int result = 0;
   int i = 0;
-  ExpressionModelHandle * m = privateModelForRecord(recordAtIndex(i++));
-  while (!m->isNull()) {
+  do {
+    ExpressionModelHandle * m = privateModelForRecord(recordAtIndex(i++));
+    if (m->isNull()) {
+      break;
+    }
     if (test(m)) {
       result++;
     }
-    m = privateModelForRecord(recordAtIndex(i++));
-  }
+  } while (true);
   return result;
 }
 
@@ -57,18 +59,19 @@ Ion::Storage::Record ExpressionModelStore::recordSatisfyingTestAtIndex(int i, Mo
   assert(0 <= i && i < numberOfModelsSatisfyingTest(test));
   int index = 0;
   int currentModelIndex = 0;
-  Ion::Storage::Record r = recordAtIndex(currentModelIndex++);
-  ExpressionModelHandle * m = privateModelForRecord(r);
-  while (!m->isNull()) {
+  do {
+    Ion::Storage::Record r = recordAtIndex(currentModelIndex++);
+    ExpressionModelHandle * m = privateModelForRecord(r);
+    if (m->isNull()) {
+      break;
+    }
     if (test(m)) {
       if (i == index) {
         return r;
       }
       index++;
     }
-    r = recordAtIndex(currentModelIndex++);
-    m = privateModelForRecord(r);
-  }
+  } while (true);
   assert(false);
   return Ion::Storage::Record();
 }

--- a/apps/shared/expression_model_store.cpp
+++ b/apps/shared/expression_model_store.cpp
@@ -63,10 +63,6 @@ Ion::Storage::Record ExpressionModelStore::recordSatisfyingTestAtIndex(int i, Mo
   Ion::Storage::Record record;
   do {
     record = recordAtIndex(index++);
-    if (record.isNull()) {
-      assert(false);
-      break;
-    }
     if (test(privateModelForRecord(record), context)) {
       if (i == count) {
         break;

--- a/apps/shared/expression_model_store.cpp
+++ b/apps/shared/expression_model_store.cpp
@@ -59,21 +59,22 @@ Ion::Storage::Record ExpressionModelStore::recordSatisfyingTestAtIndex(int i, Mo
   assert(0 <= i && i < numberOfModelsSatisfyingTest(test));
   int index = 0;
   int currentModelIndex = 0;
+  Ion::Storage::Record record;
   do {
-    Ion::Storage::Record r = recordAtIndex(currentModelIndex++);
-    ExpressionModelHandle * m = privateModelForRecord(r);
+    record = recordAtIndex(currentModelIndex++);
+    ExpressionModelHandle * m = privateModelForRecord(record);
     if (m->isNull()) {
+      assert(false);
       break;
     }
     if (test(m)) {
       if (i == index) {
-        return r;
+        break;
       }
       index++;
     }
   } while (true);
-  assert(false);
-  return Ion::Storage::Record();
+  return record;
 }
 
 void ExpressionModelStore::resetMemoizedModelsExceptRecord(const Ion::Storage::Record record) const {

--- a/apps/shared/expression_model_store.h
+++ b/apps/shared/expression_model_store.h
@@ -19,9 +19,13 @@ public:
   // By default, the number of models is not bounded
   virtual int maxNumberOfModels() const { return -1; }
   int numberOfModels() const;
-  int numberOfDefinedModels() const { return numberOfModelsSatisfyingTest(&isModelDefined); }
   Ion::Storage::Record recordAtIndex(int i) const;
-  Ion::Storage::Record definedRecordAtIndex(int i) const { return recordSatisfyingTestAtIndex(i, &isModelDefined); }
+  int numberOfDefinedModels() const {
+    return numberOfModelsSatisfyingTest(&isModelDefined, nullptr);
+  }
+  Ion::Storage::Record definedRecordAtIndex(int i) const {
+    return recordSatisfyingTestAtIndex(i, &isModelDefined, nullptr);
+  }
   ExpiringPointer<ExpressionModelHandle> modelForRecord(Ion::Storage::Record record) const { return ExpiringPointer<ExpressionModelHandle>(privateModelForRecord(record)); }
 
   // Add and Remove
@@ -35,10 +39,10 @@ public:
 protected:
   constexpr static int k_maxNumberOfMemoizedModels = 10;
   int maxNumberOfMemoizedModels() const { return maxNumberOfModels() < 0 ? k_maxNumberOfMemoizedModels : maxNumberOfModels(); }
-  typedef bool (*ModelTest)(ExpressionModelHandle * model);
-  int numberOfModelsSatisfyingTest(ModelTest test) const;
-  Ion::Storage::Record recordSatisfyingTestAtIndex(int i, ModelTest test) const;
-  static bool isModelDefined(ExpressionModelHandle * model) {
+  typedef bool (*ModelTest)(ExpressionModelHandle * model, void * context);
+  int numberOfModelsSatisfyingTest(ModelTest test, void * context) const;
+  Ion::Storage::Record recordSatisfyingTestAtIndex(int i, ModelTest test, void * context) const;
+  static bool isModelDefined(ExpressionModelHandle * model, void * context) {
     return model->isDefined();
   }
   ExpressionModelHandle * privateModelForRecord(Ion::Storage::Record record) const;

--- a/apps/shared/expression_model_store.h
+++ b/apps/shared/expression_model_store.h
@@ -21,7 +21,7 @@ public:
   int numberOfModels() const;
   int numberOfDefinedModels() const { return numberOfModelsSatisfyingTest([](ExpressionModelHandle * m) { return m->isDefined(); }); }
   Ion::Storage::Record recordAtIndex(int i) const;
-  Ion::Storage::Record definedRecordAtIndex(int i) const { return recordStatifyingTestAtIndex(i, [](ExpressionModelHandle * m) { return m->isDefined(); }); }
+  Ion::Storage::Record definedRecordAtIndex(int i) const { return recordSatisfyingTestAtIndex(i, [](ExpressionModelHandle * m) { return m->isDefined(); }); }
   ExpiringPointer<ExpressionModelHandle> modelForRecord(Ion::Storage::Record record) const { return ExpiringPointer<ExpressionModelHandle>(privateModelForRecord(record)); }
 
   // Add and Remove
@@ -37,7 +37,7 @@ protected:
   int maxNumberOfMemoizedModels() const { return maxNumberOfModels() < 0 ? k_maxNumberOfMemoizedModels : maxNumberOfModels(); }
   typedef bool (*ModelTest)(ExpressionModelHandle * model);
   int numberOfModelsSatisfyingTest(ModelTest test) const;
-  Ion::Storage::Record recordStatifyingTestAtIndex(int i, ModelTest test) const;
+  Ion::Storage::Record recordSatisfyingTestAtIndex(int i, ModelTest test) const;
   ExpressionModelHandle * privateModelForRecord(Ion::Storage::Record record) const;
 private:
   void resetMemoizedModelsExceptRecord(const Ion::Storage::Record record = Ion::Storage::Record()) const;

--- a/apps/shared/expression_model_store.h
+++ b/apps/shared/expression_model_store.h
@@ -19,9 +19,9 @@ public:
   // By default, the number of models is not bounded
   virtual int maxNumberOfModels() const { return -1; }
   int numberOfModels() const;
-  int numberOfDefinedModels() const { return numberOfModelsSatisfyingTest([](ExpressionModelHandle * m) { return m->isDefined(); }); }
+  int numberOfDefinedModels() const { return numberOfModelsSatisfyingTest(&isModelDefined); }
   Ion::Storage::Record recordAtIndex(int i) const;
-  Ion::Storage::Record definedRecordAtIndex(int i) const { return recordSatisfyingTestAtIndex(i, [](ExpressionModelHandle * m) { return m->isDefined(); }); }
+  Ion::Storage::Record definedRecordAtIndex(int i) const { return recordSatisfyingTestAtIndex(i, &isModelDefined); }
   ExpiringPointer<ExpressionModelHandle> modelForRecord(Ion::Storage::Record record) const { return ExpiringPointer<ExpressionModelHandle>(privateModelForRecord(record)); }
 
   // Add and Remove
@@ -38,6 +38,9 @@ protected:
   typedef bool (*ModelTest)(ExpressionModelHandle * model);
   int numberOfModelsSatisfyingTest(ModelTest test) const;
   Ion::Storage::Record recordSatisfyingTestAtIndex(int i, ModelTest test) const;
+  static bool isModelDefined(ExpressionModelHandle * model) {
+    return model->isDefined();
+  }
   ExpressionModelHandle * privateModelForRecord(Ion::Storage::Record record) const;
 private:
   void resetMemoizedModelsExceptRecord(const Ion::Storage::Record record = Ion::Storage::Record()) const;

--- a/apps/shared/function.cpp
+++ b/apps/shared/function.cpp
@@ -83,10 +83,10 @@ int Function::nameWithArgument(char * buffer, size_t bufferSize) {
   return result;
 }
 
-Function::FunctionRecordDataBuffer * Function::recordData() const {
+Function::RecordDataBuffer * Function::recordData() const {
   assert(!isNull());
   Ion::Storage::Record::Data d = value();
-  return reinterpret_cast<FunctionRecordDataBuffer *>(const_cast<void *>(d.buffer));
+  return reinterpret_cast<RecordDataBuffer *>(const_cast<void *>(d.buffer));
 }
 
 }

--- a/apps/shared/function.h
+++ b/apps/shared/function.h
@@ -54,14 +54,14 @@ public:
   virtual Poincare::Coordinate2D<double> evaluateXYAtParameter(double t, Poincare::Context * context) const = 0;
   virtual Poincare::Expression sumBetweenBounds(double start, double end, Poincare::Context * context) const = 0;
 protected:
-  /* FunctionRecordDataBuffer is the layout of the data buffer of Record
+  /* RecordDataBuffer is the layout of the data buffer of Record
    * representing a Function. We want to avoid padding which would:
    * - increase the size of the storage file
    * - introduce junk memory zone which are then crc-ed in Storage::checksum
    *   creating dependency on uninitialized values. */
-  class FunctionRecordDataBuffer {
+  class RecordDataBuffer {
   public:
-    FunctionRecordDataBuffer(KDColor color) : m_color(color), m_active(true) {}
+    RecordDataBuffer(KDColor color) : m_color(color), m_active(true) {}
     KDColor color() const {
       return KDColor::RGB16(m_color);
     }
@@ -84,7 +84,7 @@ protected:
     bool m_active;
   };
 private:
-  FunctionRecordDataBuffer * recordData() const;
+  RecordDataBuffer * recordData() const;
 };
 
 }

--- a/apps/shared/function.h
+++ b/apps/shared/function.h
@@ -26,6 +26,7 @@ public:
   constexpr static int k_parenthesedThetaArgumentByteLength = 4;
   constexpr static int k_parenthesedXNTArgumentByteLength = 3;
   constexpr static int k_maxNameWithArgumentSize = Poincare::SymbolAbstract::k_maxNameSize + k_parenthesedThetaArgumentByteLength; /* Function name and null-terminating char + "(θ)" */;
+  static_assert(k_maxNameWithArgumentSize > Poincare::SymbolAbstract::k_maxNameSize, "Forgot argument's size?");
   static bool BaseNameCompliant(const char * baseName, NameNotCompliantError * error = nullptr);
 
   // Constructors

--- a/apps/shared/function.h
+++ b/apps/shared/function.h
@@ -26,7 +26,6 @@ public:
   constexpr static int k_parenthesedThetaArgumentByteLength = 4;
   constexpr static int k_parenthesedXNTArgumentByteLength = 3;
   constexpr static int k_maxNameWithArgumentSize = Poincare::SymbolAbstract::k_maxNameSize + k_parenthesedThetaArgumentByteLength; /* Function name and null-terminating char + "(θ)" */;
-  static_assert(k_maxNameWithArgumentSize > Poincare::SymbolAbstract::k_maxNameSize, "Forgot argument's size?");
   static bool BaseNameCompliant(const char * baseName, NameNotCompliantError * error = nullptr);
 
   // Constructors

--- a/apps/shared/function_list_controller.cpp
+++ b/apps/shared/function_list_controller.cpp
@@ -248,10 +248,6 @@ TabViewController * FunctionListController::tabController() const {
   return static_cast<TabViewController *>(parentResponder()->parentResponder()->parentResponder()->parentResponder());
 }
 
-FunctionStore * FunctionListController::modelStore() {
-  return FunctionApp::app()->functionStore();
-}
-
 InputViewController * FunctionListController::inputController() {
   return FunctionApp::app()->inputViewController();
 }

--- a/apps/shared/function_list_controller.h
+++ b/apps/shared/function_list_controller.h
@@ -53,7 +53,6 @@ protected:
   StackViewController * stackController() const;
   void configureFunction(Ion::Storage::Record record);
   void computeTitlesColumnWidth(bool forceMax = false);
-  FunctionStore * modelStore() override;
   KDCoordinate baseline(int j);
   void resetMemoizationForIndex(int index) override;
   void shiftMemoization(bool newCellIsUnder) override;

--- a/apps/shared/function_store.cpp
+++ b/apps/shared/function_store.cpp
@@ -1,6 +1,4 @@
 #include "function_store.h"
-#include "cartesian_function.h"
-#include <assert.h>
 
 namespace Shared {
 

--- a/apps/shared/function_store.h
+++ b/apps/shared/function_store.h
@@ -13,13 +13,17 @@ class FunctionStore : public ExpressionModelStore {
 public:
   FunctionStore() : ExpressionModelStore() {}
   uint32_t storeChecksum();
-  int numberOfActiveFunctions() const { return numberOfModelsSatisfyingTest(&isFunctionActive); }
-  Ion::Storage::Record activeRecordAtIndex(int i) const { return recordSatisfyingTestAtIndex(i, &isFunctionActive); }
+  int numberOfActiveFunctions() const {
+    return numberOfModelsSatisfyingTest(&isFunctionActive, nullptr);
+  }
+  Ion::Storage::Record activeRecordAtIndex(int i) const {
+    return recordSatisfyingTestAtIndex(i, &isFunctionActive, nullptr);
+  }
   ExpiringPointer<Function> modelForRecord(Ion::Storage::Record record) const { return ExpiringPointer<Function>(static_cast<Function *>(privateModelForRecord(record))); }
 protected:
-  static bool isFunctionActive(ExpressionModelHandle * model) {
+  static bool isFunctionActive(ExpressionModelHandle * model, void * context) {
     // An active function must be defined
-    return isModelDefined(model) && static_cast<Function *>(model)->isActive();
+    return isModelDefined(model, context) && static_cast<Function *>(model)->isActive();
   }
 };
 

--- a/apps/shared/function_store.h
+++ b/apps/shared/function_store.h
@@ -13,12 +13,14 @@ class FunctionStore : public ExpressionModelStore {
 public:
   FunctionStore() : ExpressionModelStore() {}
   uint32_t storeChecksum();
-  // An active function must be defined to be counted
-  int numberOfActiveFunctions() const { return numberOfModelsSatisfyingTest([](ExpressionModelHandle * m) { return m->isDefined() && static_cast<Function *>(m)->isActive(); }); }
-  Ion::Storage::Record activeRecordAtIndex(int i) const { return recordSatisfyingTestAtIndex(i, [](ExpressionModelHandle * m) { return m->isDefined() && static_cast<Function *>(m)->isActive(); }); }
-
+  int numberOfActiveFunctions() const { return numberOfModelsSatisfyingTest(&isFunctionActive); }
+  Ion::Storage::Record activeRecordAtIndex(int i) const { return recordSatisfyingTestAtIndex(i, &isFunctionActive); }
   ExpiringPointer<Function> modelForRecord(Ion::Storage::Record record) const { return ExpiringPointer<Function>(static_cast<Function *>(privateModelForRecord(record))); }
-
+protected:
+  static bool isFunctionActive(ExpressionModelHandle * model) {
+    // An active function must be defined
+    return isModelDefined(model) && static_cast<Function *>(model)->isActive();
+  }
 };
 
 }

--- a/apps/shared/function_store.h
+++ b/apps/shared/function_store.h
@@ -15,7 +15,7 @@ public:
   uint32_t storeChecksum();
   // An active function must be defined to be counted
   int numberOfActiveFunctions() const { return numberOfModelsSatisfyingTest([](ExpressionModelHandle * m) { return m->isDefined() && static_cast<Function *>(m)->isActive(); }); }
-  Ion::Storage::Record activeRecordAtIndex(int i) const { return recordStatifyingTestAtIndex(i, [](ExpressionModelHandle * m) { return m->isDefined() && static_cast<Function *>(m)->isActive(); }); }
+  Ion::Storage::Record activeRecordAtIndex(int i) const { return recordSatisfyingTestAtIndex(i, [](ExpressionModelHandle * m) { return m->isDefined() && static_cast<Function *>(m)->isActive(); }); }
 
   ExpiringPointer<Function> modelForRecord(Ion::Storage::Record record) const { return ExpiringPointer<Function>(static_cast<Function *>(privateModelForRecord(record))); }
 

--- a/apps/shared/global_context.cpp
+++ b/apps/shared/global_context.cpp
@@ -32,7 +32,7 @@ Poincare::Expression GlobalContext::ExpressionFromFunctionRecord(Ion::Storage::R
   }
   /* An function record value has metadata before the expression. To get the
    * expression, use the function record handle. */
-  CartesianFunction f = CartesianFunction(record);
+  ContinuousFunction f = ContinuousFunction(record);
   return f.expressionClone();
 }
 
@@ -42,7 +42,7 @@ const Layout GlobalContext::LayoutForRecord(Ion::Storage::Record record) {
     return PoincareHelpers::CreateLayout(ExpressionFromSymbolRecord(record));
   } else {
     assert(Ion::Storage::FullNameHasExtension(record.fullName(), Ion::Storage::funcExtension, strlen(Ion::Storage::funcExtension)));
-    return CartesianFunction(record).layout();
+    return ContinuousFunction(record).layout();
   }
 }
 
@@ -113,13 +113,13 @@ Ion::Storage::Record::ErrorStatus GlobalContext::SetExpressionForFunction(const 
   if (!Ion::Storage::FullNameHasExtension(previousRecord.fullName(), Ion::Storage::funcExtension, strlen(Ion::Storage::funcExtension))) {
     // The previous record was not a function. Destroy it and create the new record.
     previousRecord.destroy();
-    CartesianFunction newModel = CartesianFunction::NewModel(&error, symbol.name());
+    ContinuousFunction newModel = ContinuousFunction::NewModel(&error, symbol.name());
     if (error != Ion::Storage::Record::ErrorStatus::None) {
       return error;
     }
     recordToSet = newModel;
   }
-  error = CartesianFunction(recordToSet).setExpressionContent(expressionToStore);
+  error = ContinuousFunction(recordToSet).setExpressionContent(expressionToStore);
   return error;
 }
 

--- a/apps/shared/global_context.cpp
+++ b/apps/shared/global_context.cpp
@@ -1,5 +1,5 @@
 #include "global_context.h"
-#include "cartesian_function.h"
+#include "continuous_function.h"
 #include "poincare_helpers.h"
 #include <poincare/undefined.h>
 #include <assert.h>

--- a/apps/shared/range_1D.h
+++ b/apps/shared/range_1D.h
@@ -12,7 +12,7 @@
 namespace Shared {
 
 /* This class is used in a DataBuffer of a Storage::Record. See comment in
- * Shared::Function::FunctionRecordDataBuffer about packing. */
+ * Shared::Function::RecordDataBuffer about packing. */
 
 class __attribute__((packed)) Range1D final {
 public:
@@ -30,7 +30,7 @@ public:
   static float defaultRangeLengthFor(float position);
 private:
 #if __EMSCRIPTEN__
-    // See comment about emscripten alignement in Shared::Function::FunctionRecordDataBuffer
+    // See comment about emscripten alignement in Shared::Function::RecordDataBuffer
     static_assert(sizeof(emscripten_align1_short) == sizeof(uint16_t), "emscripten_align1_short should have the same size as uint16_t");
     emscripten_align1_float m_min __attribute__((packed));
     emscripten_align1_float m_max __attribute__((packed));

--- a/apps/solver/app.h
+++ b/apps/solver/app.h
@@ -32,6 +32,12 @@ public:
   static App * app() {
     return static_cast<App *>(Container::activeApp());
   }
+  Snapshot * snapshot() {
+    return static_cast<Snapshot *>(::App::snapshot());
+  }
+  EquationStore * equationStore() {
+    return snapshot()->equationStore();
+  }
   InputViewController * inputViewController() { return &m_inputViewController; }
   ViewController * solutionsControllerStack() { return &m_alternateEmptyViewController; }
   ViewController * intervalController() { return &m_intervalController; }

--- a/apps/solver/list_controller.cpp
+++ b/apps/solver/list_controller.cpp
@@ -168,11 +168,11 @@ bool ListController::layoutFieldDidFinishEditing(LayoutField * layoutField, Poin
 }
 
 void ListController::resolveEquations() {
-  if (m_equationStore->numberOfDefinedModels() == 0) {
+  if (modelStore()->numberOfDefinedModels() == 0) {
     Container::activeApp()->displayWarning(I18n::Message::EnterEquation);
     return;
   }
-  EquationStore::Error e = m_equationStore->exactSolve(textFieldDelegateApp()->localContext());
+  EquationStore::Error e = modelStore()->exactSolve(textFieldDelegateApp()->localContext());
   switch (e) {
     case EquationStore::Error::EquationUndefined:
       Container::activeApp()->displayWarning(I18n::Message::UndefinedEquation);
@@ -202,7 +202,7 @@ void ListController::resolveEquations() {
 }
 
 void ListController::reloadButtonMessage() {
-  footer()->setMessageOfButtonAtIndex(m_equationStore->numberOfDefinedModels() > 1 ? I18n::Message::ResolveSystem : I18n::Message::ResolveEquation, 0);
+  footer()->setMessageOfButtonAtIndex(modelStore()->numberOfDefinedModels() > 1 ? I18n::Message::ResolveSystem : I18n::Message::ResolveEquation, 0);
 }
 
 void ListController::addEmptyModel() {
@@ -217,7 +217,7 @@ bool ListController::removeModelRow(Ion::Storage::Record record) {
 }
 
 void ListController::reloadBrace() {
-  EquationListView::BraceStyle braceStyle = m_equationStore->numberOfModels() <= 1 ? EquationListView::BraceStyle::None : (m_equationStore->numberOfModels() == m_equationStore->maxNumberOfModels() ? EquationListView::BraceStyle::Full : EquationListView::BraceStyle::OneRowShort);
+  EquationListView::BraceStyle braceStyle = modelStore()->numberOfModels() <= 1 ? EquationListView::BraceStyle::None : (modelStore()->numberOfModels() == modelStore()->maxNumberOfModels() ? EquationListView::BraceStyle::Full : EquationListView::BraceStyle::OneRowShort);
   m_equationListView.setBraceStyle(braceStyle);
 }
 

--- a/apps/solver/list_controller.cpp
+++ b/apps/solver/list_controller.cpp
@@ -43,10 +43,7 @@ Button * ListController::buttonAtIndex(int index, ButtonRowController::Position 
 }
 
 int ListController::typeAtLocation(int i, int j) {
-  if (j == m_equationStore->numberOfModels()) {
-    return 1;
-  }
-  return 0;
+  return isAddEmptyRow(j);
 }
 
 HighlightCell * ListController::reusableCell(int index, int type) {
@@ -71,7 +68,7 @@ int ListController::reusableCellCount(int type) {
 }
 
 void ListController::willDisplayCellForIndex(HighlightCell * cell, int index) {
-  if (index != m_equationStore->numberOfModels()) {
+  if (!isAddEmptyRow(index)) {
     willDisplayExpressionCellAtIndex(cell, index);
   }
   cell->setHighlighted(index == selectedRow());

--- a/apps/solver/list_controller.cpp
+++ b/apps/solver/list_controller.cpp
@@ -10,7 +10,6 @@ namespace Solver {
 ListController::ListController(Responder * parentResponder, EquationStore * equationStore, ButtonRowController * footer) :
   ExpressionModelListController(parentResponder, I18n::Message::AddEquation),
   ButtonRowDelegate(nullptr, footer),
-  m_equationStore(equationStore),
   m_equationListView(this),
   m_expressionCells{},
   m_resolveButton(this, equationStore->numberOfDefinedModels() > 1 ? I18n::Message::ResolveSystem : I18n::Message::ResolveEquation, Invocation([](void * context, void * sender) {
@@ -219,6 +218,10 @@ bool ListController::removeModelRow(Ion::Storage::Record record) {
 void ListController::reloadBrace() {
   EquationListView::BraceStyle braceStyle = modelStore()->numberOfModels() <= 1 ? EquationListView::BraceStyle::None : (modelStore()->numberOfModels() == modelStore()->maxNumberOfModels() ? EquationListView::BraceStyle::Full : EquationListView::BraceStyle::OneRowShort);
   m_equationListView.setBraceStyle(braceStyle);
+}
+
+EquationStore * ListController::modelStore() {
+  return App::app()->equationStore();
 }
 
 SelectableTableView * ListController::selectableTableView() {

--- a/apps/solver/list_controller.h
+++ b/apps/solver/list_controller.h
@@ -51,7 +51,7 @@ private:
   void addEmptyModel() override;
   bool removeModelRow(Ion::Storage::Record record) override;
   void reloadBrace();
-  Shared::ExpressionModelStore * modelStore() override { return m_equationStore; }
+  EquationStore * modelStore() override { return m_equationStore; }
   StackViewController * stackController() const;
   InputViewController * inputController() override;
   // ListViewDataSource

--- a/apps/solver/list_controller.h
+++ b/apps/solver/list_controller.h
@@ -51,13 +51,12 @@ private:
   void addEmptyModel() override;
   bool removeModelRow(Ion::Storage::Record record) override;
   void reloadBrace();
-  EquationStore * modelStore() override { return m_equationStore; }
+  EquationStore * modelStore() override;
   StackViewController * stackController() const;
   InputViewController * inputController() override;
   // ListViewDataSource
   KDCoordinate notMemoizedCumulatedHeightFromIndex(int j) override { return ListViewDataSource::cumulatedHeightFromIndex(j); }
   int notMemoizedIndexFromCumulatedHeight(KDCoordinate offsetY) override { return ListViewDataSource::indexFromCumulatedHeight(offsetY); }
-  EquationStore * m_equationStore;
   EquationListView m_equationListView;
   EvenOddExpressionCell m_expressionCells[k_maxNumberOfRows];
   Button m_resolveButton;

--- a/apps/variable_box_controller.cpp
+++ b/apps/variable_box_controller.cpp
@@ -106,7 +106,7 @@ void VariableBoxController::willDisplayCellForIndex(HighlightCell * cell, int in
     symbolLength = SymbolAbstract::TruncateExtension(symbolName, record.fullName(), SymbolAbstract::k_maxNameSize);
   } else {
     assert(m_currentPage == Page::Function);
-    CartesianFunction f(record);
+    ContinuousFunction f(record);
     symbolLength = f.nameWithArgument(
         symbolName,
         Shared::Function::k_maxNameWithArgumentSize

--- a/apps/variable_box_controller.cpp
+++ b/apps/variable_box_controller.cpp
@@ -100,7 +100,6 @@ void VariableBoxController::willDisplayCellForIndex(HighlightCell * cell, int in
   }
   ExpressionTableCellWithExpression * myCell = (ExpressionTableCellWithExpression *)cell;
   Storage::Record record = recordAtIndex(index);
-  assert(Shared::Function::k_maxNameWithArgumentSize > SymbolAbstract::k_maxNameSize);
   char symbolName[Shared::Function::k_maxNameWithArgumentSize];
   size_t symbolLength = 0;
   if (m_currentPage == Page::Expression) {
@@ -188,8 +187,6 @@ bool VariableBoxController::selectLeaf(int selectedRow) {
 
   // Get the name text to insert
   Storage::Record record = recordAtIndex(selectedRow);
-  assert(Shared::Function::k_maxNameWithArgumentSize > 0);
-  assert(Shared::Function::k_maxNameWithArgumentSize > SymbolAbstract::k_maxNameSize);
   constexpr size_t nameToHandleMaxSize = Shared::Function::k_maxNameWithArgumentSize;
   char nameToHandle[nameToHandleMaxSize];
   size_t nameLength = SymbolAbstract::TruncateExtension(nameToHandle, record.fullName(), nameToHandleMaxSize);

--- a/apps/variable_box_controller.cpp
+++ b/apps/variable_box_controller.cpp
@@ -1,6 +1,6 @@
 #include "variable_box_controller.h"
 #include "shared/global_context.h"
-#include "shared/cartesian_function.h"
+#include "shared/continuous_function.h"
 #include <escher/metric.h>
 #include <ion/unicode/utf8_decoder.h>
 #include <poincare/layout_helper.h>

--- a/apps/variable_box_controller.cpp
+++ b/apps/variable_box_controller.cpp
@@ -103,6 +103,7 @@ void VariableBoxController::willDisplayCellForIndex(HighlightCell * cell, int in
   char symbolName[Shared::Function::k_maxNameWithArgumentSize];
   size_t symbolLength = 0;
   if (m_currentPage == Page::Expression) {
+    static_assert(Shared::Function::k_maxNameWithArgumentSize > Poincare::SymbolAbstract::k_maxNameSize, "Forgot argument's size?");
     symbolLength = SymbolAbstract::TruncateExtension(symbolName, record.fullName(), SymbolAbstract::k_maxNameSize);
   } else {
     assert(m_currentPage == Page::Function);

--- a/apps/variable_box_empty_controller.cpp
+++ b/apps/variable_box_empty_controller.cpp
@@ -1,6 +1,5 @@
 #include "variable_box_empty_controller.h"
 #include <poincare/layout_helper.h>
-#include "graph/cartesian_function_store.h"
 #include <apps/i18n.h>
 #include <assert.h>
 

--- a/escher/include/escher/input_view_controller.h
+++ b/escher/include/escher/input_view_controller.h
@@ -22,7 +22,7 @@ public:
   void setTextBody(const char * text) {
     m_expressionFieldController.expressionField()->setText(text);
   }
-  void edit(Responder * caller, Ion::Events::Event event, void * context, const char * initialText, Invocation::Action successAction, Invocation::Action failureAction);
+  void edit(Responder * caller, Ion::Events::Event event, void * context, Invocation::Action successAction, Invocation::Action failureAction);
   bool isEditing();
   void abortEditionAndDismiss();
 

--- a/escher/include/escher/input_view_controller.h
+++ b/escher/include/escher/input_view_controller.h
@@ -16,9 +16,14 @@
 class InputViewController : public ModalViewController, InputEventHandlerDelegate, TextFieldDelegate, LayoutFieldDelegate {
 public:
   InputViewController(Responder * parentResponder, ViewController * child, InputEventHandlerDelegate * inputEventHandlerDelegate, TextFieldDelegate * textFieldDelegate, LayoutFieldDelegate * layoutFieldDelegate);
+  const char * textBody() {
+    return m_expressionFieldController.expressionField()->text();
+  }
+  void setTextBody(const char * text) {
+    m_expressionFieldController.expressionField()->setText(text);
+  }
   void edit(Responder * caller, Ion::Events::Event event, void * context, const char * initialText, Invocation::Action successAction, Invocation::Action failureAction);
   bool isEditing();
-  const char * textBody();
   void abortEditionAndDismiss();
 
   /* TextFieldDelegate */

--- a/escher/src/input_view_controller.cpp
+++ b/escher/src/input_view_controller.cpp
@@ -25,10 +25,6 @@ InputViewController::InputViewController(Responder * parentResponder, ViewContro
 {
 }
 
-const char * InputViewController::textBody() {
-  return m_expressionFieldController.expressionField()->text();
-}
-
 void InputViewController::edit(Responder * caller, Ion::Events::Event event, void * context, const char * initialText, Invocation::Action successAction, Invocation::Action failureAction) {
   m_successAction = Invocation(successAction, context);
   m_failureAction = Invocation(failureAction, context);

--- a/escher/src/input_view_controller.cpp
+++ b/escher/src/input_view_controller.cpp
@@ -25,13 +25,10 @@ InputViewController::InputViewController(Responder * parentResponder, ViewContro
 {
 }
 
-void InputViewController::edit(Responder * caller, Ion::Events::Event event, void * context, const char * initialText, Invocation::Action successAction, Invocation::Action failureAction) {
+void InputViewController::edit(Responder * caller, Ion::Events::Event event, void * context, Invocation::Action successAction, Invocation::Action failureAction) {
   m_successAction = Invocation(successAction, context);
   m_failureAction = Invocation(failureAction, context);
   displayModalViewController(&m_expressionFieldController, 1.0f, 1.0f);
-  if (initialText != nullptr) {
-    m_expressionFieldController.expressionField()->setText(initialText);
-  }
   m_expressionFieldController.expressionField()->handleEvent(event);
 }
 

--- a/poincare/include/poincare/tree_handle.h
+++ b/poincare/include/poincare/tree_handle.h
@@ -5,7 +5,7 @@
 #include <stdio.h>
 
 namespace Shared {
-  class CartesianFunction;
+  class ContinuousFunction;
 }
 
 namespace Poincare {
@@ -25,7 +25,7 @@ namespace Poincare {
 class TreeHandle {
   template<class T>
   friend class ArrayBuilder;
-  friend class ::Shared::CartesianFunction;
+  friend class ::Shared::ContinuousFunction;
   friend class TreeNode;
   friend class TreePool;
 public:

--- a/poincare/src/symbol_abstract.cpp
+++ b/poincare/src/symbol_abstract.cpp
@@ -65,7 +65,6 @@ Expression SymbolAbstract::Expand(const SymbolAbstract & symbol, Context * conte
    * symbols are defined circularly. */
   e = Expression::ExpressionWithoutSymbols(e, context);
   if (!e.isUninitialized() && isFunction) {
-    // TODO: when SequenceFunction is created, we want to specify which unknown variable to replace (UnknownX or UnknownN)
     e = e.replaceSymbolWithExpression(Symbol::Builder(UCodePointUnknownX), symbol.childAtIndex(0));
   }
   return e;


### PR DESCRIPTION
- With the newly added plot types in the Graph app, the `Shared::CartesianFunction` class may now represent a function whose curve may be plotted in `Cartesian`, `Polar` or `Parametric` mode, the class name is thus not relevant anymore. We choose `ContinuousFunction`. Indeed, even though the considered functions are not generally continuous mathematically speaking, we can not simply name it Function, since such a class already exists: it is the base class of `CartesianFunction` and `Sequence`. The name `ContinuousFunction` should be understood as marking the difference with the Sequence class. The associated class `Graph::CartesianFunctionStore` is renamed accordingly.

- The following private nested classes are simply renamed to `RecordDataBuffer`, since they reside in different specific scopes:
  - `Shared::Function::FunctionRecordDataBuffer`
  - `Shared::CartesianFunction::CartesianFunctionRecordDataBuffer`
  - `Sequence::Sequence::SequenceDataBuffer`.

- Finally, in `Shared::ContinuousFunction` the implementations of the `numberOfActiveFunctionsOfType` and `activeRecordOfTypeAtIndex` methods are factorized using `numberOfModelsSatisfyingTest` and `recordSatisfyingTestAtIndex`.

- In passing, the `isAddEmptyRow`, `modelStore`and `editExpression`methods in the `ExpressionModelListController` class are simplified.