### PR TITLE
[python] Added record module

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -140,6 +140,8 @@ port_src += $(addprefix python/port/,\
   mod/turtle/modturtle_table.c \
   mod/turtle/turtle.cpp \
   mphalport.c \
+  mod/record/modrecord_table.c\
+  mod/record/modrecord.cpp\
 )
 
 # Workarounds

--- a/python/port/genhdr/qstrdefs.in.h
+++ b/python/port/genhdr/qstrdefs.in.h
@@ -116,6 +116,15 @@ Q(time)
 Q(sleep)
 Q(monotonic)
 
+
+// record QSTRs
+Q(record)
+Q(istaken)
+Q(save)
+Q(getdata)
+Q(destroy)
+Q(listrecords)
+
 // MicroPython QSTRs
 Q()
 Q(*)

--- a/python/port/mod/record/modrecord.cpp
+++ b/python/port/mod/record/modrecord.cpp
@@ -1,0 +1,61 @@
+extern "C" {
+    #include "modrecord.h"
+    #include <py/objtuple.h>
+    #include <py/runtime.h>
+}
+#include <ion.h>
+#include "port.h"
+
+#define extension "py"
+
+Ion::Storage::Record GetRecordFromName(const char* name){
+    return Ion::Storage::sharedStorage()->recordBaseNamedWithExtension(name, extension);
+}
+
+mp_obj_t modrecord_istaken(mp_obj_t name){
+    if(Ion::Storage::sharedStorage()->hasRecord(Ion::Storage::Record(mp_obj_str_get_str(name), extension))){
+        return mp_const_true;
+    } else {
+        return mp_const_false;
+    }
+}
+
+mp_obj_t modrecord_save(mp_obj_t name, mp_obj_t data){
+    // 
+    if(Ion::Storage::sharedStorage()->createRecordWithExtension(mp_obj_str_get_str(name),extension, mp_obj_str_get_str(data), sizeof(mp_obj_str_get_str(data))) == Ion::Storage::Record::ErrorStatus::None){
+        return mp_const_true;
+    } else {
+        return mp_const_false;
+    }
+}
+
+mp_obj_t modrecord_getdata(mp_obj_t name){
+    Ion::Storage::Record r = GetRecordFromName(mp_obj_str_get_str(name));
+    if(r != NULL){
+        Ion::Storage::Record::Data d = r.value();
+        const char* content = (const char *)d.buffer;
+        return mp_obj_new_str_via_qstr(content, sizeof(content));   
+    } else {
+        return mp_const_none;
+    }
+}
+
+mp_obj_t modrecord_destroy(mp_obj_t name){
+    Ion::Storage::Record r = GetRecordFromName(mp_obj_str_get_str(name));
+    if(r != NULL){
+        r.destroy();
+        return mp_const_true;
+    } else {
+        return mp_const_false;
+    }
+}
+
+mp_obj_t modrecord_listrecords(){
+    uint8_t NRecords =Ion::Storage::sharedStorage()->numberOfRecordsWithExtension(extension);
+    mp_obj_tuple_t * t = static_cast<mp_obj_tuple_t *>(MP_OBJ_TO_PTR(mp_obj_new_tuple(NRecords, NULL)));
+    for(int i = NRecords - 1; i>=0; i--){
+        const char* name = Ion::Storage::sharedStorage()->recordWithExtensionAtIndex(extension, i).fullName();
+        t->items[i] = mp_obj_new_str(name, sizeof(name));
+    }
+    return t;
+}

--- a/python/port/mod/record/modrecord.h
+++ b/python/port/mod/record/modrecord.h
@@ -1,0 +1,7 @@
+#include <py/obj.h>
+
+mp_obj_t modrecord_istaken(mp_obj_t name);
+mp_obj_t modrecord_save(mp_obj_t name, mp_obj_t data);
+mp_obj_t modrecord_getdata(mp_obj_t name);
+mp_obj_t modrecord_destroy(mp_obj_t name);
+mp_obj_t modrecord_listrecords();

--- a/python/port/mod/record/modrecord_table.c
+++ b/python/port/mod/record/modrecord_table.c
@@ -1,0 +1,23 @@
+#include "modrecord.h"
+
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(modrecord_istaken_obj, modrecord_istaken);
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(modrecord_save_obj, modrecord_save);
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(modrecord_getdata_obj, modrecord_getdata);
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(modrecord_destroy_obj, modrecord_destroy);
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(modrecord_listrecords_obj, modrecord_listrecords);
+
+STATIC const mp_rom_map_elem_t modrecord_module_globals_table[] = {
+    {MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_record)},
+    {MP_ROM_QSTR(MP_QSTR_istaken), (mp_obj_t)&modrecord_istaken_obj},
+    {MP_ROM_QSTR(MP_QSTR_save), (mp_obj_t)&modrecord_save_obj},
+    {MP_ROM_QSTR(MP_QSTR_getdata), (mp_obj_t)&modrecord_getdata_obj},
+    {MP_ROM_QSTR(MP_QSTR_destroy), (mp_obj_t)&modrecord_destroy_obj},
+    {MP_ROM_QSTR(MP_QSTR_listrecords), (mp_obj_t)&modrecord_listrecords_obj},
+};
+
+STATIC MP_DEFINE_CONST_DICT(modrecord_module_globals, modrecord_module_globals_table);
+
+const mp_obj_module_t modrecord_module = {
+  .base = { &mp_type_module },
+  .globals = (mp_obj_dict_t*)&modrecord_module_globals,
+};

--- a/python/port/mpconfigport.h
+++ b/python/port/mpconfigport.h
@@ -132,10 +132,12 @@ extern const struct _mp_obj_module_t modion_module;
 extern const struct _mp_obj_module_t modkandinsky_module;
 extern const struct _mp_obj_module_t modtime_module;
 extern const struct _mp_obj_module_t modturtle_module;
+extern const struct _mp_obj_module_t modrecord_module;
 
 #define MICROPY_PORT_BUILTIN_MODULES \
     { MP_ROM_QSTR(MP_QSTR_ion), MP_ROM_PTR(&modion_module) }, \
     { MP_ROM_QSTR(MP_QSTR_kandinsky), MP_ROM_PTR(&modkandinsky_module) }, \
     { MP_ROM_QSTR(MP_QSTR_time), MP_ROM_PTR(&modtime_module) }, \
     { MP_ROM_QSTR(MP_QSTR_turtle), MP_ROM_PTR(&modturtle_module) }, \
+    { MP_ROM_QSTR(MP_QSTR_record), MP_ROM_PTR(&modrecord_module) }, \
 


### PR DESCRIPTION
# Warning

This module is WIP

## What does it do ?

It adds a module to add a "file" system python module based on the Ion::Storage::Records, with 5 commands :

- `save(name,data)`
- `getdata(name)`
- `istaken(name)`
- `destroy(name)`
- `listrecords()`

## To do

- [ ] Patch the \x0 characters
- [ ] Patch the `listrecords()` issue with long records name
- [ ] Add to toolbox