### PR TITLE
Fix matrix line deletion

### DIFF
--- a/poincare/include/poincare/matrix_layout.h
+++ b/poincare/include/poincare/matrix_layout.h
@@ -26,6 +26,7 @@ public:
   void moveCursorLeft(LayoutCursor * cursor, bool * shouldRecomputeLayout) override;
   void moveCursorRight(LayoutCursor * cursor, bool * shouldRecomputeLayout) override;
   void willAddSiblingToEmptyChildAtIndex(int childIndex) override;
+  void deleteBeforeCursor(LayoutCursor * cursor) override;
 
   // SerializableNode
   int serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const override;

--- a/poincare/src/matrix_layout.cpp
+++ b/poincare/src/matrix_layout.cpp
@@ -290,21 +290,12 @@ void MatrixLayoutNode::didReplaceChildAtIndex(int index, LayoutCursor * cursor, 
   assert(index >= 0 && index < m_numberOfColumns*m_numberOfRows);
   int rowIndex = rowAtChildIndex(index);
   int columnIndex = columnAtChildIndex(index);
-  bool rowIsEmpty = isRowEmpty(rowIndex);
   bool columnIsEmpty = isColumnEmpty(columnIndex);
   int newIndex = index;
   if (columnIsEmpty && m_numberOfColumns > 2) {
     // If the column is now empty, delete it
     deleteColumnAtIndex(columnIndex);
     newIndex -= rowIndex;
-  }
-  if (!rowIsEmpty && !columnIsEmpty) {
-    LayoutNode * newChild = childAtIndex(newIndex);
-    if (newChild->isEmpty()
-        && (childIsRightOfGrid(index)|| childIsBottomOfGrid(index)))
-    {
-      static_cast<EmptyLayoutNode *>(newChild)->setColor(EmptyLayoutNode::Color::Grey);
-    }
   }
   if (cursor) {
     assert(newIndex >= 0 && newIndex < m_numberOfColumns*m_numberOfRows);

--- a/poincare/src/matrix_layout.cpp
+++ b/poincare/src/matrix_layout.cpp
@@ -92,6 +92,26 @@ void MatrixLayoutNode::willAddSiblingToEmptyChildAtIndex(int childIndex) {
   }
 }
 
+void MatrixLayoutNode::deleteBeforeCursor(LayoutCursor * cursor) {
+  // Deleting the left empty layout of an empty row deletes the row
+  assert(cursor != nullptr);
+  LayoutNode * pointedChild = cursor->layoutNode();
+  if (pointedChild->isEmpty()) {
+    int indexOfPointedLayout = indexOfChild(pointedChild);
+    if (columnAtChildIndex(indexOfPointedLayout) == 0) {
+      int rowIndex = rowAtChildIndex(indexOfPointedLayout);
+      if (isRowEmpty(rowIndex) && m_numberOfRows > 2) {
+        deleteRowAtIndex(rowIndex);
+        assert(indexOfPointedLayout >= 0 && indexOfPointedLayout < m_numberOfColumns*m_numberOfRows);
+        cursor->setLayoutNode(childAtIndex(indexOfPointedLayout));
+        cursor->setPosition(LayoutCursor::Position::Right);
+        return;
+      }
+    }
+  }
+  GridLayoutNode::deleteBeforeCursor(cursor);
+}
+
 // SerializableNode
 
 int MatrixLayoutNode::serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const {
@@ -273,10 +293,8 @@ void MatrixLayoutNode::didReplaceChildAtIndex(int index, LayoutCursor * cursor, 
   bool rowIsEmpty = isRowEmpty(rowIndex);
   bool columnIsEmpty = isColumnEmpty(columnIndex);
   int newIndex = index;
-  if (rowIsEmpty && m_numberOfRows > 2) {
-    deleteRowAtIndex(rowIndex);
-  }
   if (columnIsEmpty && m_numberOfColumns > 2) {
+    // If the column is now empty, delete it
     deleteColumnAtIndex(columnIndex);
     newIndex -= rowIndex;
   }


### PR DESCRIPTION
Delete a matrix layout line only when deleting the left empty layout of an empty line.
This way, one can more easily edit matrices, for instance in the graph app for parametric functions.
Scenario:
f(t) = | t | and try to replace the t with 1
          |2t|