### PR TITLE
[apps/sequence] Set the Nstart/Nend messages at construction

### DIFF
--- a/apps/sequence/values/values_controller.cpp
+++ b/apps/sequence/values/values_controller.cpp
@@ -24,6 +24,8 @@ ValuesController::ValuesController(Responder * parentResponder, InputEventHandle
     StackViewController * stack = ((StackViewController *)valuesController->stackController());
     IntervalParameterController * controller = valuesController->intervalParameterController();
     controller->setInterval(valuesController->intervalAtColumn(valuesController->selectedColumn()));
+    /* No need to change Nstart/Nend messages because they are the only messages
+     * used and we set them in ValuesController::ValuesController(...) */
     stack->push(controller);
     return true;
   }, this), k_font)
@@ -32,6 +34,7 @@ ValuesController::ValuesController(Responder * parentResponder, InputEventHandle
     m_sequenceTitleCells[i].setOrientation(Shared::FunctionTitleCell::Orientation::HorizontalIndicator);
   }
   setupSelectableTableViewAndCells(inputEventHandlerDelegate);
+  setDefaultStartEndMessages();
 }
 
 // TableViewDataSource
@@ -64,7 +67,7 @@ I18n::Message ValuesController::emptyMessage() {
 }
 
 // ValuesController
-void ValuesController::setStartEndMessages(Shared::IntervalParameterController * controller, int column) {
+void ValuesController::setDefaultStartEndMessages() {
   m_intervalParameterController.setStartEndMessages(I18n::Message::NStart, I18n::Message::NEnd);
 }
 

--- a/apps/sequence/values/values_controller.h
+++ b/apps/sequence/values/values_controller.h
@@ -33,7 +33,11 @@ private:
   constexpr static int k_maxNumberOfDisplayableCells = k_maxNumberOfDisplayableSequences * k_maxNumberOfDisplayableRows;
 
   // ValuesController
-  void setStartEndMessages(Shared::IntervalParameterController * controller, int column) override;
+  void setStartEndMessages(Shared::IntervalParameterController * controller, int column) override {
+    setDefaultStartEndMessages();
+  }
+
+  void setDefaultStartEndMessages();
   I18n::Message valuesParameterMessageAtColumn(int columnIndex) const override;
   int maxNumberOfCells() override { return k_maxNumberOfDisplayableCells; }
   int maxNumberOfFunctions() override { return k_maxNumberOfDisplayableSequences; }


### PR DESCRIPTION
This fixes the scenario:
Add a sequence, go to the Table then click on setTheInterval -> it
displayed Xstart Xend instead of Nstart Nend

Fixes #1214 