### PR TITLE
[poincare/function] Fix getVariables

### DIFF
--- a/poincare/src/function.cpp
+++ b/poincare/src/function.cpp
@@ -39,7 +39,7 @@ int FunctionNode::getVariables(Context * context, isVariableTest isVariable, cha
   Function f(this);
   Expression e = SymbolAbstract::Expand(f, context, true);
   if (e.isUninitialized()) {
-    return 0;
+    return nextVariableIndex;
   }
   return e.node()->getVariables(context, isVariable, variables, maxSizeVariable, nextVariableIndex);
 }


### PR DESCRIPTION
Faulty scenario:
Equation x+y=f(0) without defining any variable