### PR TITLE
[ion/external_flash] Finer flash sectors

### DIFF
--- a/ion/src/device/n0100/drivers/config/external_flash.h
+++ b/ion/src/device/n0100/drivers/config/external_flash.h
@@ -22,7 +22,10 @@ using namespace Regs;
 
 constexpr static uint32_t StartAddress = 0xFFFFFFFF;
 constexpr static uint32_t EndAddress = 0xFFFFFFFF;
-constexpr static int NumberOfSectors = 0;
+constexpr static int NumberOf4KSectors = 0;
+constexpr static int NumberOf32KSectors = 0;
+constexpr static int NumberOf64KSectors = 0;
+constexpr static int NumberOfSectors = NumberOf4KSectors + NumberOf32KSectors + NumberOf64KSectors;
 constexpr static AFGPIOPin Pins[] = {};
 
 }

--- a/ion/src/device/n0110/drivers/config/external_flash.h
+++ b/ion/src/device/n0110/drivers/config/external_flash.h
@@ -22,7 +22,12 @@ using namespace Regs;
 
 constexpr static uint32_t StartAddress = 0x90000000;
 constexpr static uint32_t EndAddress = 0x90800000;
-constexpr static int NumberOfSectors = 128;
+
+constexpr static int NumberOf4KSectors = 8;
+constexpr static int NumberOf32KSectors = 1;
+constexpr static int NumberOf64KSectors = 128 - 1;
+constexpr static int NumberOfSectors = NumberOf4KSectors + NumberOf32KSectors + NumberOf64KSectors;
+
 constexpr static AFGPIOPin Pins[] = {
   AFGPIOPin(GPIOB, 2,  GPIO::AFR::AlternateFunction::AF9, GPIO::PUPDR::Pull::None, GPIO::OSPEEDR::OutputSpeed::Fast),
   AFGPIOPin(GPIOB, 6,  GPIO::AFR::AlternateFunction::AF10,  GPIO::PUPDR::Pull::None, GPIO::OSPEEDR::OutputSpeed::Fast),

--- a/ion/src/device/n0110/drivers/config/usb.h
+++ b/ion/src/device/n0110/drivers/config/usb.h
@@ -14,7 +14,7 @@ constexpr static AFGPIOPin VbusPin = AFGPIOPin(GPIOA, 9, GPIO::AFR::AlternateFun
 constexpr static AFGPIOPin DmPin = AFGPIOPin(GPIOA, 11, GPIO::AFR::AlternateFunction::AF10, GPIO::PUPDR::Pull::None, GPIO::OSPEEDR::OutputSpeed::Fast);
 constexpr static AFGPIOPin DpPin = AFGPIOPin(GPIOA, 12, GPIO::AFR::AlternateFunction::AF10, GPIO::PUPDR::Pull::None, GPIO::OSPEEDR::OutputSpeed::Fast);
 
-constexpr static const char * InterfaceStringDescriptor = "@Flash/0x08000000/04*016Kg/0x90000000/64*064Kg,64*064Kg";
+constexpr static const char * InterfaceStringDescriptor = "@Flash/0x08000000/04*016Kg/0x90000000/08*004Kg,01*032Kg,63*064Kg,64*064Kg";
 
 }
 }

