### PR TITLE
[ion/cache] Add missing memory barrier

### DIFF
--- a/ion/src/device/n0110/drivers/cache.cpp
+++ b/ion/src/device/n0110/drivers/cache.cpp
@@ -41,6 +41,7 @@ void privateCleanInvalidateDisableDCache(bool clean, bool invalidate, bool disab
         dcisw.setWAY(w);
         CORTEX.DCISW()->set(dcisw);
       }
+      __asm volatile("nop");
     } while (w-- != 0);
   } while (sets-- != 0);
 


### PR DESCRIPTION
__asm volatile("nop") creates a memory barrier that prevents a crash on
the flasher.
Scenario: On the n0110, build flasher.bin, flash it at 0x20030000, build
bench.bin, flash it using the flasher at 0x20008000 -> the flasher cannot
make the device jump to the bench