### PR TITLE
[poincare] Power: always reduce (a^b)^(-1)

### DIFF
--- a/poincare/test/simplification.cpp
+++ b/poincare/test/simplification.cpp
@@ -107,6 +107,7 @@ QUIZ_CASE(poincare_simplification_infinity) {
 }
 
 QUIZ_CASE(poincare_simplification_addition) {
+  assert_parsed_expression_simplify_to("1/x^2+3", "\u00123×x^2+1\u0013/x^2", User, Radian, Real);
   assert_parsed_expression_simplify_to("1+x", "x+1");
   assert_parsed_expression_simplify_to("1/2+1/3+1/4+1/5+1/6+1/7", "223/140");
   assert_parsed_expression_simplify_to("1+x+4-i-2x", "-i-x+5");


### PR DESCRIPTION
(a^b)^c -> a^(b*c)
This rule is not generally true: ((-2)^2)^(1/2) != (-2)^(2*1/2) = -2
This rule is true if:
- a > 0
- c is an integer

Warning 1: in real mode only c integer is not enough:
ex: ((-2)^(1/2))^2 = unreal != -2
We escape that case by returning 'unreal' if the a^b is complex.

Warning 2: If we did not apply this rule on expressions of the form
(a^b)^(-1), we would end up in infinite loop when factorizing an addition
on the same denominator.
For ex:
1+[tan(2)^1/2]^(-1) --> (tan(2)^1/2+tan(2)^1/2*[tan(2)^1/2]^(-1))/tan(2)^1/2
                    --> tan(2)+tan(2)*[tan(2)^1/2]^(-1)/tan(2)
                    --> tan(2)^(3/2)+tan(2)^(3/2)*[tan(2)^1/2]^(-1)/tan(2)^3/2
                    --> ...
Indeed, we have to apply the rule (a^b)^c -> a^(b*c) as soon as c is -1.