--- a/ion/src/device/shared/drivers/external_flash.cpp
+++ b/ion/src/device/shared/drivers/external_flash.cpp
@@ -71,6 +71,8 @@ enum class Command : uint8_t {
   Reset = 0x99,
   // Erase the whole chip or a 64-Kbyte block as being "1"
   ChipErase = 0xC7,
+  Erase4KbyteBlock = 0x20,
+  Erase32KbyteBlock = 0x52,
   Erase64KbyteBlock = 0xD8,
   SetReadParameters = 0xC0,
   DeepPowerDown = 0xB9,
@@ -79,6 +81,8 @@ enum class Command : uint8_t {
 };
 
 static constexpr uint8_t NumberOfAddressBitsIn64KbyteBlock = 16;
+static constexpr uint8_t NumberOfAddressBitsIn32KbyteBlock = 15;
+static constexpr uint8_t NumberOfAddressBitsIn4KbyteBlock = 12;
 
 class ExternalFlashStatusRegister {
 public:
@@ -367,10 +371,23 @@ void shutdown() {
 }
 
 int SectorAtAddress(uint32_t address) {
+  /* WARNING: this code assumes that the flash sectors are of increasing size:
+   * first all 4K sectors, then all 32K sectors, and finally all 64K sectors. */
   int i = address >> NumberOfAddressBitsIn64KbyteBlock;
-  if (i >= Config::NumberOfSectors) {
+  if (i > Config::NumberOf64KSectors) {
     return -1;
   }
+  if (i >= 1) {
+    return Config::NumberOf4KSectors + Config::NumberOf32KSectors + i - 1;
+  }
+  i = address >> NumberOfAddressBitsIn32KbyteBlock;
+  if (i >= 1) {
+    i = Config::NumberOf4KSectors + i - 1;
+    assert(i >= 0 && i <= Config::NumberOf32KSectors);
+    return i;
+  }
+  i = address >> NumberOfAddressBitsIn4KbyteBlock;
+  assert(i <= Config::NumberOf4KSectors);
   return i;
 }
 
@@ -408,7 +425,22 @@ void __attribute__((noinline)) EraseSector(int i) {
   unlockFlash();
   send_command(Command::WriteEnable);
   wait();
-  send_write_command(Command::Erase64KbyteBlock, reinterpret_cast<uint8_t *>(i << NumberOfAddressBitsIn64KbyteBlock), nullptr, 0);
+  /* WARNING: this code assumes that the flash sectors are of increasing size:
+   * first all 4K sectors, then all 32K sectors, and finally all 64K sectors. */
+  if (i < Config::NumberOf4KSectors) {
+    send_write_command(Command::Erase4KbyteBlock, reinterpret_cast<uint8_t *>(i << NumberOfAddressBitsIn4KbyteBlock), nullptr, 0);
+  } else if (i < Config::NumberOf4KSectors + Config::NumberOf32KSectors) {
+    /* If the sector is the number Config::NumberOf4KSectors, we want to write
+     * at the address 1 << NumberOfAddressBitsIn32KbyteBlock, hence the formula
+     * (i - Config::NumberOf4KSectors + 1). */
+    send_write_command(Command::Erase32KbyteBlock, reinterpret_cast<uint8_t *>((i - Config::NumberOf4KSectors + 1) << NumberOfAddressBitsIn32KbyteBlock), nullptr, 0);
+  } else {
+    /* If the sector is the number
+     * Config::NumberOf4KSectors - Config::NumberOf32KSectors, we want to write
+     * at the address 1 << NumberOfAddressBitsIn32KbyteBlock, hence the formula
+     * (i - Config::NumberOf4KSectors - Config::NumberOf32KSectors + 1). */
+    send_write_command(Command::Erase64KbyteBlock, reinterpret_cast<uint8_t *>((i - Config::NumberOf4KSectors - Config::NumberOf32KSectors + 1) << NumberOfAddressBitsIn64KbyteBlock), nullptr, 0);
+  }
   wait();
   set_as_memory_mapped();
 }

--- a/ion/src/device/shared/drivers/external_flash.h
+++ b/ion/src/device/shared/drivers/external_flash.h
@@ -15,7 +15,12 @@
  *   2^7                64KiB blocks   0x..0000 - 0x..FFFF
  *   2^7 * 2            32KiB blocks   0x..0000 - 0x..7FFF or 0x..8000 - 0x..FFFF
  *   2^7 * 2 * 2^3       4KiB blocks   0x...000 - 0x...FFF
- *   2^7 * 2 * 2^3 * 2^4 256B pages    0x....00 - 0x....FF */
+ *   2^7 * 2 * 2^3 * 2^4 256B pages    0x....00 - 0x....FF
+ *
+ * To be able to erase a small sector for the exam mode, we say that the flash
+ * is cut into 8 + 1 + 2^7-1 = 136 sectors: 8 sectors of 4Kb, 1 sector of 32Kb
+ * and 2^7-1 sectors of 64Kb. These sectors are the smallest erasable units. If
+ * need be, we can define more sectors to erase even more finely the flash. */
 
 namespace Ion {
 namespace Device {


### PR DESCRIPTION
Instead of 128 sectors of 64K, there are now 8 sectors of 4K, 1 of 32K
and 127 of 64K. This makes a more finely erasable flash, which is needed
for the exam mode.