### PR TITLE
[apps] [code] Fix nullptr deref (fix #1176)

### DIFF
--- a/apps/code/console_controller.cpp
+++ b/apps/code/console_controller.cpp
@@ -267,7 +267,9 @@ void ConsoleController::tableViewDidChangeSelection(SelectableTableView * t, int
       }
     }
     ConsoleLineCell * selectedCell = (ConsoleLineCell *)(t->selectedCell());
-    selectedCell->reloadCell();
+    if (selectedCell) {
+      selectedCell->reloadCell();
+    }
   }
 }
 


### PR DESCRIPTION
When scrolling up in the python shell history, `selectedCell` could be NULL.

Tested on the simulator.