### PR TITLE
Corrected graph Ymin/Ymax issue

### DIFF
--- a/apps/shared/curve_view.cpp
+++ b/apps/shared/curve_view.cpp
@@ -110,7 +110,7 @@ const float CurveView::pixelWidth() const {
 }
 
 const float CurveView::pixelHeight() const {
-  return (m_curveViewRange->yMax() - m_curveViewRange->yMin()) / (m_frame.height() - 1);
+  return (m_curveViewRange->yMax() - m_curveViewRange->yMin()) / (m_frame.height() - m_bannerView->minimalSizeForOptimalDisplay().height() - 1);
 }
 
 float CurveView::pixelToFloat(Axis axis, KDCoordinate p) const {


### PR DESCRIPTION
When you try to set a window size, it doesn't include the bar size, and so the Ymin/Ymax is wrong.
I changed to include the bar size.

Before (I set 0 107 at Y window size) :
![image](https://user-images.githubusercontent.com/43498612/71511839-05744c00-2894-11ea-85d1-1b25e827e1f1.png)
You can't see the 0 

After (I set 0 107 at Y window size):
![image](https://user-images.githubusercontent.com/43498612/71511881-33599080-2894-11ea-9ce4-7988df90b695.png)
You can see the 0
