### PR TITLE
[apps/on_boarding] If POST are OK, the led is white

### DIFF
--- a/apps/on_boarding/power_on_self_test.cpp
+++ b/apps/on_boarding/power_on_self_test.cpp
@@ -6,7 +6,7 @@ namespace OnBoarding {
 
 KDColor PowerOnSelfTest::Perform() {
   KDColor previousLEDColor = Ion::LED::getColor();
-  KDColor resultColor = KDColorGreen;
+  KDColor resultColor = KDColorWhite;
 
   // Screen tests
   bool screenTestsOK = Shared::POSTAndHardwareTests::VBlankOK() && (Shared::POSTAndHardwareTests::TextLCDGlyphFailures() <= k_textErrorsLimit);


### PR DESCRIPTION
Green is used to indicate end-of-charge, so we put the POST led in white
so there is no confusion