### PR TITLE
Calibrate SysTick

### DIFF
--- a/ion/src/device/shared/drivers/board.cpp
+++ b/ion/src/device/shared/drivers/board.cpp
@@ -79,14 +79,14 @@ void setStandardFrequency(Frequency f) {
 
 void setClockFrequency(Frequency f) {
   // TODO: Update TIM3 prescaler or ARR to avoid irregular LED blinking
-  switch (f) {
-    case Frequency::High:
-      RCC.CFGR()->setHPRE(RCC::CFGR::AHBPrescaler::SysClk);
-      return;
-    default:
-      assert(f == Frequency::Low);
-      RCC.CFGR()->setHPRE(Clocks::Config::AHBLowFrequencyPrescalerReg);
-      return;
+  if (f == Frequency::High) {
+    RCC.CFGR()->setHPRE(RCC::CFGR::AHBPrescaler::SysClk);
+    Device::Timing::setSysTickFrequency(Ion::Device::Clocks::Config::HCLKFrequency);
+  } else {
+    assert(f == Frequency::Low);
+    // Change the systick frequency to compensate the KCLK frequency change
+    Device::Timing::setSysTickFrequency(Ion::Device::Clocks::Config::HCLKLowFrequency);
+    RCC.CFGR()->setHPRE(Clocks::Config::AHBLowFrequencyPrescalerReg);
   }
 }
 

--- a/ion/src/device/shared/drivers/timing.cpp
+++ b/ion/src/device/shared/drivers/timing.cpp
@@ -18,10 +18,11 @@ void msleep(uint32_t ms) {
   // We decrease the AHB clock frequency to save power while sleeping.
   Device::Board::setClockFrequency(Device::Board::Frequency::Low);
   for (volatile uint32_t i=0; i<Config::LoopsPerMillisecond*ms; i++) {
-      __asm volatile("nop");
+    __asm volatile("nop");
   }
   Device::Board::setClockFrequency(Device::Board::standardFrequency());
 }
+
 void usleep(uint32_t us) {
   for (volatile uint32_t i=0; i<Config::LoopsPerMicrosecond*us; i++) {
     __asm volatile("nop");
@@ -44,12 +45,7 @@ using namespace Regs;
 volatile uint64_t MillisElapsed = 0;
 
 void init() {
-  /* Systick clock source is the CPU clock HCLK divided by 8. To get 1 ms
-   * systick overflow, we need to set it to :
-   * (HCLK (MHz) * 1 000 000 / 8 )/ 1000 (ms/s) = HCLK (MHz) * 1000 / 8. */
-  constexpr int SysTickPerMillisecond = Ion::Device::Clocks::Config::HCLKFrequency * 1000 / 8;
-  CORTEX.SYST_RVR()->setRELOAD(SysTickPerMillisecond - 1); // Remove 1 because the counter resets *after* counting to 0
-  CORTEX.SYST_CVR()->setCURRENT(0);
+  setSysTickFrequency(Ion::Device::Clocks::Config::HCLKFrequency);
   CORTEX.SYST_CSR()->setCLKSOURCE(CORTEX::SYST_CSR::CLKSOURCE::AHB_DIV8);
   CORTEX.SYST_CSR()->setTICKINT(true);
   CORTEX.SYST_CSR()->setENABLE(true);
@@ -58,6 +54,15 @@ void init() {
 void shutdown() {
   CORTEX.SYST_CSR()->setENABLE(false);
   CORTEX.SYST_CSR()->setTICKINT(false);
+}
+
+void setSysTickFrequency(int frequencyInMHz) {
+  /* Systick clock source is the CPU clock HCLK divided by 8. To get 1 ms
+   * systick overflow, we need to set it to :
+   * (HCLK (MHz) * 1 000 000 / 8 )/ 1000 (ms/s) = HCLK (MHz) * 1000 / 8. */
+  int SysTickPerMillisecond = frequencyInMHz * 1000 / 8;
+  CORTEX.SYST_RVR()->setRELOAD(SysTickPerMillisecond - 1); // Remove 1 because the counter resets *after* counting to 0
+  CORTEX.SYST_CVR()->setCURRENT(0); // setCURRENT will set the value to 0, no matter the argument, as per the CORTEX user guide
 }
 
 }

--- a/ion/src/device/shared/drivers/timing.h
+++ b/ion/src/device/shared/drivers/timing.h
@@ -8,6 +8,7 @@ namespace Device {
 namespace Timing {
 
 void init();
+void setSysTickFrequency(int frequencyInMHz);
 void shutdown();
 
 extern volatile uint64_t MillisElapsed;

--- a/python/port/helpers.cpp
+++ b/python/port/helpers.cpp
@@ -23,13 +23,20 @@ bool micropython_port_vm_hook_loop() {
 }
 
 bool micropython_port_interruptible_msleep(uint32_t delay) {
-  uint32_t start = Ion::Timing::millis();
-  while (Ion::Timing::millis() - start < delay) {
+  /* We don't use millis because the systick drifts when changing the HCLK
+   * frequency. */
+  constexpr uint32_t interruptionCheckDelay = 100;
+  const uint32_t numberOfInterruptionChecks = delay / interruptionCheckDelay;
+  uint32_t remainingInterruptionChecks = numberOfInterruptionChecks;
+  while (remainingInterruptionChecks > 0) {
+    // We assume the time taken by the interruption check is insignificant
     if (micropython_port_interrupt_if_needed()) {
       return true;
     }
-    Ion::Timing::msleep(1);
+    remainingInterruptionChecks--;
+    Ion::Timing::msleep(interruptionCheckDelay);
   }
+  Ion::Timing::msleep(delay - numberOfInterruptionChecks * interruptionCheckDelay);
   return false;
 }
 


### PR DESCRIPTION
millis() was quite false because we change the HCLK frequency in msleep.
This is mitigated by also changing the Systick frequency in msleep, but this provokes a small drift, visible in the Python sleep -> This method was changed to generate less frequency changes