### PR TITLE
[apps/apps_container] Fix screen noise before the logo on n0100

### DIFF
--- a/apps/apps_container.cpp
+++ b/apps/apps_container.cpp
@@ -207,7 +207,12 @@ bool AppsContainer::switchTo(App::Snapshot * snapshot) {
 }
 
 void AppsContainer::run() {
-  window()->setFrame(KDRect(0, 0, Ion::Display::Width, Ion::Display::Height));
+  KDRect screenRect = KDRect(0, 0, Ion::Display::Width, Ion::Display::Height);
+  window()->setFrame(screenRect);
+  /* We push a white screen here, because fetching the exam mode takes some time
+   * and it is visible when reflashing a N0100 (there is some noise on the
+   * screen before the logo appears). */
+  Ion::Display::pushRectUniform(screenRect, KDColorWhite);
   if (GlobalPreferences::sharedGlobalPreferences()->examMode()) {
     activateExamMode();
   }


### PR DESCRIPTION
Push a white screen before fetching the examm mode, as this fetch takes
some time and the screen noise becomes visible on a n0100 when
downloading a new software.