### PR TITLE
[poincare][apps/shared] Use IEEE754::exponentInBase10 instead of std::floor(std::log10())

### DIFF
--- a/apps/shared/range_1D.cpp
+++ b/apps/shared/range_1D.cpp
@@ -1,6 +1,7 @@
 #include "range_1D.h"
 #include <assert.h>
 #include <ion.h>
+#include <poincare/ieee754.h>
 
 namespace Shared {
 
@@ -36,7 +37,7 @@ void Range1D::setMax(float max, float lowerMaxFloat, float upperMaxFloat) {
 }
 
 float Range1D::defaultRangeLengthFor(float position) {
-  return std::pow(10.0f, std::floor(std::log10(std::fabs(position)))-1.0f);
+  return std::pow(10.0f, Poincare::IEEE754<float>::exponentBase10(position)-1.0f);
 }
 
 float Range1D::clipped(float x, bool isMax, float lowerMaxFloat, float upperMaxFloat) {

--- a/poincare/src/derivative.cpp
+++ b/poincare/src/derivative.cpp
@@ -1,4 +1,5 @@
 #include <poincare/derivative.h>
+#include <poincare/ieee754.h>
 #include <poincare/layout_helper.h>
 #include <poincare/serialization_helper.h>
 
@@ -64,7 +65,7 @@ Evaluation<T> DerivativeNode::templatedApproximate(Context * context, Preference
   if (std::fabs(error) < min) {
     return Complex<T>::Builder(result);
   }
-  error = std::pow((T)10, std::floor(std::log10(std::fabs(error)))+2);
+  error = std::pow((T)10, IEEE754<T>::exponentBase10(error)+2);
   return Complex<T>::Builder(std::round(result/error)*error);
 }
 

--- a/poincare/src/print_float.cpp
+++ b/poincare/src/print_float.cpp
@@ -348,7 +348,7 @@ PrintFloat::TextLengths PrintFloat::ConvertFloatToTextPrivate(T f, char * buffer
   /* Part IV: Exponent */
 
   int exponent = mode == Preferences::PrintFloatMode::Engineering ? exponentForEngineeringNotation : exponentInBase10;
-  int numberOfCharExponent = exponent != 0 ? std::log10(std::fabs((T)exponent)) + 1 : 0;
+  int numberOfCharExponent = exponent != 0 ? IEEE754<T>::exponentBase10((T)exponent) + 1 : 0;
   if (exponent < 0) {
     // If the exponent is < 0, we need a additional char for the sign
     numberOfCharExponent++;


### PR DESCRIPTION
This avoids precision issues when computing the number of digits of a number.