### PR TITLE
[apps/calculation] Improve the upkeeping of Poincare pool

### DIFF
--- a/apps/calculation/history_controller.cpp
+++ b/apps/calculation/history_controller.cpp
@@ -24,6 +24,13 @@ HistoryController::HistoryController(EditExpressionController * editExpressionCo
 }
 
 void HistoryController::reload() {
+  /* When reloading, we might not used anymore cell that hold previous layouts.
+   * We clean them all before reloading their content to avoid taking extra
+   * useless space in the Poincare pool. */
+  for (int i = 0; i < k_maxNumberOfDisplayedRows; i++) {
+    m_calculationHistory[i].resetMemoization();
+  }
+
   m_selectableTableView.reloadData();
   /* TODO
    * Replace the following by selectCellAtLocation in order to avoid laying out

--- a/apps/calculation/history_view_cell.cpp
+++ b/apps/calculation/history_view_cell.cpp
@@ -193,6 +193,14 @@ void HistoryViewCell::layoutSubviews(bool force) {
   force);
 }
 
+void HistoryViewCell::resetMemoization() {
+  // Clean the layouts to make room in the pool
+  // TODO: maybe do this only when the layout won't change to avoid blinking
+  m_inputView.setLayout(Poincare::Layout());
+  m_scrollableOutputView.setLayouts(Poincare::Layout(), Poincare::Layout(), Poincare::Layout());
+  m_calculationCRC32 = 0;
+}
+
 void HistoryViewCell::setCalculation(Calculation * calculation, bool expanded) {
   uint32_t newCalculationCRC = Ion::crc32Byte((const uint8_t *)calculation, ((char *)calculation->next()) - ((char *) calculation));
   if (newCalculationCRC == m_calculationCRC32 && m_calculationExpanded == expanded) {
@@ -200,10 +208,8 @@ void HistoryViewCell::setCalculation(Calculation * calculation, bool expanded) {
   }
   Poincare::Context * context = App::app()->localContext();
 
-  // Clean the layouts to make room in the pool
   // TODO: maybe do this only when the layout won't change to avoid blinking
-  m_inputView.setLayout(Poincare::Layout());
-  m_scrollableOutputView.setLayouts(Poincare::Layout(), Poincare::Layout(), Poincare::Layout());
+  resetMemoization();
 
   // Memoization
   m_calculationCRC32 = newCalculationCRC;

--- a/apps/calculation/history_view_cell.h
+++ b/apps/calculation/history_view_cell.h
@@ -42,6 +42,7 @@ public:
   }
   Poincare::Layout layout() const override;
   KDColor backgroundColor() const override;
+  void resetMemoization();
   void setCalculation(Calculation * calculation, bool expanded);
   int numberOfSubviews() const override;
   View * subviewAtIndex(int index) override;


### PR DESCRIPTION
Reset history cell memoization when reloading table. Otherwise, the Poincare pool store useless layouts for cells that aren't displayed.

This fixes the following issue: input "(transpose([1 2 3 4 5 6][1 2 3 4 5
6])^8", the computation works, clear the history, input the same
calculation again, it fails with a memory error.