### PR TITLE
[poincare] Power::shallowReduce

### DIFF
--- a/poincare/src/power.cpp
+++ b/poincare/src/power.cpp
@@ -844,8 +844,8 @@ Expression Power::shallowBeautify(ExpressionNode::ReductionContext reductionCont
   // If the denominator is initialized, the index of the power is of form -y
   if (!p.isUninitialized()) {
     Division d = Division::Builder(Rational::Builder(1), p);
-    p.shallowReduce(reductionContext);
     replaceWithInPlace(d);
+    p.shallowReduce(reductionContext);
     return d.shallowBeautify(reductionContext);
   }
   // Step 2: Turn a^(1/n) into root(a, n)

--- a/poincare/test/helper.h
+++ b/poincare/test/helper.h
@@ -20,9 +20,9 @@ constexpr Poincare::Preferences::PrintFloatMode EngineeringMode = Poincare::Pref
 void quiz_assert_print_if_failure(bool test, const char * information);
 void quiz_assert_log_if_failure(bool test, Poincare::TreeHandle tree);
 
-typedef Poincare::Expression (*ProcessExpression)(Poincare::Expression, Poincare::Context * context, Poincare::ExpressionNode::ReductionTarget target, Poincare::Preferences::ComplexFormat complexFormat, Poincare::Preferences::AngleUnit angleUnit);
+typedef Poincare::Expression (*ProcessExpression)(Poincare::Expression, Poincare::Context * context, Poincare::ExpressionNode::ReductionTarget target, Poincare::Preferences::ComplexFormat complexFormat, Poincare::Preferences::AngleUnit angleUnit, bool symbolicComputation);
 
-void assert_parsed_expression_process_to(const char * expression, const char * result, Poincare::ExpressionNode::ReductionTarget target, Poincare::Preferences::ComplexFormat complexFormat, Poincare::Preferences::AngleUnit angleUnit, ProcessExpression process, int numberOfSignifiantDigits = Poincare::PrintFloat::k_numberOfStoredSignificantDigits);
+void assert_parsed_expression_process_to(const char * expression, const char * result, Poincare::ExpressionNode::ReductionTarget target, Poincare::Preferences::ComplexFormat complexFormat, Poincare::Preferences::AngleUnit angleUnit, bool symbolicComputation, ProcessExpression process, int numberOfSignifiantDigits = Poincare::PrintFloat::k_numberOfStoredSignificantDigits);
 
 // Parsing
 
@@ -32,7 +32,7 @@ Poincare::Expression parse_expression(const char * expression, bool addParenthes
 
 void assert_simplify(const char * expression, Poincare::Preferences::AngleUnit angleUnit = Radian, Poincare::Preferences::ComplexFormat complexFormat = Cartesian);
 
-void assert_parsed_expression_simplify_to(const char * expression, const char * simplifiedExpression, Poincare::ExpressionNode::ReductionTarget target = User, Poincare::Preferences::AngleUnit angleUnit = Radian, Poincare::Preferences::ComplexFormat complexFormat = Cartesian);
+void assert_parsed_expression_simplify_to(const char * expression, const char * simplifiedExpression, Poincare::ExpressionNode::ReductionTarget target = User, Poincare::Preferences::AngleUnit angleUnit = Radian, Poincare::Preferences::ComplexFormat complexFormat = Cartesian, bool symbolicComputation = true);
 
 // Approximation
 

--- a/poincare/test/simplification.cpp
+++ b/poincare/test/simplification.cpp
@@ -394,6 +394,9 @@ QUIZ_CASE(poincare_simplification_function) {
   assert_parsed_expression_simplify_to("sign(-√(2))", "-1");
   assert_parsed_expression_simplify_to("sign(x)", "sign(x)");
   assert_parsed_expression_simplify_to("sign(2+𝐢)", "sign(2+𝐢)");
+  // Test with no symbolic compuation to check that n inside a sum expression is not replaced by Undefined
+  assert_parsed_expression_simplify_to("sum(n,n,1,5)", "sum(n,n,1,5)", User, Radian, Cartesian, false);
+  assert_parsed_expression_simplify_to("sum(1/n,n,1,2)", "sum(1/n,n,1,2)", User, Radian, Cartesian, false);
   assert_parsed_expression_simplify_to("permute(99,4)", "90345024");
   assert_parsed_expression_simplify_to("permute(20,-10)", Undefined::Name());
   assert_parsed_expression_simplify_to("re(1/2)", "1/2");


### PR DESCRIPTION
Reducing should happen after replacing the expression in its hierarchical context.
Fix sum(1/n, n, 1, 5) reducing with no symbolic computation.