### PR TITLE
Fixes for Linux simulator build

### DIFF
--- a/build/platform.simulator.linux.mak
+++ b/build/platform.simulator.linux.mak
@@ -1,2 +1,2 @@
 TOOLCHAIN = host-gcc
-EXE = bin
+EXE = elf

--- a/docs/build/index.md
+++ b/docs/build/index.md
@@ -31,14 +31,19 @@ brew install armmbed/formulae/arm-none-eabi-gcc fltk freetype libpng pkg-config 
 Most of the required tools are available as apt packages:
 
 ```
-apt-get install build-essential git libfltk1.3-dev libfreetype6-dev libpng-dev pkg-config
+apt-get install build-essential git libx11-dev libxext-dev libfreetype6-dev libpng-dev libjpeg-dev pkg-config
 ```
 
-You'll also need to install the latest version of  and make it available in your $PATH:
+You'll also need to install the latest version of GCC and make it available in your $PATH:
 
 1. Download the [GCC toolchain distributed by ARM](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads). You should obtain a `gcc-arm-none-eabi-x-linux.tar.bz2` file.
 2. Decompress that file with `tar xvfj gcc-arm-none-eabi-*-linux.tar.bz2`
 3. Add the resulting folder to your $PATH. If you use bash, ``echo "export PATH=\$PATH:`find $(pwd)/gcc-arm-none-eabi-*-update/bin -type d`" >> ~/.bashrc`` should do what you need (you'll need to restart your terminal afterwards).
+
+Alternatively, on Debian 10 and later you can directly install a sufficiently modern cross-toolchain:
+```
+apt-get install gcc-arm-none-eabi binutils-arm-none-eabi
+```
 
 ## Retrieve the source code
 

--- a/ion/src/simulator/linux/include/SDL_config.h
+++ b/ion/src/simulator/linux/include/SDL_config.h
@@ -124,7 +124,6 @@
 #define HAVE_GETAUXVAL 1
 #define HAVE_POLL 1
 #define HAVE__EXIT 1
-#define HAVE_IMMINTRIN_H 1
 
 /* Enable audio output drivers */
 #define SDL_AUDIO_DRIVER_DUMMY 1

--- a/ion/src/simulator/shared/main.cpp
+++ b/ion/src/simulator/shared/main.cpp
@@ -77,7 +77,13 @@ void init() {
 
   SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "1");
 
+  // Try creating a hardware-accelerated renderer.
   sRenderer = SDL_CreateRenderer(sWindow, -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
+  if (!sRenderer) {
+    // Try creating a software renderer.
+    sRenderer = SDL_CreateRenderer(sWindow, -1, 0);
+  }
+  assert(sRenderer);
 
   Display::init(sRenderer);
 


### PR DESCRIPTION
These changes are required to build and run the simulator on a Chrome OS Linux container.

Note that documentation for building on other platforms should be updated too.