### PR TITLE
[apps/regression] Fix cursor redrawing when changing cursor type

### DIFF
--- a/apps/regression/graph_controller.cpp
+++ b/apps/regression/graph_controller.cpp
@@ -82,16 +82,16 @@ void GraphController::viewWillAppear() {
   /* Since *m_selectedDotIndex is altered by initCursorParameters(),
    * the following must absolutely come at the end. */
   if (*m_selectedDotIndex >= 0) {
-    m_view.setCursorView(static_cast<Shared::CursorView *>(&m_crossCursorView));
+    setRoundCrossCursorView(false);
   } else {
-    m_view.setCursorView(static_cast<Shared::CursorView *>(&m_roundCursorView));
+    setRoundCrossCursorView(true);
     m_roundCursorView.setColor(Palette::DataColor[*m_selectedSeriesIndex]);
   }
 }
 
 void GraphController::selectRegressionCurve() {
   *m_selectedDotIndex = -1;
-  m_view.setCursorView(&m_roundCursorView);
+  setRoundCrossCursorView(true);
   m_roundCursorView.setColor(Palette::DataColor[*m_selectedSeriesIndex]);
 }
 
@@ -334,7 +334,7 @@ bool GraphController::moveCursorVertically(int direction) {
 
   if (validDot) {
     // Select the dot
-    m_view.setCursorView(&m_crossCursorView);
+    setRoundCrossCursorView(false);
     *m_selectedSeriesIndex = closestDotSeries;
     *m_selectedDotIndex = dotSelected;
     if (dotSelected == m_store->numberOfPairsOfSeries(*m_selectedSeriesIndex)) {
@@ -402,6 +402,17 @@ InteractiveCurveViewRangeDelegate::Range GraphController::computeYRange(Interact
   range.min = minY;
   range.max = maxY;
   return range;
+}
+
+void GraphController::setRoundCrossCursorView(bool round) {
+  CursorView * nextCursorView = round ? static_cast<Shared::CursorView *>(&m_roundCursorView) : static_cast<Shared::CursorView *>(&m_crossCursorView);
+  if (m_view.cursorView() == nextCursorView) {
+    return;
+  }
+#ifdef GRAPH_CURSOR_SPEEDUP
+  m_roundCursorView.resetMemoization();
+#endif
+  m_view.setCursorView(nextCursorView);
 }
 
 }

--- a/apps/regression/graph_controller.h
+++ b/apps/regression/graph_controller.h
@@ -55,6 +55,7 @@ private:
   // InteractiveCurveViewRangeDelegate
   Shared::InteractiveCurveViewRangeDelegate::Range computeYRange(Shared::InteractiveCurveViewRange * interactiveCurveViewRange) override;
 
+  void setRoundCrossCursorView(bool round);
   Shared::CursorView m_crossCursorView;
   Shared::RoundCursorView m_roundCursorView;
   BannerView m_bannerView;

--- a/apps/shared/round_cursor_view.h
+++ b/apps/shared/round_cursor_view.h
@@ -14,6 +14,9 @@ public:
   KDSize minimalSizeForOptimalDisplay() const override;
   void setColor(KDColor color);
   void setCursorFrame(KDRect frame) override;
+#ifdef GRAPH_CURSOR_SPEEDUP
+  void resetMemoization() const { m_underneathPixelBufferLoaded = false; }
+#endif
 private:
 #ifdef GRAPH_CURSOR_SPEEDUP
   bool eraseCursorIfPossible();


### PR DESCRIPTION
Scenario:
double x[numberOfPoints] = {0.0, 0.975, 1.97, 2.945, 3.971, 4.887, 5.924, 6.964, 7.979, 8.974, 9.998};
double y[numberOfPoints] = {-23.784, -23.322, -28.322, -18.422, -4.813206, 7.146241, 16.631, 16.632, 9.209189, -6.050863, -19.659};
Quadratic regression, navigate on the points then go on the
regressioncurve -> there is a drawing glitch