### PR TITLE
[ion/storage] Fix memoization dirtying when renaming a record

### DIFF
--- a/ion/src/shared/storage.cpp
+++ b/ion/src/shared/storage.cpp
@@ -345,11 +345,14 @@ Storage::Record::ErrorStatus Storage::setBaseNameWithExtensionOfRecord(Record re
       return notifyFullnessToDelegate();
     }
     overrideSizeAtPosition(p, newRecordSize);
-    overrideBaseNameWithExtensionAtPosition(p+sizeof(record_size_t), baseName, extension);
+    char * fullNamePosition = p + sizeof(record_size_t);
+    overrideBaseNameWithExtensionAtPosition(fullNamePosition, baseName, extension);
+    // Recompute the CRC32
+    record = Record(fullNamePosition);
     notifyChangeToDelegate(record);
     m_lastRecordRetrieved = record;
     m_lastRecordRetrievedPointer = p;
-   return Record::ErrorStatus::None;
+    return Record::ErrorStatus::None;
   }
   return Record::ErrorStatus::RecordDoesNotExist;
 }


### PR DESCRIPTION
Don't forget to update the CRC32 of the record
Scenario : New funciton f(x) = 1, change it to parametric, rename it
a(t), creae a new function -> instead of being empty, it is has a
"ghost" value of [t 1].

Fixes #1213 