### PR TITLE
Python code editor: Shift+Up and Shift+Down can now be used to quickly navigate through the code

### DIFF
--- a/escher/src/text_area.cpp
+++ b/escher/src/text_area.cpp
@@ -110,6 +110,10 @@ bool TextArea::handleEvent(Ion::Events::Event event) {
     contentView()->moveCursorGeo(-INT_MAX/2, 0);
   } else if (event == Ion::Events::ShiftRight) {
     contentView()->moveCursorGeo(INT_MAX/2, 0);
+  } else if (event == Ion::Events::ShiftUp) {
+    contentView()->moveCursorGeo(0, -INT_MAX/2);
+  } else if (event == Ion::Events::ShiftDown) {
+    contentView()->moveCursorGeo(0, INT_MAX/2);
   } else if (event == Ion::Events::Backspace) {
     return removePreviousGlyph();
   } else if (event.hasText()) {

--- a/ion/include/ion/events.h
+++ b/ion/include/ion/events.h
@@ -117,6 +117,8 @@ constexpr Event EXE = Event::PlainKey(Keyboard::Key::EXE);
 // Shift
 
 constexpr Event ShiftLeft  = Event::ShiftKey(Keyboard::Key::Left);
+constexpr Event ShiftUp  = Event::ShiftKey(Keyboard::Key::Up);
+constexpr Event ShiftDown = Event::ShiftKey(Keyboard::Key::Down);
 constexpr Event ShiftRight = Event::ShiftKey(Keyboard::Key::Right);
 
 constexpr Event AlphaLock = Event::ShiftKey(Keyboard::Key::Alpha);

--- a/ion/include/ion/keyboard/layout_B2/layout_events.h
+++ b/ion/include/ion/keyboard/layout_B2/layout_events.h
@@ -20,7 +20,7 @@ static constexpr EventData s_dataForEvent[4*Event::PageSize] = {
   T("1"), T("2"), T("3"), T("+"), T("-"), U(),
   T("0"), T("."), T("ᴇ"), TL(), TL(), U(),
 // Shift
-  TL(), U(), U(), TL(), U(), U(),
+  TL(), TL(), TL(), TL(), U(), U(),
   U(), U(), U(), U(), U(), U(),
   U(), U(), TL(), TL(), TL(), TL(),
   T("["), T("]"), T("{"), T("}"), T("_"), T("→"),

--- a/ion/include/ion/keyboard/layout_B3/layout_events.h
+++ b/ion/include/ion/keyboard/layout_B3/layout_events.h
@@ -20,7 +20,7 @@ static constexpr EventData s_dataForEvent[4*Event::PageSize] = {
   T("1"), T("2"), T("3"), T("+"), T("-"), U(),
   T("0"), T("."), T("ᴇ"), TL(), TL(), U(),
 // Shift
-  TL(), U(), U(), TL(), U(), U(),
+  TL(), TL(), TL(), TL(), U(), U(),
   U(), U(), U(), U(), U(), U(),
   U(), U(), TL(), TL(), TL(), TL(),
   T("["), T("]"), T("{"), T("}"), T("_"), T("→"),


### PR DESCRIPTION
This is a very small feature that I always wanted.
When writing longer scripts in the Python app, it's very annoying to scroll all the way to the top.
Shift+Right and Shift+Left can already be used to jump to the beginning/end of a line but such a feature did not exist for Up/Down jumping. With this PR, you can jump to the top of your script with Shift+Up or to the bottom with Shift+Down.
I had to implement the ShiftUp and ShiftDown Ion Events for this to work.