### PR TITLE
[build] Added make PLATFORM=simulator run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,3 +141,23 @@ cowsay_%:
 .PHONY: clena
 clena: cowsay_CLENA clean
 
+.PHONY: compile
+compile: output/$(BUILD_TYPE)/simulator/$(HOST)/epsilon.$(EXE)
+
+.PHONY: cleanandcompile
+cleanandcompile:
+	${MAKE} cleanall
+	${MAKE} compile
+
+.PHONY: start
+start:
+	@echo "INFO Starting output/$(BUILD_TYPE)/simulator/$(HOST)/epsilon.$(EXE)"
+	@$(Q) output/$(BUILD_TYPE)/simulator/$(HOST)/epsilon.$(EXE)
+
+.PHONY: clean_run
+clean_run: cleanandcompile
+	${MAKE} start
+
+.PHONY: run
+run: compile
+	${MAKE} start


### PR DESCRIPTION
I added this : https://github.com/numworks/epsilon/issues/1231#issuecomment-562140084

Now there's :
- `make PLATFORM=simulator cleanall` : that cleans all the output folder
- `make PLATFORM=simulator start` : that starts the simulator
- `make PLATFORM=simulator run` : that compile and starts the simulator
- `make PLATFORM=simulator clean_run` : that cleans the output folder, compile and starts the simulator

So in experiment, it'll be very usefull...

Thanks to @m4xi1m3 for cleanall, and learn me some things about makefile