### PR TITLE
Calculation fix selection issues

### DIFF
--- a/apps/calculation/history_controller.cpp
+++ b/apps/calculation/history_controller.cpp
@@ -112,13 +112,12 @@ void HistoryController::tableViewDidChangeSelection(SelectableTableView * t, int
   if (withinTemporarySelection || previousSelectedCellY == selectedRow()) {
     return;
   }
-  HistoryViewCell * cell = static_cast<HistoryViewCell *>(t->selectedCell());
   if (previousSelectedCellY == -1) {
-    setSelectedSubviewType(SubviewType::Output, cell);
+    setSelectedSubviewType(SubviewType::Output);
   } else if (selectedRow() < previousSelectedCellY) {
-    setSelectedSubviewType(SubviewType::Output, cell);
+    setSelectedSubviewType(SubviewType::Output);
   } else if (selectedRow() > previousSelectedCellY) {
-    setSelectedSubviewType(SubviewType::Input, cell);
+    setSelectedSubviewType(SubviewType::Input);
   }
   HistoryViewCell * selectedCell = (HistoryViewCell *)(t->selectedCell());
   if (selectedCell == nullptr) {
@@ -166,10 +165,12 @@ void HistoryController::scrollToCell(int i, int j) {
   m_selectableTableView.scrollToCell(i, j);
 }
 
-void HistoryController::historyViewCellDidChangeSelection() {
+HistoryViewCell * HistoryController::historyViewCellDidChangeSelection() {
   /* Update the whole table as the height of the selected cell row might have
    * changed. */
   m_selectableTableView.reloadData();
+  // Return the selected cell if one
+  return static_cast<HistoryViewCell *>(m_selectableTableView.selectedCell());
 }
 
 }

--- a/apps/calculation/history_controller.h
+++ b/apps/calculation/history_controller.h
@@ -30,7 +30,7 @@ private:
   int storeIndex(int i) { return numberOfRows() - i - 1; }
   Shared::ExpiringPointer<Calculation> calculationAtIndex(int i);
   CalculationSelectableTableView * selectableTableView();
-  void historyViewCellDidChangeSelection() override;
+  HistoryViewCell * historyViewCellDidChangeSelection() override;
   constexpr static int k_maxNumberOfDisplayedRows = 5;
   CalculationSelectableTableView m_selectableTableView;
   HistoryViewCell m_calculationHistory[k_maxNumberOfDisplayedRows];

--- a/apps/calculation/history_view_cell.cpp
+++ b/apps/calculation/history_view_cell.cpp
@@ -15,13 +15,13 @@ static inline KDCoordinate maxCoordinate(KDCoordinate x, KDCoordinate y) { retur
 HistoryViewCellDataSource::HistoryViewCellDataSource() :
   m_selectedSubviewType(SubviewType::Output) {}
 
-void HistoryViewCellDataSource::setSelectedSubviewType(SubviewType subviewType, HistoryViewCell * cell) {
+void HistoryViewCellDataSource::setSelectedSubviewType(SubviewType subviewType) {
   m_selectedSubviewType = subviewType;
+  HistoryViewCell * cell = historyViewCellDidChangeSelection();
   if (cell) {
     cell->setHighlighted(cell->isHighlighted());
     cell->cellDidSelectSubview(subviewType);
   }
-  historyViewCellDidChangeSelection();
 }
 
 /* HistoryViewCell */
@@ -185,7 +185,7 @@ bool HistoryViewCell::handleEvent(Ion::Events::Event event) {
   if ((event == Ion::Events::Down && m_dataSource->selectedSubviewType() == HistoryViewCellDataSource::SubviewType::Input) ||
     (event == Ion::Events::Up && m_dataSource->selectedSubviewType() == HistoryViewCellDataSource::SubviewType::Output)) {
     HistoryViewCellDataSource::SubviewType otherSubviewType = m_dataSource->selectedSubviewType() == HistoryViewCellDataSource::SubviewType::Input ? HistoryViewCellDataSource::SubviewType::Output : HistoryViewCellDataSource::SubviewType::Input;
-    m_dataSource->setSelectedSubviewType(otherSubviewType, this);
+    m_dataSource->setSelectedSubviewType(otherSubviewType);
     CalculationSelectableTableView * tableView = (CalculationSelectableTableView *)parentResponder();
     tableView->scrollToSubviewOfTypeOfCellAtLocation(otherSubviewType, tableView->selectedColumn(), tableView->selectedRow());
     Container::activeApp()->setFirstResponder(this);

--- a/apps/calculation/history_view_cell.h
+++ b/apps/calculation/history_view_cell.h
@@ -17,13 +17,14 @@ public:
     Output
   };
   HistoryViewCellDataSource();
-  void setSelectedSubviewType(SubviewType subviewType, HistoryViewCell * cell = nullptr);
+  void setSelectedSubviewType(SubviewType subviewType);
   SubviewType selectedSubviewType() { return m_selectedSubviewType; }
 private:
   /* This method should belong to a delegate instead of a data source but as
    * both the data source and the delegate will be the same controller, we
    * avoid keeping 2 pointers in HistoryViewCell. */
-  virtual void historyViewCellDidChangeSelection() = 0;
+  // It returns the selected cell at the end of the method
+  virtual HistoryViewCell * historyViewCellDidChangeSelection() = 0;
   SubviewType m_selectedSubviewType;
 };
 

--- a/apps/shared/scrollable_exact_approximate_expressions_view.cpp
+++ b/apps/shared/scrollable_exact_approximate_expressions_view.cpp
@@ -158,7 +158,7 @@ void ScrollableExactApproximateExpressionsView::didBecomeFirstResponder() {
 }
 
 bool ScrollableExactApproximateExpressionsView::handleEvent(Ion::Events::Event event) {
-  if (m_contentCell.leftExpressionView()->layout().isUninitialized()) {
+  if (!m_contentCell.displayLeftExpression()) {
     return ScrollableView::handleEvent(event);
   }
   bool rightExpressionIsVisible = minimalSizeForOptimalDisplay().width() - m_contentCell.rightExpressionView()->minimalSizeForOptimalDisplay().width() - contentOffset().x() < bounds().width()

--- a/apps/shared/scrollable_exact_approximate_expressions_view.h
+++ b/apps/shared/scrollable_exact_approximate_expressions_view.h
@@ -52,6 +52,7 @@ private:
       return m_selectedSubviewPosition;
     }
     void setSelectedSubviewPosition(SubviewPosition subviewPosition);
+    bool displayLeftExpression() const { return m_displayLeftExpression; }
     void setDisplayLeftExpression(bool display);
     void layoutSubviews() override;
     int numberOfSubviews() const override;


### PR DESCRIPTION
This resolves two bugs:
- Add "1" to the calculation history. Go up and then go left, the selection is on an invisible layout.
- Add multiple times the calculation "1.2" to the history. Go up, the selection is on the left expression instead of the right one.