### PR TITLE
[poincare] Use std::move when needed

### DIFF
--- a/poincare/src/addition.cpp
+++ b/poincare/src/addition.cpp
@@ -9,6 +9,7 @@
 #include <poincare/subtraction.h>
 #include <poincare/undefined.h>
 #include <assert.h>
+#include <utility>
 
 namespace Poincare {
 
@@ -420,7 +421,7 @@ Expression Addition::factorizeOnCommonDenominator(ExpressionNode::ReductionConte
   a.addChildAtIndexInPlace(result, aChildrenCount, aChildrenCount);
   result.privateShallowReduce(reductionContext, false, true);
   replaceWithInPlace(a);
-  return a;
+  return std::move(a);
 }
 
 void Addition::factorizeChildrenAtIndexesInPlace(int index1, int index2, ExpressionNode::ReductionContext reductionContext) {

--- a/poincare/src/approximation_helper.cpp
+++ b/poincare/src/approximation_helper.cpp
@@ -3,6 +3,7 @@
 #include <poincare/evaluation.h>
 #include <poincare/matrix_complex.h>
 #include <cmath>
+#include <utility>
 extern "C" {
 #include <assert.h>
 }
@@ -39,7 +40,7 @@ template<typename T> Evaluation<T> ApproximationHelper::Map(const ExpressionNode
       result.addChildAtIndexInPlace(compute(m.complexAtIndex(i), complexFormat, angleUnit), i, i);
     }
     result.setDimensions(m.numberOfRows(), m.numberOfColumns());
-    return result;
+    return std::move(result);
   }
 }
 

