### PR TITLE
Fix expression serialization in lists

### DIFF
--- a/apps/shared/expression_model.cpp
+++ b/apps/shared/expression_model.cpp
@@ -33,7 +33,11 @@ void ExpressionModel::text(const Storage::Record * record, char * buffer, size_t
   if (symbol != 0) {
     e = e.replaceSymbolWithExpression(Symbol::Builder(UCodePointUnknown), Symbol::Builder(symbol));
   }
-  e.serialize(buffer, bufferSize);
+  int serializedSize = e.serialize(buffer, bufferSize);
+  if (serializedSize >= bufferSize - 1) {
+    // It is very likely that the buffer is overflowed
+    buffer[0] = 0;
+  }
 }
 
 bool ExpressionModel::isCircularlyDefined(const Storage::Record * record, Poincare::Context * context) const {

--- a/apps/shared/expression_model.cpp
+++ b/apps/shared/expression_model.cpp
@@ -24,14 +24,16 @@ ExpressionModel::ExpressionModel() :
 
 void ExpressionModel::text(const Storage::Record * record, char * buffer, size_t bufferSize, CodePoint symbol) const {
   Expression e = expressionClone(record);
-  if (e.isUninitialized() && bufferSize > 0) {
-    buffer[0] = 0;
-  } else {
-    if (symbol != 0 && !e.isUninitialized()) {
-      e = e.replaceSymbolWithExpression(Symbol::Builder(UCodePointUnknown), Symbol::Builder(symbol));
+  if (e.isUninitialized()) {
+    if (bufferSize > 0) {
+      buffer[0] = 0;
     }
-    e.serialize(buffer, bufferSize);
+    return;
   }
+  if (symbol != 0) {
+    e = e.replaceSymbolWithExpression(Symbol::Builder(UCodePointUnknown), Symbol::Builder(symbol));
+  }
+  e.serialize(buffer, bufferSize);
 }
 
 bool ExpressionModel::isCircularlyDefined(const Storage::Record * record, Poincare::Context * context) const {

--- a/escher/src/text_field.cpp
+++ b/escher/src/text_field.cpp
@@ -78,6 +78,12 @@ void TextField::ContentView::setText(const char * text) {
     maxBufferSize = m_draftTextBufferSize;
     buffer = s_draftTextBuffer;
   }
+  if (textRealLength > maxBufferSize - 1) {
+    // The text was too long to be copied
+    // TODO Maybe add a warning for the user?
+    buffer[0] = 0;
+    return;
+  }
   int textLength = minInt(textRealLength, maxBufferSize - 1);
   // Copy the text
   strlcpy(buffer, text, maxBufferSize);


### PR DESCRIPTION
Fix a serialisation problem.

Scenario: Create a new sequence which is the multiplication of a lot of
imaginary i. Save it (many multiplication sign are added), then try to
edit it again, in linear edition mode: the text overflows the buffer. If
we still copied it, it might get copied until the middle of a code point,
which would make the UTF8Decoder crash afterwards.