### PR TITLE
[build] Don't invoke bash-specific '[['

### DIFF
--- a/build/targets.device.n0110.mak
+++ b/build/targets.device.n0110.mak
@@ -13,7 +13,7 @@ $(BUILD_DIR)/test.external_flash.write.$(EXE): $(BUILD_DIR)/quiz/src/test_ion_ex
 	@echo "        button on the back of your device."
 	$(Q) until $(PYTHON) build/device/dfu.py -l | grep -E "0483:a291|0483:df11" > /dev/null 2>&1; do sleep 2;done
 	$(eval DFU_SLAVE := $(shell $(PYTHON) build/device/dfu.py -l | grep -E "0483:a291|0483:df11"))
-	$(Q) if [[ "$(DFU_SLAVE)" == *"0483:df11"* ]]; \
+	$(Q) if expr "$(DFU_SLAVE)" : ".*0483:df11.*" > /dev/null; \
 	  then \
 	    $(PYTHON) build/device/dfu.py -u $(word 2,$^); \
 	    sleep 2; \


### PR DESCRIPTION
'[[' isn't available when $SHELL isn't set to bash, so use expr from
coreutils to check for the presence of the device in DFU mode.

$SHELL doesn't come from the environment, so I _think_ that on most Debian based distros this will always be /bin/sh, which isn't bash, inside of the make environment.