### PR TITLE
Give access to MathToolbox's model in third-party apps

### DIFF
--- a/apps/math_toolbox.h
+++ b/apps/math_toolbox.h
@@ -8,11 +8,11 @@ class MathToolbox : public Toolbox {
 public:
   MathToolbox();
 protected:
-  bool selectLeaf(int selectedRow) override;
-  const ToolboxMessageTree * rootModel() const override;
-  MessageTableCellWithMessage * leafCellAtIndex(int index) override;
-  MessageTableCellWithChevron* nodeCellAtIndex(int index) override;
-  int maxNumberOfDisplayedRows() override;
+  virtual bool selectLeaf(int selectedRow) override;
+  virtual const ToolboxMessageTree * rootModel() const override;
+  virtual MessageTableCellWithMessage * leafCellAtIndex(int index) override;
+  virtual MessageTableCellWithChevron * nodeCellAtIndex(int index) override;
+  virtual int maxNumberOfDisplayedRows() override;
   constexpr static int k_maxNumberOfDisplayedRows = 6; // = 240/40
 private:
   MessageTableCellWithMessage m_leafCells[k_maxNumberOfDisplayedRows];


### PR DESCRIPTION
As part of my third-party RPN app (https://github.com/boricj/numworks-rpn), I provide a math toolbox to use in order to access advanced features. `MathToolbox` has the right tree model for me, but I need custom handling to fit the RPN input mechanism.

I see three easy options here:
- Change visibility of `Toolbox`'s `rootModel()` method (what I currently do: https://github.com/boricj/numworks-rpn/commit/d8ee77f28aa02a9c2e745ea063c97cbc5d1bb880)
- Put the tree model somewhere where I can access it from my third-party app's source code
- Carry a copy of the tree model in my app (I'd rather not)

This can also be an opportunity to revisit the Sequence app's own toolbox, which is based off `MathToolbox` and has a fairly convoluted implementation of its overrides.

This particular pull request is not meant to be taken as-is, but rather to discuss and decide what to do here.