### PR TITLE
[poincare] Decimal: change order definition on Decimal expression

### DIFF
--- a/poincare/include/poincare/decimal.h
+++ b/poincare/include/poincare/decimal.h
@@ -53,6 +53,9 @@ public:
   }
 
   // Comparison
+  /* Warning: Decimal(mantissa: 1000, exponent: 3) and Decimal(mantissa: 1, exponent: 3)
+   * are strictly ordered with the SimplificationOrder although they are equal
+   * with the usual math order (1.000E3 == 1E3). */
   int simplificationOrderSameType(const ExpressionNode * e, bool ascending, bool canBeInterrupted) const override;
 
   // Simplification

--- a/poincare/src/decimal.cpp
+++ b/poincare/src/decimal.cpp
@@ -81,9 +81,7 @@ int DecimalNode::simplificationOrderSameType(const ExpressionNode * e, bool asce
   } else {
     assert(m_exponent == other->m_exponent);
     assert(exponent() == other->exponent());
-    double approx0 = templatedApproximate<double>();
-    double approx1 = other->templatedApproximate<double>();
-    return (approx0 == approx1 ? 0 : (approx0 < approx1 ? -1 : 1));
+    unsignedComparison = Integer::NaturalOrder(unsignedMantissa(), other->unsignedMantissa());
   }
   return ((int)Number(this).sign())*unsignedComparison;
 }

--- a/poincare/test/expression.cpp
+++ b/poincare/test/expression.cpp
@@ -48,8 +48,9 @@ QUIZ_CASE(poincare_expression_decimal_constructor) {
   assert_pool_size(initialPoolSize+4);
 
   assert_equal(Decimal::Builder("25", 3), Decimal::Builder("25", 3));
-  assert_equal(Decimal::Builder("1000", -3), Decimal::Builder("1", -3));
-  assert_equal(Decimal::Builder("1000", 3), Decimal::Builder("1", 3));
+  assert_equal(Decimal::Builder("25", 3), Decimal::Builder(25, 3));
+  assert_not_equal(Decimal::Builder("1000", -3), Decimal::Builder("1", -3));
+  assert_not_equal(Decimal::Builder("1000", 3), Decimal::Builder("1", 3));
   assert_not_equal(Decimal::Builder(123,234), Decimal::Builder(42, 108));
   assert_not_equal(Decimal::Builder(12,2), Decimal::Builder(123, 2));
   assert_not_equal(Decimal::Builder(1234,2), Decimal::Builder(1234,3));


### PR DESCRIPTION
Now, Decimal node "1.000E3" is not equal to Decimal node "1E3" node anymore.
This prevents from using double comparison (which is sometimes wrong due to
double precision) to implement decimal comparison.