### PR TITLE
[poincare] Fix multiplication symbol before Symbol Expression

### DIFF
--- a/poincare/include/poincare/symbol.h
+++ b/poincare/include/poincare/symbol.h
@@ -34,7 +34,7 @@ public:
   /* Simplification */
   Expression shallowReduce(ReductionContext reductionContext) override;
   Expression shallowReplaceReplaceableSymbols(Context * context) override;
-  LayoutShape leftLayoutShape() const override { return strlen(m_name) > 1 ? LayoutShape::MoreLetters : LayoutShape::OneLetter; };
+  LayoutShape leftLayoutShape() const override;
 
   /* Approximation */
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }

--- a/poincare/src/symbol.cpp
+++ b/poincare/src/symbol.cpp
@@ -107,6 +107,15 @@ Expression SymbolNode::shallowReplaceReplaceableSymbols(Context * context) {
   return Symbol(this).shallowReplaceReplaceableSymbols(context);
 }
 
+ExpressionNode::LayoutShape SymbolNode::leftLayoutShape() const {
+  UTF8Decoder decoder(m_name);
+  decoder.nextCodePoint();
+  if (decoder.nextCodePoint() == UCodePointNull) {  // nextCodePoint asserts that the first character is non-null
+    return LayoutShape::OneLetter;
+  }
+  return LayoutShape::MoreLetters;
+}
+
 template<typename T>
 Evaluation<T> SymbolNode::templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const {
   Symbol s(this);


### PR DESCRIPTION
This makes consistent 2x and 2θ (sign omission in both cases).