--- a/poincare/src/binomial_coefficient.cpp
+++ b/poincare/src/binomial_coefficient.cpp
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <cmath>
+#include <utility>
 
 namespace Poincare {
 
@@ -109,7 +110,7 @@ Expression BinomialCoefficient::shallowReduce(Context * context) {
   // As we cap the n < k_maxNValue = 300, result < binomial(300, 150) ~2^89
   assert(!result.numeratorOrDenominatorIsInfinity());
   replaceWithInPlace(result);
-  return result;
+  return std::move(result);
 }
 
 template double BinomialCoefficientNode::compute(double k, double n);

--- a/poincare/src/complex_cartesian.cpp
+++ b/poincare/src/complex_cartesian.cpp
@@ -15,6 +15,7 @@
 #include <poincare/undefined.h>
 #include <assert.h>
 #include <cmath>
+#include <utility>
 
 namespace Poincare {
 
@@ -107,14 +108,14 @@ Expression ComplexCartesian::squareNorm(ExpressionNode::ReductionContext reducti
   if (!aFactor.isUninitialized() && !aArgument.isUninitialized() && !bFactor.isUninitialized() && !bArgument.isUninitialized() && aFactor.isIdenticalTo(bFactor) && aArgument.isIdenticalTo(bArgument)) {
     Power result = Power::Builder(aFactor, Rational::Builder(2));
     aFactor.shallowReduce(reductionContext);
-    return result;
+    return std::move(result);
   }
   Expression a2 = Power::Builder(a, Rational::Builder(2));
   Expression b2 = Power::Builder(b, Rational::Builder(2));
   Addition add = Addition::Builder(a2, b2);
   a2.shallowReduce(reductionContext);
   b2.shallowReduce(reductionContext);
-  return add;
+  return std::move(add);
 }
 
 Expression ComplexCartesian::norm(ExpressionNode::ReductionContext reductionContext) {
@@ -170,7 +171,7 @@ Expression ComplexCartesian::argument(ExpressionNode::ReductionContext reduction
     signa.shallowReduce(reductionContext);
     Multiplication mul = Multiplication::Builder(Rational::Builder(1,2), Constant::Builder(UCodePointGreekSmallLetterPi), sub);
     sub.shallowReduce(reductionContext);
-    return mul;
+    return std::move(mul);
   }
 }
 
@@ -320,7 +321,7 @@ Expression ComplexCartesian::powerHelper(Expression norm, Expression trigo, Expr
   Multiplication m = Multiplication::Builder(norm, trigo);
   norm.shallowReduce(reductionContext);
   trigo.shallowReduce(reductionContext);
-  return m;
+  return std::move(m);
 }
 
 ComplexCartesian ComplexCartesian::power(ComplexCartesian & other, ExpressionNode::ReductionContext reductionContext) {

--- a/poincare/src/confidence_interval.cpp
+++ b/poincare/src/confidence_interval.cpp
@@ -6,8 +6,9 @@
 #include <poincare/layout_helper.h>
 #include <poincare/serialization_helper.h>
 #include <poincare/undefined.h>
-#include <cmath>
 #include <assert.h>
+#include <cmath>
+#include <utility>
 
 namespace Poincare {
 
@@ -89,7 +90,7 @@ Expression ConfidenceInterval::shallowReduce(ExpressionNode::ReductionContext re
   matrix.setDimensions(1, 2);
   replaceWithInPlace(matrix);
   matrix.deepReduceChildren(reductionContext);
-  return matrix;
+  return std::move(matrix);
 }
 
 

--- a/poincare/src/conjugate.cpp
+++ b/poincare/src/conjugate.cpp
@@ -2,12 +2,12 @@
 #include <poincare/conjugate_layout.h>
 #include <poincare/complex_cartesian.h>
 #include <poincare/multiplication.h>
+#include <poincare/opposite.h>
 #include <poincare/rational.h>
 #include <poincare/serialization_helper.h>
-
-#include <poincare/opposite.h>
 #include <assert.h>
 #include <cmath>
+#include <utility>
 
 namespace Poincare {
 
@@ -53,7 +53,7 @@ Expression Conjugate::shallowReduce(ExpressionNode::ReductionContext reductionCo
     complexChild.replaceChildAtIndexInPlace(1, m);
     m.shallowReduce(reductionContext);
     replaceWithInPlace(complexChild);
-    return complexChild;
+    return std::move(complexChild);
   }
   if (c.type() == ExpressionNode::Type::Rational) {
     replaceWithInPlace(c);

--- a/poincare/src/decimal.cpp
+++ b/poincare/src/decimal.cpp
@@ -10,7 +10,7 @@
 #include <ion/unicode/utf8_helper.h>
 #include <assert.h>
 #include <cmath>
-#include <assert.h>
+#include <utility>
 
 namespace Poincare {
 
@@ -416,7 +416,7 @@ Expression Decimal::setSign(ExpressionNode::Sign s) {
   assert(s == ExpressionNode::Sign::Positive || s == ExpressionNode::Sign::Negative);
   Decimal result = *this;
   result.node()->setNegative(s == ExpressionNode::Sign::Negative);
-  return result;
+  return std::move(result);
 }
 
 Expression Decimal::shallowReduce() {
@@ -453,7 +453,7 @@ Expression Decimal::shallowBeautify() {
     Opposite o = Opposite::Builder();
     replaceWithInPlace(o);
     o.replaceChildAtIndexInPlace(0, abs);
-    return o;
+    return std::move(o);
   }
   return *this;
 }

--- a/poincare/src/equal.cpp
+++ b/poincare/src/equal.cpp
@@ -18,6 +18,8 @@ extern "C" {
 #include <math.h>
 #include <limits.h>
 }
+#include <utility>
+
 namespace Poincare {
 
 Expression EqualNode::shallowReduce(ReductionContext reductionContext) {
@@ -29,7 +31,7 @@ Layout EqualNode::createLayout(Preferences::PrintFloatMode floatDisplayMode, int
   result.addOrMergeChildAtIndex(childAtIndex(0)->createLayout(floatDisplayMode, numberOfSignificantDigits), 0, false);
   result.addChildAtIndex(CodePointLayout::Builder('='), result.numberOfChildren(), result.numberOfChildren(), nullptr);
   result.addOrMergeChildAtIndex(childAtIndex(1)->createLayout(floatDisplayMode, numberOfSignificantDigits), result.numberOfChildren(), false);
-  return result;
+  return std::move(result);
 }
 
 int EqualNode::serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const {

--- a/poincare/src/expression.cpp
+++ b/poincare/src/expression.cpp
@@ -10,6 +10,7 @@
 #include <ion/unicode/utf8_helper.h>
 #include <cmath>
 #include <float.h>
+#include <utility>
 
 #include "parsing/parser.h"
 
@@ -373,7 +374,7 @@ Expression Expression::makePositiveAnyNegativeNumeralFactor(ExpressionNode::Redu
       // Otherwise, we make it positive
       m.childAtIndex(0).setSign(ExpressionNode::Sign::Positive, reductionContext);
     }
-    return m;
+    return std::move(m);
   }
   return Expression();
 }

--- a/poincare/src/factor.cpp
+++ b/poincare/src/factor.cpp
@@ -11,6 +11,7 @@ extern "C" {
 #include <assert.h>
 }
 #include <cmath>
+#include <utility>
 
 namespace Poincare {
 
@@ -80,7 +81,7 @@ Expression Factor::shallowBeautify(ExpressionNode::ReductionContext reductionCon
   Rational r = static_cast<Rational &>(c);
   if (r.isZero()) {
     replaceWithInPlace(r);
-    return r;
+    return std::move(r);
   }
   Multiplication numeratorDecomp = createMultiplicationOfIntegerPrimeDecomposition(r.unsignedIntegerNumerator(), reductionContext.context(), reductionContext.complexFormat(), reductionContext.angleUnit());
   if (numeratorDecomp.numberOfChildren() == 0) {

--- a/poincare/src/factorial.cpp
+++ b/poincare/src/factorial.cpp
@@ -5,10 +5,10 @@
 #include <poincare/parenthesis.h>
 #include <poincare/rational.h>
 #include <poincare/serialization_helper.h>
-
 #include <poincare/symbol.h>
 #include <poincare/undefined.h>
 #include <cmath>
+#include <utility>
 
 namespace Poincare {
 
@@ -71,7 +71,7 @@ Layout FactorialNode::createLayout(Preferences::PrintFloatMode floatDisplayMode,
   result.addOrMergeChildAtIndex(childAtIndex(0)->createLayout(floatDisplayMode, numberOfSignificantDigits), 0, false);
   int childrenCount = result.numberOfChildren();
   result.addChildAtIndex(CodePointLayout::Builder('!'), childrenCount, childrenCount, nullptr);
-  return result;
+  return std::move(result);
 }
 
 int FactorialNode::serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const {
@@ -106,7 +106,7 @@ Expression Factorial::shallowReduce(ExpressionNode::ReductionContext reductionCo
     Rational fact = Rational::Builder(Integer::Factorial(r.unsignedIntegerNumerator()));
     assert(!fact.numeratorOrDenominatorIsInfinity()); // because fact < k_maxOperandValue!
     replaceWithInPlace(fact);
-    return fact;
+    return std::move(fact);
   }
   if (c.type() == ExpressionNode::Type::Constant) {
     // e! = undef, i! = undef, pi! = undef

--- a/poincare/src/layout_helper.cpp
+++ b/poincare/src/layout_helper.cpp
@@ -6,6 +6,7 @@
 #include <poincare/vertical_offset_layout.h>
 #include <ion/unicode/utf8_decoder.h>
 #include <assert.h>
+#include <utility>
 
 namespace Poincare {
 
@@ -24,7 +25,7 @@ Layout LayoutHelper::Infix(const Expression & expression, Preferences::PrintFloa
         result.numberOfChildren(),
         true);
   }
-  return result;
+  return std::move(result);
 }
 
 Layout LayoutHelper::Prefix(const Expression & expression, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits, const char * operatorName) {
@@ -44,7 +45,7 @@ Layout LayoutHelper::Prefix(const Expression & expression, Preferences::PrintFlo
   }
   // Add the parenthesed arguments.
   result.addOrMergeChildAtIndex(Parentheses(args, false), result.numberOfChildren(), true);
-  return result;
+  return std::move(result);
 }
 
 Layout LayoutHelper::Parentheses(Layout layout, bool cloneLayout) {
@@ -54,7 +55,7 @@ Layout LayoutHelper::Parentheses(Layout layout, bool cloneLayout) {
     result.addOrMergeChildAtIndex(cloneLayout ? layout.clone() : layout, 1, true);
   }
   result.addChildAtIndex(RightParenthesisLayout::Builder(), result.numberOfChildren(), result.numberOfChildren(), nullptr);
-  return result;
+  return std::move(result);
 }
 
 Layout LayoutHelper::String(const char * buffer, int bufferLen, const KDFont * font) {
@@ -99,7 +100,7 @@ Layout LayoutHelper::Logarithm(Layout argument, Layout index) {
   VerticalOffsetLayout offsetLayout = VerticalOffsetLayout::Builder(index, VerticalOffsetLayoutNode::Position::Subscript);
   resultLayout.addChildAtIndex(offsetLayout, resultLayout.numberOfChildren(), resultLayout.numberOfChildren(), nullptr);
   resultLayout.addOrMergeChildAtIndex(Parentheses(argument, false), resultLayout.numberOfChildren(), true);
-  return resultLayout;
+  return std::move(resultLayout);
 }
 
 }

--- a/poincare/src/logarithm.cpp
+++ b/poincare/src/logarithm.cpp
@@ -13,10 +13,11 @@
 #include <poincare/serialization_helper.h>
 #include <poincare/undefined.h>
 #include <poincare/unreal.h>
-#include <cmath>
 #include <ion.h>
 #include <assert.h>
+#include <cmath>
 #include <stdlib.h>
+#include <utility>
 
 namespace Poincare {
 
@@ -344,7 +345,7 @@ Expression Logarithm::splitLogarithmInteger(Integer i, bool isDenominator, Expre
       return e;
     }
     Multiplication m = Multiplication::Builder(Rational::Builder(-1), e);
-    return m;
+    return std::move(m);
   }
   Addition a = Addition::Builder();
   for (int index = 0; index < numberOfPrimeFactors; index++) {
@@ -358,7 +359,7 @@ Expression Logarithm::splitLogarithmInteger(Integer i, bool isDenominator, Expre
     a.addChildAtIndexInPlace(m, a.numberOfChildren(), a.numberOfChildren());
     m.shallowReduce(reductionContext);
   }
-  return a;
+  return std::move(a);
 }
 
 Expression Logarithm::shallowBeautify() {
@@ -367,13 +368,13 @@ Expression Logarithm::shallowBeautify() {
   if (childAtIndex(1).isIdenticalTo(e)) {
     NaperianLogarithm np = NaperianLogarithm::Builder(childAtIndex(0));
     replaceWithInPlace(np);
-    return np;
+    return std::move(np);
   }
   Rational ten = Rational::Builder(10);
   if (childAtIndex(1).isIdenticalTo(ten)) {
     CommonLogarithm l = CommonLogarithm::Builder(childAtIndex(0));
     replaceWithInPlace(l);
-    return l;
+    return std::move(l);
   }
   return *this;
 }

--- a/poincare/src/matrix.cpp
+++ b/poincare/src/matrix.cpp
@@ -9,11 +9,12 @@
 #include <poincare/serialization_helper.h>
 #include <poincare/subtraction.h>
 #include <poincare/undefined.h>
+#include <assert.h>
 #include <cmath>
 #include <float.h>
-#include <string.h>
-#include <assert.h>
 #include <stdlib.h>
+#include <string.h>
+#include <utility>
 
 namespace Poincare {
 
@@ -35,7 +36,7 @@ Layout MatrixNode::createLayout(Preferences::PrintFloatMode floatDisplayMode, in
     layout.addChildAtIndex(c->createLayout(floatDisplayMode, numberOfSignificantDigits), layout.numberOfChildren(), layout.numberOfChildren(), nullptr);
   }
   layout.setDimensions(m_numberOfRows, m_numberOfColumns);
-  return layout;
+  return std::move(layout);
 }
 
 int MatrixNode::serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const {
@@ -89,7 +90,7 @@ Evaluation<T> MatrixNode::templatedApproximate(Context * context, Preferences::C
     matrix.addChildAtIndexInPlace(c->approximate(T(), context, complexFormat, angleUnit), matrix.numberOfChildren(), matrix.numberOfChildren());
   }
   matrix.setDimensions(numberOfRows(), numberOfColumns());
-  return matrix;
+  return std::move(matrix);
 }
 
 // MATRIX
@@ -440,7 +441,7 @@ Expression Matrix::computeInverseOrDeterminant(bool computeDeterminant, Expressi
       }
     }
     inverse.setDimensions(dim, dim);
-    return inverse;
+    return std::move(inverse);
   } else {
     *couldCompute = false;
     return Expression();

--- a/poincare/src/matrix_complex.cpp
+++ b/poincare/src/matrix_complex.cpp
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <assert.h>
 #include <float.h>
+#include <utility>
 
 namespace Poincare {
 
@@ -49,7 +50,7 @@ Expression MatrixComplexNode<T>::complexToExpression(Preferences::ComplexFormat 
     i++;
   }
   matrix.setDimensions(numberOfRows(), numberOfColumns());
-  return matrix;
+  return std::move(matrix);
 }
 
 template<typename T>

--- a/poincare/src/matrix_dimension.cpp
+++ b/poincare/src/matrix_dimension.cpp
@@ -5,6 +5,7 @@
 #include <poincare/rational.h>
 #include <poincare/serialization_helper.h>
 #include <cmath>
+#include <utility>
 
 namespace Poincare {
 
@@ -61,7 +62,7 @@ Expression MatrixDimension::shallowReduce(Context * context) {
   }
   result.setDimensions(1, 2);
   replaceWithInPlace(result);
-  return result;
+  return std::move(result);
 }
 
 }

--- a/poincare/src/matrix_trace.cpp
+++ b/poincare/src/matrix_trace.cpp
@@ -6,6 +6,7 @@
 #include <poincare/serialization_helper.h>
 #include <poincare/undefined.h>
 #include <cmath>
+#include <utility>
 
 namespace Poincare {
 
@@ -29,7 +30,7 @@ template<typename T>
 Evaluation<T> MatrixTraceNode::templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const {
   Evaluation<T> input = childAtIndex(0)->approximate(T(), context, complexFormat, angleUnit);
   Complex<T> result = Complex<T>::Builder(input.trace());
-  return result;
+  return std::move(result);
 }
 
 

--- a/poincare/src/multiplication.cpp
+++ b/poincare/src/multiplication.cpp
@@ -12,9 +12,10 @@
 #include <poincare/serialization_helper.h>
 #include <poincare/tangent.h>
 #include <poincare/undefined.h>
-#include <cmath>
 #include <ion.h>
 #include <assert.h>
+#include <cmath>
+#include <utility>
 
 namespace Poincare {
 
@@ -281,7 +282,7 @@ Expression Multiplication::shallowBeautify(ExpressionNode::ReductionContext redu
     Opposite o = Opposite::Builder();
     noNegativeNumeral.replaceWithInPlace(o);
     o.replaceChildAtIndexInPlace(0, noNegativeNumeral);
-    return o;
+    return std::move(o);
   }
 
   /* Step 2: Merge negative powers: a*b^(-1)*c^(-pi)*d = a*(b*c^pi)^(-1)

--- a/poincare/src/n_ary_expression.cpp
+++ b/poincare/src/n_ary_expression.cpp
@@ -4,6 +4,7 @@ extern "C" {
 #include <assert.h>
 #include <stdlib.h>
 }
+#include <utility>
 
 namespace Poincare {
 
@@ -49,7 +50,7 @@ Expression NAryExpressionNode::squashUnaryHierarchyInPlace() {
     reference.replaceWithInPlace(child);
     return child;
   }
-  return reference;
+  return std::move(reference);
 }
 
 // Private

--- a/poincare/src/nth_root.cpp
+++ b/poincare/src/nth_root.cpp
@@ -11,6 +11,7 @@
 #include <poincare/serialization_helper.h>
 #include <assert.h>
 #include <cmath>
+#include <utility>
 
 namespace Poincare {
 
@@ -60,7 +61,7 @@ Evaluation<T> NthRootNode::templatedApproximate(Context * context, Preferences::
     }
     result = PowerNode::compute(basec, std::complex<T>(1.0)/(indexc), complexFormat);
   }
-  return result;
+  return std::move(result);
 }
 
 

--- a/poincare/src/number.cpp
+++ b/poincare/src/number.cpp
@@ -1,16 +1,16 @@
 #include <poincare/number.h>
 #include <poincare/decimal.h>
+#include <poincare/float.h>
+#include <poincare/infinity.h>
 #include <poincare/integer.h>
 #include <poincare/rational.h>
-#include <poincare/float.h>
 #include <poincare/undefined.h>
-#include <poincare/infinity.h>
-
 extern "C" {
 #include <stdlib.h>
 #include <assert.h>
 }
 #include <cmath>
+#include <utility>
 
 namespace Poincare {
 
@@ -89,7 +89,7 @@ Number Number::BinaryOperation(const Number & i, const Number & j, RationalBinar
     // Rational + Rational
     Rational a = rationalOp(static_cast<const Rational&>(i), static_cast<const Rational&>(j));
     if (!a.numeratorOrDenominatorIsInfinity()) {
-      return a;
+      return std::move(a);
     }
   }
   /* At least one of the operands is Undefined/Infinity/Float, or the Rational

--- a/poincare/src/opposite.cpp
+++ b/poincare/src/opposite.cpp
@@ -7,12 +7,10 @@
 #include <poincare/multiplication.h>
 #include <poincare/rational.h>
 #include <poincare/serialization_helper.h>
-
-extern "C" {
-#include <cmath>
 #include <assert.h>
+#include <cmath>
 #include <stdlib.h>
-}
+#include <utility>
 
 namespace Poincare {
 
@@ -52,7 +50,7 @@ Layout OppositeNode::createLayout(Preferences::PrintFloatMode floatDisplayMode, 
   } else {
     result.addOrMergeChildAtIndex(childAtIndex(0)->createLayout(floatDisplayMode, numberOfSignificantDigits), 1, false);
   }
-  return result;
+  return std::move(result);
 }
 
 int OppositeNode::serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const {

--- a/poincare/src/parsing/parser.cpp
+++ b/poincare/src/parsing/parser.cpp
@@ -1,5 +1,6 @@
 #include "parser.h"
 #include <ion/unicode/utf8_decoder.h>
+#include <utility>
 
 namespace Poincare {
 
@@ -563,7 +564,7 @@ Expression Parser::parseCommaSeparatedList() {
     commaSeparatedList.addChildAtIndexInPlace(item, length, length);
     length++;
   } while (popTokenIfType(Token::Comma));
-  return commaSeparatedList;
+  return std::move(commaSeparatedList);
 }
 
 void Parser::defaultParseLeftParenthesis(bool isSystemParenthesis, Expression & leftHandSide, Token::Type stoppingType) {

--- a/poincare/src/power.cpp
+++ b/poincare/src/power.cpp
@@ -5,27 +5,28 @@
 #include <poincare/constant.h>
 #include <poincare/cosine.h>
 #include <poincare/division.h>
+#include <poincare/horizontal_layout.h>
 #include <poincare/infinity.h>
 #include <poincare/matrix.h>
 #include <poincare/matrix_identity.h>
 #include <poincare/matrix_inverse.h>
+#include <poincare/naperian_logarithm.h>
 #include <poincare/nth_root.h>
 #include <poincare/opposite.h>
-#include <poincare/naperian_logarithm.h>
 #include <poincare/parenthesis.h>
+#include <poincare/serialization_helper.h>
 #include <poincare/sine.h>
 #include <poincare/square_root.h>
-#include <poincare/symbol.h>
 #include <poincare/subtraction.h>
+#include <poincare/symbol.h>
 #include <poincare/undefined.h>
 #include <poincare/unreal.h>
-#include <poincare/horizontal_layout.h>
 #include <poincare/vertical_offset_layout.h>
-#include <poincare/serialization_helper.h>
-#include <cmath>
-#include <math.h>
 #include <ion.h>
 #include <assert.h>
+#include <cmath>
+#include <math.h>
+#include <utility>
 
 namespace Poincare {
 
@@ -161,7 +162,7 @@ Layout PowerNode::createLayout(Preferences::PrintFloatMode floatDisplayMode, int
       result.numberOfChildren(),
       result.numberOfChildren(),
       nullptr);
-  return result;
+  return std::move(result);
 }
 
 // Serialize
@@ -340,11 +341,11 @@ Expression Power::shallowReduce(ExpressionNode::ReductionContext reductionContex
     if (exp == 0) {
       Matrix id = Matrix::CreateIdentity(matrixBase.numberOfRows());
       replaceWithInPlace(id);
-      return id;
+      return std::move(id);
     }
     if (exp == 1) {
       replaceWithInPlace(matrixBase);
-      return matrixBase;
+      return std::move(matrixBase);
     }
     Expression result = matrixBase.clone();
     // TODO: implement a quick exponentiation
@@ -931,7 +932,7 @@ Expression Power::simplifyRationalRationalPower(ExpressionNode::ReductionContext
       return Power::Builder(a, b);
     }
     replaceWithInPlace(r);
-    return r;
+    return std::move(r);
   }
   Expression n;
   Expression d;
@@ -982,7 +983,7 @@ Expression Power::CreateSimplifiedIntegerRationalPower(Integer i, Rational r, bo
   Rational p2 = Rational::Builder(oneExponent, rDenominator);
   Power p = Power::Builder(p1, p2);
   if (r1.isEqualTo(Integer(1)) && !i.isNegative()) {
-    return p;
+    return std::move(p);
   }
   Integer one(1);
   Rational r3 = isDenominator ? Rational::Builder(one, r1) : Rational::Builder(r1);
@@ -1205,7 +1206,7 @@ Expression Power::CreateComplexExponent(const Expression & r, ExpressionNode::Re
   iComplex.shallowReduce(reductionContext);
   Power p = Power::Builder(exp, mExp);
   mExp.shallowReduce(reductionContext);
-  return p;
+  return std::move(p);
 #if 0
   const Constant iComplex = Constant::Builder(UCodePointMathematicalBoldSmallI);
   const Constant pi = Constant::Builder(UCodePointGreekSmallLetterPi);

--- a/poincare/src/prediction_interval.cpp
+++ b/poincare/src/prediction_interval.cpp
@@ -1,16 +1,15 @@
 #include <poincare/prediction_interval.h>
-#include <poincare/matrix.h>
 #include <poincare/addition.h>
-#include <poincare/multiplication.h>
-#include <poincare/power.h>
-#include <poincare/undefined.h>
 #include <poincare/division.h>
 #include <poincare/layout_helper.h>
+#include <poincare/matrix.h>
+#include <poincare/multiplication.h>
+#include <poincare/power.h>
 #include <poincare/serialization_helper.h>
-extern "C" {
+#include <poincare/undefined.h>
 #include <assert.h>
-}
 #include <cmath>
+#include <utility>
 
 namespace Poincare {
 
@@ -96,7 +95,7 @@ Expression PredictionInterval::shallowReduce(ExpressionNode::ReductionContext re
   matrix.setDimensions(1, 2);
   replaceWithInPlace(matrix);
   matrix.deepReduceChildren(reductionContext);
-  return matrix;
+  return std::move(matrix);
 }
 
 }

--- a/poincare/src/rational.cpp
+++ b/poincare/src/rational.cpp
@@ -5,12 +5,12 @@
 #include <poincare/infinity.h>
 #include <poincare/opposite.h>
 #include <poincare/serialization_helper.h>
-extern "C" {
-#include <stdlib.h>
-#include <string.h>
 #include <assert.h>
 #include <math.h>
-}
+#include <utility>
+#include <stdlib.h>
+#include <string.h>
+
 namespace Poincare {
 
 /* Rational Node */
@@ -259,7 +259,7 @@ Expression Rational::shallowBeautify() {
     Opposite o = Opposite::Builder();
     replaceWithInPlace(o);
     o.replaceChildAtIndexInPlace(0, abs);
-    return o;
+    return std::move(o);
   }
   return *this;
 }

--- a/poincare/src/round.cpp
+++ b/poincare/src/round.cpp
@@ -1,11 +1,12 @@
 #include <poincare/round.h>
-#include <poincare/undefined.h>
-#include <poincare/rational.h>
-#include <poincare/power.h>
 #include <poincare/layout_helper.h>
+#include <poincare/power.h>
+#include <poincare/rational.h>
 #include <poincare/serialization_helper.h>
+#include <poincare/undefined.h>
 #include <assert.h>
 #include <cmath>
+#include <utility>
 
 namespace Poincare {
 
@@ -76,7 +77,7 @@ Expression Round::shallowReduce(ExpressionNode::ReductionContext reductionContex
       return *this;
     }
     replaceWithInPlace(result);
-    return result;
+    return std::move(result);
   }
   return *this;
 }

--- a/poincare/src/sign_function.cpp
+++ b/poincare/src/sign_function.cpp
@@ -4,10 +4,10 @@
 #include <poincare/rational.h>
 #include <poincare/serialization_helper.h>
 #include <poincare/undefined.h>
-
 #include <ion.h>
 #include <assert.h>
 #include <math.h>
+#include <utility>
 
 namespace Poincare {
 
@@ -24,7 +24,7 @@ Expression SignFunctionNode::setSign(Sign s, ReductionContext reductionContext) 
   SignFunction sign(this);
   Rational r = Rational::Builder(s == ExpressionNode::Sign::Positive ? 1 : -1);
   sign.replaceWithInPlace(r);
-  return r;
+  return std::move(r);
 }
 
 Layout SignFunctionNode::createLayout(Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const {
@@ -87,7 +87,7 @@ Expression SignFunction::shallowReduce(ExpressionNode::ReductionContext reductio
         Multiplication m = Multiplication::Builder(Rational::Builder(-1));
         replaceWithInPlace(m);
         m.addChildAtIndexInPlace(sign, 1, 1); // sign does not need to be shallowReduced because -x = NAN --> x = NAN
-        return m; // m does not need to be shallowReduced, -1*sign cannot be reduced
+        return std::move(m); // m does not need to be shallowReduced, -1*sign cannot be reduced
       }
     } else if (c.real() < 0) {
       resultSign = Rational::Builder(-1);
@@ -96,7 +96,7 @@ Expression SignFunction::shallowReduce(ExpressionNode::ReductionContext reductio
     }
   }
   replaceWithInPlace(resultSign);
-  return resultSign;
+  return std::move(resultSign);
 }
 
 }

--- a/poincare/src/store.cpp
+++ b/poincare/src/store.cpp
@@ -1,17 +1,16 @@
 #include <poincare/store.h>
 #include <poincare/code_point_layout.h>
-#include <poincare/context.h>
 #include <poincare/complex.h>
+#include <poincare/context.h>
 #include <poincare/horizontal_layout.h>
 #include <poincare/serialization_helper.h>
 #include <poincare/symbol.h>
 #include <poincare/undefined.h>
 #include <ion.h>
-extern "C" {
 #include <assert.h>
-#include <stdlib.h>
 #include <math.h>
-}
+#include <stdlib.h>
+#include <utility>
 
 namespace Poincare {
 
@@ -31,7 +30,7 @@ Layout StoreNode::createLayout(Preferences::PrintFloatMode floatDisplayMode, int
   result.addOrMergeChildAtIndex(childAtIndex(0)->createLayout(floatDisplayMode, numberOfSignificantDigits), 0, false);
   result.addChildAtIndex(CodePointLayout::Builder(UCodePointRightwardsArrow), result.numberOfChildren(), result.numberOfChildren(), nullptr);
   result.addOrMergeChildAtIndex(childAtIndex(1)->createLayout(floatDisplayMode, numberOfSignificantDigits), result.numberOfChildren(), false);
-  return result;
+  return std::move(result);
 }
 
 template<typename T>


### PR DESCRIPTION
When returning a subclass of an Expression as an Expression, make sure
to use std::move, otherwise the compiler cannot proceeed to copy
ellision.