### PR TITLE
Improve Android builds

### DIFF
--- a/build/toolchain.android.mak
+++ b/build/toolchain.android.mak
@@ -9,19 +9,25 @@ endif
 
 NDK_TOOLCHAIN_PATH = $(NDK_PATH)/toolchains/llvm/prebuilt/$(NDK_HOST_TAG)/bin
 
+# No 64 bit device has ever shipped with an API level < 21. Consequently, there
+# is no toolchain for those archs on those API levels. Let's enforce NDK_VERSION
+# at 21 for these archs, and 16 for the others.
+
 ifeq ($(NDK_ABI),armeabi-v7a)
   NDK_TARGET = armv7a-linux-androideabi
+  NDK_VERSION = 16
 else ifeq ($(NDK_ABI),arm64-v8a)
   NDK_TARGET = aarch64-linux-android
+  NDK_VERSION = 21
 else ifeq ($(NDK_ABI),x86)
   NDK_TARGET = i686-linux-android
+  NDK_VERSION = 16
 else ifeq ($(NDK_ABI),x86_64)
   NDK_TARGET = x86_64-linux-android
+  NDK_VERSION = 21
 endif
 
 ifdef NDK_TARGET
-
-NDK_VERSION ?= 21
 
 CC = $(NDK_TOOLCHAIN_PATH)/$(NDK_TARGET)$(NDK_VERSION)-clang
 CXX = $(NDK_TOOLCHAIN_PATH)/$(NDK_TARGET)$(NDK_VERSION)-clang++

--- a/ion/src/simulator/android/build.gradle
+++ b/ion/src/simulator/android/build.gradle
@@ -22,11 +22,11 @@ allprojects {
 apply plugin: 'com.android.application'
 
 android {
-  compileSdkVersion 28
+  compileSdkVersion 29
   defaultConfig {
     applicationId "com.numworks.calculator"
     minSdkVersion 16
-    targetSdkVersion 26
+    targetSdkVersion 28
     def (major, minor, patch) = System.getenv('EPSILON_VERSION').toLowerCase().tokenize('.').collect{it.toInteger()}
     versionCode major*1000000 + minor*10000 + patch * 100
     versionName System.getenv('EPSILON_VERSION')


### PR DESCRIPTION
* Match NDK version to what's specified in the APK (`minSdkVersion`)
* Bump compileSdkVersion and targetSdkVersion