### PR TITLE
Fix derivative bug

### DIFF
--- a/poincare/test/approximation.cpp
+++ b/poincare/test/approximation.cpp
@@ -258,6 +258,9 @@ QUIZ_CASE(poincare_approximation_function) {
   assert_expression_approximates_to<float>("diff(2×TO^2, TO, 7)", "28");
   assert_expression_approximates_to<double>("diff(2×TO^2, TO, 7)", "28");
 
+  //assert_expression_approximates_to<float>("diff(-1/3×x^3+6x^2-11x-50,x,11)", "0"); // FIXME error too big
+  assert_expression_approximates_to<double>("diff(-1/3×x^3+6x^2-11x-50,x,11)", "0");
+
   assert_expression_approximates_to<float>("floor(2.3)", "2");
   assert_expression_approximates_to<double>("floor(2.3)", "2");
 


### PR DESCRIPTION
Fix a derivative error:
- Stop the iterative riddersApproximation if the error starts increasing
- h should be superior to 10 epsilon
- if the result is close to 0, be less restrictive on the error/result ratio

Fixes #1150 
The derivative now displays -2E-11 in graph for f(x) = -1/3 x^3 + 6x^2 - 11x - 50 and "go to" x = 11.

To display 0, we should implement the derivative reduction