### PR TITLE
Remove statically allocated buffers

### DIFF
--- a/apps/battery_view.cpp
+++ b/apps/battery_view.cpp
@@ -54,9 +54,6 @@ bool BatteryView::setIsPlugged(bool isPlugged) {
   return false;
 }
 
-KDColor s_flashWorkingBuffer[BatteryView::k_flashHeight*BatteryView::k_flashWidth];
-KDColor s_tickWorkingBuffer[BatteryView::k_tickHeight*BatteryView::k_tickWidth];
-
 void BatteryView::drawRect(KDContext * ctx, KDRect rect) const {
   assert(m_chargeState != Ion::Battery::Charge::EMPTY);
   /* We draw from left to right. The middle part representing the battery
@@ -72,7 +69,8 @@ void BatteryView::drawRect(KDContext * ctx, KDRect rect) const {
     // Charging: Yellow background with flash
     ctx->fillRect(KDRect(batteryInsideX, 0, batteryInsideWidth, k_batteryHeight), Palette::YellowLight);
     KDRect frame((k_batteryWidth-k_flashWidth)/2, 0, k_flashWidth, k_flashHeight);
-    ctx->blendRectWithMask(frame, KDColorWhite, (const uint8_t *)flashMask, s_flashWorkingBuffer);
+    KDColor flashWorkingBuffer[BatteryView::k_flashHeight*BatteryView::k_flashWidth];
+    ctx->blendRectWithMask(frame, KDColorWhite, (const uint8_t *)flashMask, flashWorkingBuffer);
   } else if (m_chargeState == Ion::Battery::Charge::LOW) {
     assert(!m_isPlugged);
     // Low: Quite empty battery
@@ -91,7 +89,8 @@ void BatteryView::drawRect(KDContext * ctx, KDRect rect) const {
     if (m_isPlugged) {
       // Plugged and full: Full battery with tick
       KDRect frame((k_batteryWidth-k_tickWidth)/2, (k_batteryHeight-k_tickHeight)/2, k_tickWidth, k_tickHeight);
-      ctx->blendRectWithMask(frame, Palette::YellowDark, (const uint8_t *)tickMask, s_tickWorkingBuffer);
+      KDColor tickWorkingBuffer[BatteryView::k_tickHeight*BatteryView::k_tickWidth];
+      ctx->blendRectWithMask(frame, Palette::YellowDark, (const uint8_t *)tickMask, tickWorkingBuffer);
     }
   }
 

--- a/apps/hardware_test/arrow_view.cpp
+++ b/apps/hardware_test/arrow_view.cpp
@@ -48,16 +48,15 @@ void ArrowView::setColor(KDColor color) {
   }
 }
 
-KDColor s_arrowWorkingBuffer[10*9];
-
 void ArrowView::drawRect(KDContext * ctx, KDRect rect) const {
+  KDColor arrowWorkingBuffer[10*9];
   ctx->fillRect(bounds(), KDColorWhite);
   KDCoordinate startLine = m_directionIsUp ? k_arrowHeight : 0;
   KDCoordinate startArrow = m_directionIsUp ? 0 : bounds().height()-k_arrowHeight;
   ctx->fillRect(KDRect((Ion::Display::Width-k_arrowThickness)/2, startLine, k_arrowThickness, bounds().height()-k_arrowHeight), m_color);
   KDRect frame((Ion::Display::Width-k_arrowWidth)/2, startArrow, k_arrowWidth, k_arrowHeight);
   const uint8_t * mask = m_directionIsUp ? (const uint8_t *)arrowUpMask : (const uint8_t *)arrowDownMask;
-  ctx->blendRectWithMask(frame, m_color, mask, s_arrowWorkingBuffer);
+  ctx->blendRectWithMask(frame, m_color, mask, arrowWorkingBuffer);
 }
 
 }

--- a/apps/lock_view.cpp
+++ b/apps/lock_view.cpp
@@ -12,11 +12,10 @@ const uint8_t lockMask[LockView::k_lockHeight][LockView::k_lockWidth] = {
   {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
 };
 
-KDColor s_lockWorkingBuffer[LockView::k_lockHeight*LockView::k_lockWidth];
-
 void LockView::drawRect(KDContext * ctx, KDRect rect) const {
   KDRect frame((bounds().width() - k_lockWidth)/2,  (bounds().height()-k_lockHeight)/2, k_lockWidth, k_lockHeight);
-  ctx->blendRectWithMask(frame, KDColorWhite, (const uint8_t *)lockMask, s_lockWorkingBuffer);
+  KDColor lockWorkingBuffer[LockView::k_lockHeight*LockView::k_lockWidth];
+  ctx->blendRectWithMask(frame, KDColorWhite, (const uint8_t *)lockMask, lockWorkingBuffer);
 }
 
 KDSize LockView::minimalSizeForOptimalDisplay() const {

--- a/apps/shared/ok_view.cpp
+++ b/apps/shared/ok_view.cpp
@@ -25,13 +25,12 @@ const uint8_t okMask[OkView::k_okSize][OkView::k_okSize] = {
   {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xE1, 0x0C, 0x0C, 0x0C, 0x0C, 0x0C, 0x0C, 0x0C, 0x0C, 0xE1, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF},
 };
 
-KDColor s_okWorkingBuffer[OkView::k_okSize*OkView::k_okSize];
-
 void OkView::drawRect(KDContext * ctx, KDRect rect) const {
   KDCoordinate width = bounds().width();
   KDCoordinate height =  bounds().height();
   KDRect frame((width-k_okSize)/2, (height-k_okSize)/2, k_okSize, k_okSize);
-  ctx->blendRectWithMask(frame, KDColorBlack, (const uint8_t *)okMask, s_okWorkingBuffer);
+  KDColor okWorkingBuffer[OkView::k_okSize*OkView::k_okSize];
+  ctx->blendRectWithMask(frame, KDColorBlack, (const uint8_t *)okMask, okWorkingBuffer);
 }
 
 KDSize OkView::minimalSizeForOptimalDisplay() const {

--- a/apps/shared/round_cursor_view.cpp
+++ b/apps/shared/round_cursor_view.cpp
@@ -16,13 +16,12 @@ static const uint8_t cursorMask[cursorSize][cursorSize] = {
   {0xFF, 0xFF, 0xFF, 0xED, 0xB6, 0xB6, 0xED, 0xFF, 0xFF, 0xFF},
 };
 
-static KDColor s_cursorWorkingBuffer[cursorSize*cursorSize];
-
 void RoundCursorView::drawRect(KDContext * ctx, KDRect rect) const {
   KDRect r = bounds();
+  KDColor cursorWorkingBuffer[cursorSize*cursorSize];
   ctx->getPixels(r, m_underneathPixelBuffer);
   m_underneathPixelBufferLoaded = true;
-  ctx->blendRectWithMask(r, m_color, (const uint8_t *)cursorMask, s_cursorWorkingBuffer);
+  ctx->blendRectWithMask(r, m_color, (const uint8_t *)cursorMask, cursorWorkingBuffer);
 }
 
 KDSize RoundCursorView::minimalSizeForOptimalDisplay() const {
@@ -64,10 +63,11 @@ bool RoundCursorView::eraseCursorIfPossible() {
     return false;
   }
   // Erase the cursor
+  KDColor cursorWorkingBuffer[cursorSize*cursorSize];
   KDContext * ctx = KDIonContext::sharedContext();
   ctx->setOrigin(currentFrame.origin());
   ctx->setClippingRect(currentFrame);
-  ctx->fillRectWithPixels(KDRect(0,0,k_cursorSize, k_cursorSize), m_underneathPixelBuffer, s_cursorWorkingBuffer);
+  ctx->fillRectWithPixels(KDRect(0,0,k_cursorSize, k_cursorSize), m_underneathPixelBuffer, cursorWorkingBuffer);
   // TODO Restore the context to previous values?
   return true;
 }

--- a/apps/solver/equation_list_view.cpp
+++ b/apps/solver/equation_list_view.cpp
@@ -105,15 +105,14 @@ const uint8_t bottomBrace[braceExtremumHeight][braceExtremumWidth] = {
   {0xFF, 0xFF, 0xF7, 0x25, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00},
 };
 
-KDColor s_braceWorkingBuffer[60];
-
 void EquationListView::BraceView::drawRect(KDContext * ctx, KDRect rect) const {
   ctx->fillRect(bounds(), KDColorWhite);
   KDCoordinate height = bounds().height();
   KDCoordinate margin = 3;
-  ctx->blendRectWithMask(KDRect(margin, 0, braceExtremumWidth, braceExtremumHeight), KDColorBlack, (const uint8_t *)topBrace, (KDColor *)(s_braceWorkingBuffer));
-  ctx->blendRectWithMask(KDRect(0, height/2-braceCenterHeight/2, braceCenterWidth, braceCenterHeight), KDColorBlack, (const uint8_t *)middleBrace, (KDColor *)(s_braceWorkingBuffer));
-  ctx->blendRectWithMask(KDRect(margin, height-braceExtremumHeight, braceExtremumWidth, braceExtremumHeight), KDColorBlack, (const uint8_t *)bottomBrace, (KDColor *)(s_braceWorkingBuffer));
+  KDColor braceWorkingBuffer[60];
+  ctx->blendRectWithMask(KDRect(margin, 0, braceExtremumWidth, braceExtremumHeight), KDColorBlack, (const uint8_t *)topBrace, (KDColor *)(braceWorkingBuffer));
+  ctx->blendRectWithMask(KDRect(0, height/2-braceCenterHeight/2, braceCenterWidth, braceCenterHeight), KDColorBlack, (const uint8_t *)middleBrace, (KDColor *)(braceWorkingBuffer));
+  ctx->blendRectWithMask(KDRect(margin, height-braceExtremumHeight, braceExtremumWidth, braceExtremumHeight), KDColorBlack, (const uint8_t *)bottomBrace, (KDColor *)(braceWorkingBuffer));
   ctx->fillRect(KDRect(margin, braceExtremumHeight, 1, height/2-braceCenterHeight/2-braceExtremumHeight), KDColorBlack);
   ctx->fillRect(KDRect(margin, height/2+braceCenterHeight/2, 1, height/2-braceExtremumHeight/2-braceExtremumHeight), KDColorBlack);
 }

--- a/escher/src/chevron_view.cpp
+++ b/escher/src/chevron_view.cpp
@@ -14,8 +14,6 @@ const uint8_t chevronMask[ChevronView::k_chevronHeight][ChevronView::k_chevronWi
   {0x0C, 0xE1, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF},
 };
 
-KDColor s_workingBuffer[ChevronView::k_chevronWidth*ChevronView::k_chevronHeight];
-
 void ChevronView::drawRect(KDContext * ctx, KDRect rect) const {
   /* Draw the chevron aligned on the right of the view and vertically centered.
    * The heightCenter is the coordinate of the vertical middle of the view. That
@@ -24,7 +22,8 @@ void ChevronView::drawRect(KDContext * ctx, KDRect rect) const {
   KDCoordinate heightCenter = bounds().height()/2;
   KDCoordinate chevronHalfHeight = k_chevronHeight/2;
   KDRect frame(width - k_chevronWidth, heightCenter -chevronHalfHeight, k_chevronWidth, k_chevronHeight);
-  ctx->blendRectWithMask(frame, Palette::YellowDark, (const uint8_t *)chevronMask, s_workingBuffer);
+  KDColor workingBuffer[ChevronView::k_chevronWidth*ChevronView::k_chevronHeight];
+  ctx->blendRectWithMask(frame, Palette::YellowDark, (const uint8_t *)chevronMask, workingBuffer);
 }
 
 KDSize ChevronView::minimalSizeForOptimalDisplay() const {

--- a/escher/src/ellipsis_view.cpp
+++ b/escher/src/ellipsis_view.cpp
@@ -7,8 +7,6 @@ const uint8_t ellipsisMask[EllipsisView::k_ellipsisHeight][EllipsisView::k_ellip
   {0xFF, 0xD1, 0xA1, 0xC1, 0xFF, 0xFF, 0xFF, 0xD1, 0xA1, 0xC1, 0xFF, 0xFF, 0xFF, 0xD1, 0xA1, 0xC1, 0xFF},
 };
 
-KDColor s_ellipsisWorkingBuffer[EllipsisView::k_ellipsisWidth*EllipsisView::k_ellipsisHeight];
-
 void EllipsisView::drawRect(KDContext * ctx, KDRect rect) const {
   /* Draw the ellipsis vertically and horizontally centered in the view.
    * The heightCenter is the coordinate of the vertical middle of the view. That
@@ -18,7 +16,8 @@ void EllipsisView::drawRect(KDContext * ctx, KDRect rect) const {
   KDCoordinate heightCenter =  bounds().height()/2;
   KDCoordinate ellipsisHalfHeight = k_ellipsisHeight/2;
   KDRect frame(widthCenter - ellipsisHalfWidth, heightCenter - ellipsisHalfHeight, k_ellipsisWidth, k_ellipsisHeight);
-  ctx->blendRectWithMask(frame, KDColorBlack, (const uint8_t *)ellipsisMask, s_ellipsisWorkingBuffer);
+  KDColor ellipsisWorkingBuffer[EllipsisView::k_ellipsisWidth*EllipsisView::k_ellipsisHeight];
+  ctx->blendRectWithMask(frame, KDColorBlack, (const uint8_t *)ellipsisMask, ellipsisWorkingBuffer);
 }
 
 KDSize EllipsisView::minimalSizeForOptimalDisplay() const {

--- a/escher/src/gauge_view.cpp
+++ b/escher/src/gauge_view.cpp
@@ -40,18 +40,17 @@ void GaugeView::setBackgroundColor(KDColor color) {
   }
 }
 
-KDColor s_gaugeIndicatorWorkingBuffer[GaugeView::k_indicatorDiameter*GaugeView::k_indicatorDiameter];
-
 void GaugeView::drawRect(KDContext * ctx, KDRect rect) const {
   ctx->fillRect(bounds(), m_backgroundColor);
   /* Draw the gauge centered vertically on all the width available */
   KDCoordinate width = bounds().width()-k_indicatorDiameter;
   KDCoordinate height =  bounds().height();
+  KDColor gaugeIndicatorWorkingBuffer[GaugeView::k_indicatorDiameter*GaugeView::k_indicatorDiameter];
 
   ctx->fillRect(KDRect(k_indicatorDiameter/2, (height-k_thickness)/2, width*m_level, k_thickness), Palette::YellowDark);
   ctx->fillRect(KDRect(k_indicatorDiameter/2+width*m_level, (height-k_thickness)/2, width*(1.0f-m_level), k_thickness), Palette::GreyDark);
   KDRect frame(width*m_level, (height-k_indicatorDiameter)/2, k_indicatorDiameter, k_indicatorDiameter);
-  ctx->blendRectWithMask(frame, Palette::YellowDark, (const uint8_t *)gaugeIndicatorMask, s_gaugeIndicatorWorkingBuffer);
+  ctx->blendRectWithMask(frame, Palette::YellowDark, (const uint8_t *)gaugeIndicatorMask, gaugeIndicatorWorkingBuffer);
 }
 
 KDSize GaugeView::minimalSizeForOptimalDisplay() const {

--- a/escher/src/key_view.cpp
+++ b/escher/src/key_view.cpp
@@ -76,14 +76,13 @@ void KeyView::setType(Type type) {
   markRectAsDirty(bounds());
 }
 
-KDColor s_keyWorkingBuffer[KeyView::k_keySize*KeyView::k_keySize];
-
 void KeyView::drawRect(KDContext * ctx, KDRect rect) const {
   /* Draw the key centered on the view. */
   KDCoordinate width = bounds().width();
   KDCoordinate height =  bounds().height();
   KDRect frame((width - k_keySize)/2, (height - k_keySize)/2, k_keySize, k_keySize);
-  ctx->blendRectWithMask(frame, KDColorBlack, mask(), s_keyWorkingBuffer);
+  KDColor keyWorkingBuffer[KeyView::k_keySize*KeyView::k_keySize];
+  ctx->blendRectWithMask(frame, KDColorBlack, mask(), keyWorkingBuffer);
 }
 
 KDSize KeyView::minimalSizeForOptimalDisplay() const {

--- a/escher/src/switch_view.cpp
+++ b/escher/src/switch_view.cpp
@@ -46,8 +46,6 @@ void SwitchView::setState(bool state) {
   markRectAsDirty(bounds());
 }
 
-KDColor s_switchWorkingBuffer[SwitchView::k_switchWidth*SwitchView::k_switchHeight];
-
 void SwitchView::drawRect(KDContext * ctx, KDRect rect) const {
   /* Draw the switch aligned on the right of the view and vertically centered.
    * The heightCenter is the coordinate of the vertical middle of the view. That
@@ -55,13 +53,14 @@ void SwitchView::drawRect(KDContext * ctx, KDRect rect) const {
   KDCoordinate width = bounds().width();
   KDCoordinate heightCenter =  bounds().height()/2;
   KDCoordinate switchHalfHeight = k_switchHeight/2;
+  KDColor switchWorkingBuffer[SwitchView::k_switchWidth*SwitchView::k_switchHeight];
 
   KDColor mainColor = m_state ? Palette::YellowDark : Palette::GreyDark;
   KDRect frame(width - k_switchWidth, heightCenter -switchHalfHeight, k_switchWidth, k_switchHeight);
-  ctx->blendRectWithMask(frame, mainColor, (const uint8_t *)switchMask, s_switchWorkingBuffer);
+  ctx->blendRectWithMask(frame, mainColor, (const uint8_t *)switchMask, switchWorkingBuffer);
   KDCoordinate onOffX = width - (m_state ? k_onOffSize : k_switchWidth);
   KDRect onOffFrame(onOffX, heightCenter -switchHalfHeight, k_onOffSize, k_onOffSize);
-  ctx->blendRectWithMask(onOffFrame, KDColorWhite, (const uint8_t *)onOffMask, s_switchWorkingBuffer);
+  ctx->blendRectWithMask(onOffFrame, KDColorWhite, (const uint8_t *)onOffMask, switchWorkingBuffer);
 }
 
 KDSize SwitchView::minimalSizeForOptimalDisplay() const {

--- a/poincare/include/poincare/parenthesis_layout.h
+++ b/poincare/include/poincare/parenthesis_layout.h
@@ -27,7 +27,6 @@ public:
 #endif
 
 protected:
-  static KDColor s_parenthesisWorkingBuffer[k_parenthesisCurveHeight*k_parenthesisCurveWidth];
   KDSize computeSize() override {
     return KDSize(ParenthesisWidth(), HeightGivenChildHeight(childHeight()));
   }

--- a/poincare/src/left_parenthesis_layout.cpp
+++ b/poincare/src/left_parenthesis_layout.cpp
@@ -25,20 +25,21 @@ const uint8_t bottomLeftCurve[ParenthesisLayoutNode::k_parenthesisCurveHeight][P
 };
 
 void LeftParenthesisLayoutNode::RenderWithChildHeight(KDCoordinate childHeight, KDContext * ctx, KDPoint p, KDColor expressionColor, KDColor backgroundColor) {
+  KDColor parenthesisWorkingBuffer[k_parenthesisCurveHeight*k_parenthesisCurveWidth];
   KDCoordinate parenthesisHeight = ParenthesisLayoutNode::HeightGivenChildHeight(childHeight);
   KDRect frame(p.x()+ParenthesisLayoutNode::k_externWidthMargin,
       p.y()+ParenthesisLayoutNode::k_externHeightMargin,
       ParenthesisLayoutNode::k_parenthesisCurveWidth,
       ParenthesisLayoutNode::k_parenthesisCurveHeight);
 
-  ctx->blendRectWithMask(frame, expressionColor, (const uint8_t *)topLeftCurve, (KDColor *)(ParenthesisLayoutNode::s_parenthesisWorkingBuffer));
+  ctx->blendRectWithMask(frame, expressionColor, (const uint8_t *)topLeftCurve, parenthesisWorkingBuffer);
 
   frame = KDRect(p.x()+ParenthesisLayoutNode::k_externWidthMargin,
       p.y() + parenthesisHeight - ParenthesisLayoutNode::k_parenthesisCurveHeight - ParenthesisLayoutNode::k_externHeightMargin,
       ParenthesisLayoutNode::k_parenthesisCurveWidth,
       ParenthesisLayoutNode::k_parenthesisCurveHeight);
 
-  ctx->blendRectWithMask(frame, expressionColor, (const uint8_t *)bottomLeftCurve, (KDColor *)(ParenthesisLayoutNode::s_parenthesisWorkingBuffer));
+  ctx->blendRectWithMask(frame, expressionColor, (const uint8_t *)bottomLeftCurve, parenthesisWorkingBuffer);
 
   ctx->fillRect(KDRect(p.x()+ParenthesisLayoutNode::k_externWidthMargin,
         p.y()+ParenthesisLayoutNode::k_parenthesisCurveHeight+ParenthesisLayoutNode::k_externHeightMargin,

--- a/poincare/src/parenthesis_layout.cpp
+++ b/poincare/src/parenthesis_layout.cpp
@@ -2,6 +2,4 @@
 
 namespace Poincare {
 
-KDColor ParenthesisLayoutNode::s_parenthesisWorkingBuffer[];
-
 }

--- a/poincare/src/right_parenthesis_layout.cpp
+++ b/poincare/src/right_parenthesis_layout.cpp
@@ -25,20 +25,21 @@ const uint8_t bottomRightCurve[ParenthesisLayoutNode::k_parenthesisCurveHeight][
 };
 
 void RightParenthesisLayoutNode::RenderWithChildHeight(KDCoordinate childHeight, KDContext * ctx, KDPoint p, KDColor expressionColor, KDColor backgroundColor) {
+  KDColor parenthesisWorkingBuffer[k_parenthesisCurveHeight*k_parenthesisCurveWidth];
   KDCoordinate parenthesisHeight = ParenthesisLayoutNode::HeightGivenChildHeight(childHeight);
   KDRect frame = KDRect(p.x() + ParenthesisLayoutNode::k_widthMargin + ParenthesisLayoutNode::k_lineThickness - ParenthesisLayoutNode::k_parenthesisCurveWidth,
       p.y() + ParenthesisLayoutNode::k_externHeightMargin,
       ParenthesisLayoutNode::k_parenthesisCurveWidth,
       ParenthesisLayoutNode::k_parenthesisCurveHeight);
 
-  ctx->blendRectWithMask(frame, expressionColor, (const uint8_t *)topRightCurve, (KDColor *)(ParenthesisLayoutNode::s_parenthesisWorkingBuffer));
+  ctx->blendRectWithMask(frame, expressionColor, (const uint8_t *)topRightCurve, parenthesisWorkingBuffer);
 
   frame = KDRect(p.x() + ParenthesisLayoutNode::k_widthMargin + ParenthesisLayoutNode::k_lineThickness - ParenthesisLayoutNode::k_parenthesisCurveWidth,
     p.y() + parenthesisHeight - ParenthesisLayoutNode::k_parenthesisCurveHeight - ParenthesisLayoutNode::k_externHeightMargin,
     ParenthesisLayoutNode::k_parenthesisCurveWidth,
     ParenthesisLayoutNode::k_parenthesisCurveHeight);
 
-  ctx->blendRectWithMask(frame, expressionColor, (const uint8_t *)bottomRightCurve, (KDColor *)(ParenthesisLayoutNode::s_parenthesisWorkingBuffer));
+  ctx->blendRectWithMask(frame, expressionColor, (const uint8_t *)bottomRightCurve, parenthesisWorkingBuffer);
 
   ctx->fillRect(KDRect(p.x()+ParenthesisLayoutNode::k_widthMargin,
         p.y()+ParenthesisLayoutNode::k_parenthesisCurveHeight+2,

--- a/poincare/src/trigonometry_cheat_table.cpp
+++ b/poincare/src/trigonometry_cheat_table.cpp
@@ -82,7 +82,7 @@ Expression TrigonometryCheatTable::simplify(const Expression e, ExpressionNode::
  * For instance, when simplfy a Cosine, we always compute the value for an angle
  * in the top right trigonometric quadrant. */
 const TrigonometryCheatTable * TrigonometryCheatTable::Table() {
-  static Row sTableRows[] = {
+  static const Row sTableRows[] = {
     Row(Row::Pair("-90", -90.0f),
         Row::Pair("π*(-2)^(-1)", -1.5707963267948966f),
         Row::Pair("-100", -100.0f),
@@ -306,7 +306,7 @@ const TrigonometryCheatTable * TrigonometryCheatTable::Table() {
         Row::Pair("0",0.0f),
         Row::Pair("0",0.0f))
   };
-  static TrigonometryCheatTable sTable(sTableRows);
+  static const TrigonometryCheatTable sTable(sTableRows);
   return &sTable;
 }
 


### PR DESCRIPTION
Following #1208, a bunch of static buffers in RAM were found that could be allocated on the stack or in Flash, most of them being rendering buffers. The calculator seems stable after these modifications. The `Poincare::Integer` static buffers have scary comments attached to them, so I left them alone (but I'm not quite convinced of their truthfulness).

Saves 3.5 KiB of RAM.