### PR TITLE
[apps/code] Do not refresh the print if the sandbox is displayed

### DIFF
--- a/apps/code/console_controller.cpp
+++ b/apps/code/console_controller.cpp
@@ -399,6 +399,9 @@ void ConsoleController::resetSandbox() {
 }
 
 void ConsoleController::refreshPrintOutput() {
+  if (sandboxIsDisplayed()) {
+    return;
+  }
   m_selectableTableView.reloadData();
   m_selectableTableView.selectCellAtLocation(0, m_consoleStore.numberOfLines());
   if (m_preventEdition) {


### PR DESCRIPTION
Otherwise the first responder becomes the console edit line, and events
(such as Toolbox) are not intercepted by the sandbox anymore.