### PR TITLE
[build] Fix target %.dfu for N0110: avoid downloading flasher on addresses that are being executed 

### DIFF
--- a/build/targets.device.n0110.mak
+++ b/build/targets.device.n0110.mak
@@ -12,7 +12,10 @@ $(BUILD_DIR)/test.external_flash.write.$(EXE): $(BUILD_DIR)/quiz/src/test_ion_ex
 	@echo "        using an USB cable and press at the same time the 6 key and the RESET"
 	@echo "        button on the back of your device."
 	$(Q) until $(PYTHON) build/device/dfu.py -l | grep -E "0483:a291|0483:df11" > /dev/null 2>&1; do sleep 2;done
-	$(Q) $(PYTHON) build/device/dfu.py -u $(word 2,$^)
-	$(Q) sleep 2
+	$(eval DFU_SLAVE := $(shell $(PYTHON) build/device/dfu.py -l | grep -E "0483:a291|0483:df11"))
+	$(Q) if [[ "$(DFU_SLAVE)" == *"0483:df11"* ]]; \
+	  then \
+	    $(PYTHON) build/device/dfu.py -u $(word 2,$^); \
+	    sleep 2; \
+	fi
 	$(Q) $(PYTHON) build/device/dfu.py -u $(word 1,$^)
-


### PR DESCRIPTION
In NumWorks DFU mode, execution jumps at the end of the stack, which is where we upload the flasher. The flasher is not required when NumWorks DFU mode is working.