### PR TITLE
Performance fixes relating to floating point operations

### DIFF
--- a/apps/calculation/additional_outputs/complex_graph_cell.cpp
+++ b/apps/calculation/additional_outputs/complex_graph_cell.cpp
@@ -44,7 +44,7 @@ void ComplexGraphView::drawRect(KDContext * ctx, KDRect rect) const {
    * and the line of equation (real*t,imag*t).
    * (a*cos(t), b*sin(t)) = (real*t,imag*t) --> tan(t) = sign(a)*sign(b) (± π)
    * --> t = π/4 [π/2] according to sign(a) and sign(b). */
-  float th = real < 0.0f ? 3.0f*M_PI/4.0f : M_PI/4.0f;
+  float th = real < 0.0f ? 3.0f*(float)M_PI/4.0f : (float)M_PI/4.0f;
   th = imag < 0.0f ? -th : th;
   // Compute ellipsis parameters a and b
   float factor = 5.0f;
@@ -53,7 +53,7 @@ void ComplexGraphView::drawRect(KDContext * ctx, KDRect rect) const {
   // Avoid flat ellipsis for edge cases (for real = 0, the case imag = 0 is excluded)
   if (real == 0.0f) {
     a = 1.0f/factor;
-    th = imag < 0.0f ? -M_PI/2.0f : M_PI/2.0f;
+    th = imag < 0.0f ? -(float)M_PI/2.0f : (float)M_PI/2.0f;
   }
   std::complex<float> parameters(a,b);
   drawCurve(ctx, rect, 0.0f, 1.0f, 0.01f,

--- a/apps/calculation/additional_outputs/complex_graph_cell.cpp
+++ b/apps/calculation/additional_outputs/complex_graph_cell.cpp
@@ -44,7 +44,7 @@ void ComplexGraphView::drawRect(KDContext * ctx, KDRect rect) const {
    * and the line of equation (real*t,imag*t).
    * (a*cos(t), b*sin(t)) = (real*t,imag*t) --> tan(t) = sign(a)*sign(b) (± π)
    * --> t = π/4 [π/2] according to sign(a) and sign(b). */
-  float th = real < 0.0f ? 3.0f*(float)M_PI/4.0f : (float)M_PI/4.0f;
+  float th = real < 0.0f ? (float)(3.0*M_PI_4) : (float)M_PI_4;
   th = imag < 0.0f ? -th : th;
   // Compute ellipsis parameters a and b
   float factor = 5.0f;
@@ -53,7 +53,7 @@ void ComplexGraphView::drawRect(KDContext * ctx, KDRect rect) const {
   // Avoid flat ellipsis for edge cases (for real = 0, the case imag = 0 is excluded)
   if (real == 0.0f) {
     a = 1.0f/factor;
-    th = imag < 0.0f ? -(float)M_PI/2.0f : (float)M_PI/2.0f;
+    th = imag < 0.0f ? (float)-M_PI_2 : (float)M_PI_2;
   }
   std::complex<float> parameters(a,b);
   drawCurve(ctx, rect, 0.0f, 1.0f, 0.01f,

--- a/apps/calculation/additional_outputs/trigonometry_model.h
+++ b/apps/calculation/additional_outputs/trigonometry_model.h
@@ -18,7 +18,7 @@ public:
   float yMax() const override { return yCenter() + yHalfRange(); }
 
   void setAngle(float f) { m_angle = f; }
-  float angle() const { return m_angle*M_PI/Poincare::Trigonometry::PiInAngleUnit(Poincare::Preferences::sharedPreferences()->angleUnit()); }
+  float angle() const { return m_angle*(float)M_PI/(float)Poincare::Trigonometry::PiInAngleUnit(Poincare::Preferences::sharedPreferences()->angleUnit()); }
 private:
   constexpr static float k_xHalfRange = 2.1f;
   // We center the yRange around the semi-circle where the angle is

--- a/apps/probability/distribution/binomial_distribution.cpp
+++ b/apps/probability/distribution/binomial_distribution.cpp
@@ -66,7 +66,7 @@ double BinomialDistribution::cumulativeDistributiveInverseForProbability(double 
 }
 
 double BinomialDistribution::rightIntegralInverseForProbability(double * probability) {
-  if (m_parameter1 == 0.0 && (m_parameter2 == 0.0 || m_parameter2 == 1.0)) {
+  if (m_parameter1 == 0.0f && (m_parameter2 == 0.0f || m_parameter2 == 1.0f)) {
     return NAN;
   }
   if (*probability <= 0.0) {

--- a/apps/probability/distribution/chi_squared_distribution.cpp
+++ b/apps/probability/distribution/chi_squared_distribution.cpp
@@ -44,7 +44,7 @@ double ChiSquaredDistribution::cumulativeDistributiveFunctionAtAbscissa(double x
     return 0.0;
   }
   double result = 0.0;
-  if (regularizedGamma(m_parameter1/2.0, x/2.0, k_regularizedGammaPrecision, k_maxRegularizedGammaIterations, &result)) {
+  if (regularizedGamma(m_parameter1/2.0f, x/2.0, k_regularizedGammaPrecision, k_maxRegularizedGammaIterations, &result)) {
     return result;
   }
   return NAN;

--- a/apps/probability/distribution/student_distribution.cpp
+++ b/apps/probability/distribution/student_distribution.cpp
@@ -55,7 +55,7 @@ double StudentDistribution::cumulativeDistributiveInverseForProbability(double *
 
 float StudentDistribution::lnCoefficient() const {
   const float k = m_parameter1;
-  return std::lgamma((k+1.0f)/2.0f) - std::lgamma(k/2.0f) - (M_PI+k)/2.0f;
+  return std::lgamma((k+1.0f)/2.0f) - std::lgamma(k/2.0f) - ((float)M_PI+k)/2.0f;
 }
 
 }

--- a/apps/probability/distribution/student_distribution.cpp
+++ b/apps/probability/distribution/student_distribution.cpp
@@ -23,7 +23,7 @@ float StudentDistribution::evaluateAtAbscissa(float x) const {
 }
 
 bool StudentDistribution::authorizedValueAtIndex(float x, int index) const {
-  return x >= FLT_EPSILON && x <= 200.0; // We cannot draw the curve for x > 200 (coefficient() is too small)
+  return x >= FLT_EPSILON && x <= 200.0f; // We cannot draw the curve for x > 200 (coefficient() is too small)
 }
 
 double StudentDistribution::cumulativeDistributiveFunctionAtAbscissa(double x) const {

--- a/apps/shared/function_graph_view.cpp
+++ b/apps/shared/function_graph_view.cpp
@@ -75,8 +75,8 @@ void FunctionGraphView::reloadBetweenBounds(float start, float end) {
   if (start == end) {
     return;
   }
-  float pixelLowerBound = floatToPixel(Axis::Horizontal, start)-2.0;
-  float pixelUpperBound = floatToPixel(Axis::Horizontal, end)+4.0;
+  float pixelLowerBound = floatToPixel(Axis::Horizontal, start) - 2.0f;
+  float pixelUpperBound = floatToPixel(Axis::Horizontal, end) + 4.0f;
   /* We exclude the banner frame from the dirty zone to avoid unnecessary
    * redrawing */
   KDRect dirtyZone(KDRect(pixelLowerBound, 0, pixelUpperBound-pixelLowerBound,

--- a/liba/Makefile
+++ b/liba/Makefile
@@ -57,6 +57,7 @@ liba_src += $(addprefix liba/src/external/openbsd/, \
   s_copysignf.c \
   s_cosf.c \
   s_erf.c \
+  s_erff.c \
   s_expm1f.o\
   s_fabsf.c \
   s_fmaxf.c \

--- a/liba/Makefile
+++ b/liba/Makefile
@@ -65,6 +65,7 @@ liba_src += $(addprefix liba/src/external/openbsd/, \
   s_frexp.c \
   s_log1pf.c \
   s_logb.c \
+  s_logbf.c \
   s_modf.c \
   s_modff.c \
   s_rint.c \

--- a/liba/src/external/openbsd/s_erff.c
+++ b/liba/src/external/openbsd/s_erff.c
@@ -1,0 +1,185 @@
+/* s_erff.c -- float version of s_erf.c.
+ * Conversion to float by Ian Lance Taylor, Cygnus Support, ian@cygnus.com.
+ * Taken from openlibm at 5b0e7e981321687ac0abe711fdeb30adcd9da932 and
+ * modified for Numworks Epsilon by Neven Sajko <nsajko@gmail.com>
+ */
+
+/*
+ * ====================================================
+ * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+ *
+ * Developed at SunPro, a Sun Microsystems, Inc. business.
+ * Permission to use, copy, modify, and distribute this
+ * software is freely granted, provided that this notice
+ * is preserved.
+ * ====================================================
+ */
+
+//__FBSDID("$FreeBSD: src/lib/msun/src/s_erff.c,v 1.8 2008/02/22 02:30:35 das Exp $");
+
+#include "math.h"
+
+#include "math_private.h"
+
+static const float
+tiny	    = 1e-30,
+half=  5.0000000000e-01, /* 0x3F000000 */
+one =  1.0000000000e+00, /* 0x3F800000 */
+two =  2.0000000000e+00, /* 0x40000000 */
+/*
+ * Coefficients for approximation to erf on [0,0.84375]
+ */
+efx =  1.2837916613e-01, /* 0x3e0375d4 */
+efx8=  1.0270333290e+00, /* 0x3f8375d4 */
+/*
+ *  Domain [0, 0.84375], range ~[-5.4446e-10,5.5197e-10]:
+ *  |(erf(x) - x)/x - p(x)/q(x)| < 2**-31.
+ */
+pp0  =  1.28379166e-01F, /*  0x1.06eba8p-3 */
+pp1  = -3.36030394e-01F, /* -0x1.58185ap-2 */
+pp2  = -1.86260219e-03F, /* -0x1.e8451ep-10 */
+qq1  =  3.12324286e-01F, /*  0x1.3fd1f0p-2 */
+qq2  =  2.16070302e-02F, /*  0x1.620274p-6 */
+qq3  = -1.98859419e-03F, /* -0x1.04a626p-9 */
+/*
+ * Domain [0.84375, 1.25], range ~[-1.953e-11,1.940e-11]:
+ * |(erf(x) - erx) - p(x)/q(x)| < 2**-36.
+ */
+erx  =  8.42697144e-01F, /*  0x1.af7600p-1.  erf(1) rounded to 16 bits. */
+pa0  =  3.64939137e-06F, /*  0x1.e9d022p-19 */
+pa1  =  4.15109694e-01F, /*  0x1.a91284p-2 */
+pa2  = -1.65179938e-01F, /* -0x1.5249dcp-3 */
+pa3  =  1.10914491e-01F, /*  0x1.c64e46p-4 */
+qa1  =  6.02074385e-01F, /*  0x1.344318p-1 */
+qa2  =  5.35934687e-01F, /*  0x1.126608p-1 */
+qa3  =  1.68576106e-01F, /*  0x1.593e6ep-3 */
+qa4  =  5.62181212e-02F, /*  0x1.cc89f2p-5 */
+/*
+ * Domain [1.25,1/0.35], range ~[-7.043e-10,7.457e-10]:
+ * |log(x*erfc(x)) + x**2 + 0.5625 - r(x)/s(x)| < 2**-30
+ */
+ra0  = -9.87132732e-03F, /* -0x1.4376b2p-7 */
+ra1  = -5.53605914e-01F, /* -0x1.1b723cp-1 */
+ra2  = -2.17589188e+00F, /* -0x1.1683a0p+1 */
+ra3  = -1.43268085e+00F, /* -0x1.6ec42cp+0 */
+sa1  =  5.45995426e+00F, /*  0x1.5d6fe4p+2 */
+sa2  =  6.69798088e+00F, /*  0x1.acabb8p+2 */
+sa3  =  1.43113089e+00F, /*  0x1.6e5e98p+0 */
+sa4  = -5.77397496e-02F, /* -0x1.d90108p-5 */
+/*
+ * Domain [1/0.35, 11], range ~[-2.264e-13,2.336e-13]:
+ * |log(x*erfc(x)) + x**2 + 0.5625 - r(x)/s(x)| < 2**-42
+ */
+rb0  = -9.86494310e-03F, /* -0x1.434124p-7 */
+rb1  = -6.25171244e-01F, /* -0x1.401672p-1 */
+rb2  = -6.16498327e+00F, /* -0x1.8a8f16p+2 */
+rb3  = -1.66696873e+01F, /* -0x1.0ab70ap+4 */
+rb4  = -9.53764343e+00F, /* -0x1.313460p+3 */
+sb1  =  1.26884899e+01F, /*  0x1.96081cp+3 */
+sb2  =  4.51839523e+01F, /*  0x1.6978bcp+5 */
+sb3  =  4.72810211e+01F, /*  0x1.7a3f88p+5 */
+sb4  =  8.93033314e+00F; /*  0x1.1dc54ap+3 */
+
+
+float
+erff(float x)
+{
+	int32_t hx,ix,i;
+	float R,S,P,Q,s,y,z,r;
+	GET_FLOAT_WORD(hx,x);
+	ix = hx&0x7fffffff;
+	if(ix>=0x7f800000) {		/* erf(nan)=nan */
+	    i = ((u_int32_t)hx>>31)<<1;
+	    return (float)(1-i)+one/x;	/* erf(+-inf)=+-1 */
+	}
+
+	if(ix < 0x3f580000) {		/* |x|<0.84375 */
+            if(ix < 0x38800000) {       /* |x|<2**-14 */
+                if (ix < 0x04000000)    /* |x|<0x1p-119 */
+                    return (8*x+efx8*x)/8;      /* avoid spurious underflow */
+		return x + efx*x;
+	    }
+	    z = x*x;
+            r = pp0+z*(pp1+z*pp2);
+            s = one+z*(qq1+z*(qq2+z*qq3));
+	    y = r/s;
+	    return x + x*y;
+	}
+	if(ix < 0x3fa00000) {		/* 0.84375 <= |x| < 1.25 */
+	    s = fabsf(x)-one;
+            P = pa0+s*(pa1+s*(pa2+s*pa3));
+            Q = one+s*(qa1+s*(qa2+s*(qa3+s*qa4)));
+	    if(hx>=0) return erx + P/Q; else return -erx - P/Q;
+	}
+	if (ix >= 0x40800000) {		/* inf>|x|>=4 */
+	    if(hx>=0) return one-tiny; else return tiny-one;
+	}
+	x = fabsf(x);
+ 	s = one/(x*x);
+	if(ix< 0x4036DB6E) {	/* |x| < 1/0.35 */
+            R=ra0+s*(ra1+s*(ra2+s*ra3));
+            S=one+s*(sa1+s*(sa2+s*(sa3+s*sa4)));
+	} else {	/* |x| >= 1/0.35 */
+            R=rb0+s*(rb1+s*(rb2+s*(rb3+s*rb4)));
+            S=one+s*(sb1+s*(sb2+s*(sb3+s*sb4)));
+        }
+        SET_FLOAT_WORD(z,hx&0xffffe000);
+        r  = expf(-z*z-0.5625F)*expf((z-x)*(z+x)+R/S);
+	if(hx>=0) return one-r/x; else return  r/x-one;
+}
+
+float
+erfcf(float x)
+{
+	int32_t hx,ix;
+	float R,S,P,Q,s,y,z,r;
+	GET_FLOAT_WORD(hx,x);
+	ix = hx&0x7fffffff;
+	if(ix>=0x7f800000) {			/* erfc(nan)=nan */
+						/* erfc(+-inf)=0,2 */
+	    return (float)(((u_int32_t)hx>>31)<<1)+one/x;
+	}
+
+	if(ix < 0x3f580000) {		/* |x|<0.84375 */
+	    if(ix < 0x33800000)  	/* |x|<2**-56 */
+		return one-x;
+	    z = x*x;
+            r = pp0+z*(pp1+z*pp2);
+            s = one+z*(qq1+z*(qq2+z*qq3));
+	    y = r/s;
+	    if(hx < 0x3e800000) {  	/* x<1/4 */
+		return one-(x+x*y);
+	    } else {
+		r = x*y;
+		r += (x-half);
+	        return half - r ;
+	    }
+	}
+	if(ix < 0x3fa00000) {		/* 0.84375 <= |x| < 1.25 */
+	    s = fabsf(x)-one;
+            P = pa0+s*(pa1+s*(pa2+s*pa3));
+            Q = one+s*(qa1+s*(qa2+s*(qa3+s*qa4)));
+	    if(hx>=0) {
+	        z  = one-erx; return z - P/Q;
+	    } else {
+		z = erx+P/Q; return one+z;
+	    }
+	}
+	if (ix < 0x41300000) {		/* |x|<28 */
+	    x = fabsf(x);
+ 	    s = one/(x*x);
+	    if(ix< 0x4036DB6D) {	/* |x| < 1/.35 ~ 2.857143*/
+                R=ra0+s*(ra1+s*(ra2+s*ra3));
+                S=one+s*(sa1+s*(sa2+s*(sa3+s*sa4)));
+	    } else {			/* |x| >= 1/.35 ~ 2.857143 */
+                if(hx<0&&ix>=0x40a00000) return two-tiny;/* x < -5 */
+                R=rb0+s*(rb1+s*(rb2+s*(rb3+s*rb4)));
+                S=one+s*(sb1+s*(sb2+s*(sb3+s*sb4)));
+	    }
+            SET_FLOAT_WORD(z,hx&0xffffe000);
+            r  = expf(-z*z-0.5625F)*expf((z-x)*(z+x)+R/S);
+	    if(hx>0) return r/x; else return two-r/x;
+	} else {
+	    if(hx>0) return tiny*tiny; else return two-tiny;
+	}
+}

--- a/liba/src/external/openbsd/s_logbf.c
+++ b/liba/src/external/openbsd/s_logbf.c
@@ -1,0 +1,42 @@
+/* s_logbf.c -- float version of s_logb.c.
+ * Conversion to float by Ian Lance Taylor, Cygnus Support, ian@cygnus.com.
+ * Taken from openlibm at 5b0e7e981321687ac0abe711fdeb30adcd9da932 and
+ * modified for Numworks Epsilon by Neven Sajko <nsajko@gmail.com>
+ */
+
+/*
+ * ====================================================
+ * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+ *
+ * Developed at SunPro, a Sun Microsystems, Inc. business.
+ * Permission to use, copy, modify, and distribute this
+ * software is freely granted, provided that this notice
+ * is preserved.
+ * ====================================================
+ */
+
+//__FBSDID("$FreeBSD: src/lib/msun/src/s_logbf.c,v 1.9 2008/02/22 02:30:35 das Exp $");
+
+#include "math.h"
+
+#include "math_private.h"
+
+static const float
+two25 = 3.355443200e+07;		/* 0x4c000000 */
+
+float
+logbf(float x)
+{
+	int32_t ix;
+	GET_FLOAT_WORD(ix,x);
+	ix &= 0x7fffffff;			/* high |x| */
+	if(ix==0) return (float)-1.0/fabsf(x);
+	if(ix>=0x7f800000) return x*x;
+	if(ix<0x00800000) {
+		x *= two25;		 /* convert subnormal x to normal */
+		GET_FLOAT_WORD(ix,x);
+		ix &= 0x7fffffff;
+		return (float) ((ix>>23)-127-25);
+	} else
+		return (float) ((ix>>23)-127);
+}

--- a/libaxx/include/cmath
+++ b/libaxx/include/cmath
@@ -104,7 +104,9 @@ static inline float cos(float x) { return __builtin_cosf(x); }
 static inline double cosh(double x) { return __builtin_cosh(x); }
 static inline float cosh(float x) { return __builtin_coshf(x); }
 static inline double erf(double x) { return __builtin_erf(x); }
+static inline float erf(float x) { return __builtin_erff(x); }
 static inline double erfc(double x) { return __builtin_erfc(x); }
+static inline float erfc(float x) { return __builtin_erfcf(x); }
 static inline double exp(double x) { return __builtin_exp(x); }
 static inline float exp(float x) { return __builtin_expf(x); }
 static inline double fabs(double x) { return __builtin_fabs(x); }

--- a/libaxx/include/cmath
+++ b/libaxx/include/cmath
@@ -48,6 +48,7 @@
 #undef asin
 #undef asinh
 #undef atan
+#undef atan2
 #undef atanh
 #undef ceil
 #undef copysign
@@ -67,6 +68,7 @@
 #undef log1p
 #undef log10
 #undef log
+#undef logb
 #undef pow
 #undef round
 #undef scalbn
@@ -89,6 +91,8 @@ static inline double asinh(double x) { return __builtin_asinh(x); }
 static inline float asinh(float x) { return __builtin_asinhf(x); }
 static inline double atan(double x) { return __builtin_atan(x); }
 static inline float atan(float x) { return __builtin_atanf(x); }
+static inline double atan2(double y, double x) { return __builtin_atan2(y, x); }
+static inline float atan2(float y, float x) { return __builtin_atan2f(y, x); }
 static inline double atanh(double x) { return __builtin_atanh(x); }
 static inline float atanh(float x) { return __builtin_atanhf(x); }
 static inline double ceil(double x) { return __builtin_ceil(x); }
@@ -114,7 +118,7 @@ static inline float fmod(float x, float y) { return __builtin_fmodf(x, y); }
 static inline int fpclassify(double x) { return __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, x); }
 static inline int fpclassify(float x) { return __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, x); }
 static inline double hypot(double x, double y) { return __builtin_hypot(x, y); }
-static inline float hypotf(float x, float y) { return __builtin_hypotf(x, y); }
+static inline float hypot(float x, float y) { return __builtin_hypotf(x, y); }
 static inline bool isfinite(double x) { return __builtin_isfinite(x); }
 static inline bool isfinite(float x) { return __builtin_isfinite(x); }
 static inline bool isinf(double x) { return __builtin_isinf(x); }
@@ -129,10 +133,14 @@ static inline double log10(double x) { return __builtin_log10(x); }
 static inline float log10(float x) { return __builtin_log10f(x); }
 static inline double log(double x) { return __builtin_log(x); }
 static inline float log(float x) { return __builtin_logf(x); }
+static inline double logb(double x) { return __builtin_logb(x); }
+static inline float logb(float x) { return __builtin_logbf(x); }
 static inline double pow(double x, double y) { return __builtin_pow(x, y); }
 static inline float pow(float x, float y) { return __builtin_powf(x, y); }
 static inline double round(double x) { return __builtin_round(x); }
 static inline float round(float x) { return __builtin_roundf(x); }
+static inline double scalbn(double a, int e) { return __builtin_scalbn(a, e); }
+static inline float scalbn(float a, int e) { return __builtin_scalbnf(a, e); }
 static inline double sin(double x) { return __builtin_sin(x); }
 static inline float sin(float x) { return __builtin_sinf(x); }
 static inline double sinh(double x) { return __builtin_sinh(x); }

--- a/poincare/include/poincare/ieee754.h
+++ b/poincare/include/poincare/ieee754.h
@@ -53,7 +53,7 @@ public:
   }
   static int exponentBase10(T f) {
     static T k_log10base2 = 3.321928094887362347870319429489390175864831393024580612054;
-    if (f == 0.0) {
+    if (f == (T)0.0) {
       return 0;
     }
     T exponentBase2 = exponent(f);
@@ -68,7 +68,7 @@ public:
      * in -0.31 < x < 1, we get:
      * e2 = [e1/log(10,2)]  or e2 = [e1/log(10,2)]-1 depending on m1. */
     int exponentBase10 = std::round(exponentBase2/k_log10base2);
-    if (std::pow(10.0, exponentBase10) > std::fabs(f)) {
+    if (std::pow((T)10.0, exponentBase10) > std::fabs(f)) {
       exponentBase10--;
     }
     return exponentBase10;

--- a/poincare/src/approximation_helper.cpp
+++ b/poincare/src/approximation_helper.cpp
@@ -33,7 +33,7 @@ template <typename T> std::complex<T> ApproximationHelper::TruncateRealOrImagina
   if (absMod<T>(arg, (T)M_PI) <= precision) {
     c.imag(0);
   }
-  if (absMod<T>(arg-(T)M_PI/2.0, (T)M_PI) <= precision) {
+  if (absMod<T>(arg-(T)M_PI_2, (T)M_PI) <= precision) {
     c.real(0);
   }
   return c;

--- a/poincare/src/arc_cosine.cpp
+++ b/poincare/src/arc_cosine.cpp
@@ -26,7 +26,7 @@ Expression ArcCosineNode::shallowReduce(ReductionContext reductionContext) {
 template<typename T>
 Complex<T> ArcCosineNode::computeOnComplex(const std::complex<T> c, Preferences::ComplexFormat, Preferences::AngleUnit angleUnit) {
   std::complex<T> result;
-  if (c.imag() == 0 && std::fabs(c.real()) <= 1.0) {
+  if (c.imag() == 0 && std::fabs(c.real()) <= (T)1.0) {
     /* acos: [-1;1] -> R
      * In these cases we rather use std::acos(double) because acos on complexes
      * is not as precise as pow on double in std library. For instance,

--- a/poincare/src/arc_sine.cpp
+++ b/poincare/src/arc_sine.cpp
@@ -26,7 +26,7 @@ Expression ArcSineNode::shallowReduce(ReductionContext reductionContext) {
 template<typename T>
 Complex<T> ArcSineNode::computeOnComplex(const std::complex<T> c, Preferences::ComplexFormat, Preferences::AngleUnit angleUnit) {
   std::complex<T> result;
-  if (c.imag() == 0 && std::fabs(c.real()) <= 1.0) {
+  if (c.imag() == 0 && std::fabs(c.real()) <= (T)1.0) {
     /* asin: [-1;1] -> R
      * In these cases we rather use std::asin(double) because asin on complexes
      * is not as precise as asin on double in std library. For instance,

--- a/poincare/src/arc_tangent.cpp
+++ b/poincare/src/arc_tangent.cpp
@@ -22,7 +22,7 @@ int ArcTangentNode::serialize(char * buffer, int bufferSize, Preferences::PrintF
 template<typename T>
 Complex<T> ArcTangentNode::computeOnComplex(const std::complex<T> c, Preferences::ComplexFormat, Preferences::AngleUnit angleUnit) {
   std::complex<T> result;
-  if (c.imag() == 0 && std::fabs(c.real()) <= 1.0) {
+  if (c.imag() == 0 && std::fabs(c.real()) <= (T)1.0) {
     /* atan: R -> R
      * In these cases we rather use std::atan(double) because atan on complexes
      * is not as precise as atan on double in std library. For instance,

--- a/poincare/src/complex.cpp
+++ b/poincare/src/complex.cpp
@@ -26,7 +26,7 @@ ComplexNode<T>::ComplexNode(std::complex<T> c) :
   EvaluationNode<T>(),
   std::complex<T>(c.real(), c.imag())
 {
-  if (!std::isnan(c.imag()) && c.imag() != 0.0) {
+  if (!std::isnan(c.imag()) && c.imag() != (T)0.0) {
     Expression::SetEncounteredComplex(true);
   }
   if (this->real() == -0) {
@@ -39,7 +39,7 @@ ComplexNode<T>::ComplexNode(std::complex<T> c) :
 
 template<typename T>
 T ComplexNode<T>::toScalar() const {
-  if (this->imag() == 0.0) {
+  if (this->imag() == (T)0.0) {
     return this->real();
   }
   return NAN;
@@ -63,7 +63,7 @@ Expression ComplexNode<T>::complexToExpression(Preferences::ComplexFormat comple
       Number::DecimalNumber<T>(std::fabs(tb)),
       complexFormat,
       (std::isnan(this->real()) || std::isnan(this->imag())),
-      ra == 0.0, std::fabs(ra) == 1.0, tb == 0.0, std::fabs(tb) == 1.0, ra < 0.0, tb < 0.0
+      ra == (T)0.0, std::fabs(ra) == (T)1.0, tb == (T)0.0, std::fabs(tb) == (T)1.0, ra < (T)0.0, tb < (T)0.0
     );
 }
 

--- a/poincare/src/complex_cartesian.cpp
+++ b/poincare/src/complex_cartesian.cpp
@@ -35,7 +35,7 @@ Complex<T> ComplexCartesianNode::templatedApproximate(Context * context, Prefere
   assert(imagEvalution.type() == EvaluationNode<T>::Type::Complex);
   std::complex<T> a = static_cast<Complex<T> &>(realEvaluation).stdComplex();
   std::complex<T> b = static_cast<Complex<T> &>(imagEvalution).stdComplex();
-  if ((a.imag() != 0.0 && !std::isnan(a.imag())) || (b.imag() != 0.0 && !std::isnan(b.imag()))) {
+  if ((a.imag() != (T)0.0 && !std::isnan(a.imag())) || (b.imag() != (T)0.0 && !std::isnan(b.imag()))) {
     /* a and b are supposed to be real (if they are not undefined). However,
      * due to double precision limit, the approximation of the real part or the
      * imaginary part can lead to complex values.

--- a/poincare/src/derivative.cpp
+++ b/poincare/src/derivative.cpp
@@ -56,7 +56,7 @@ Evaluation<T> DerivativeNode::templatedApproximate(Context * context, Preference
   do {
     T currentError;
     T currentResult = riddersApproximation(context, complexFormat, angleUnit, evaluationArgument, h, &currentError);
-    h /= 10.0;
+    h /= (T)10.0;
     if (std::isnan(currentError) || currentError > error) {
       continue;
     }

--- a/poincare/src/division.cpp
+++ b/poincare/src/division.cpp
@@ -47,7 +47,7 @@ Expression DivisionNode::shallowReduce(ReductionContext reductionContext) {
 }
 
 template<typename T> Complex<T> DivisionNode::compute(const std::complex<T> c, const std::complex<T> d, Preferences::ComplexFormat complexFormat) {
-  if (d.real() == 0.0 && d.imag() == 0.0) {
+  if (d.real() == (T)0.0 && d.imag() == (T)0.0) {
     return Complex<T>::Undefined();
   }
   return Complex<T>::Builder(c/d);

--- a/poincare/src/integral.cpp
+++ b/poincare/src/integral.cpp
@@ -128,8 +128,8 @@ IntegralNode::DetailedResult<T> IntegralNode::kronrodGaussQuadrature(T a, T b, C
   T fv1[10];
   T fv2[10];
 
-  T center = 0.5 * (a+b);
-  T halfLength = 0.5 * (b-a);
+  T center = (T)0.5 * (a+b);
+  T halfLength = (T)0.5 * (b-a);
   T absHalfLength = std::fabs(halfLength);
 
   DetailedResult<T> errorResult;
@@ -163,7 +163,7 @@ IntegralNode::DetailedResult<T> IntegralNode::kronrodGaussQuadrature(T a, T b, C
     absKronrodIntegral += wKronrod[j] * (std::fabs(fval1) + std::fabs(fval2));
   }
 
-  T halfKronrodIntegral = 0.5 * kronrodIntegral;
+  T halfKronrodIntegral = (T)0.5 * kronrodIntegral;
   T kronrodIntegralDifference = wKronrod[10] * std::fabs(fCenter - halfKronrodIntegral);
   for (int j = 0; j < 10; j++) {
     kronrodIntegralDifference += wKronrod[j] * (std::fabs(fv1[j] - halfKronrodIntegral) + std::fabs(fv2[j] - halfKronrodIntegral));
@@ -176,7 +176,7 @@ IntegralNode::DetailedResult<T> IntegralNode::kronrodGaussQuadrature(T a, T b, C
     T errorCoefficient = std::pow((T)(200*absError/kronrodIntegralDifference), (T)1.5);
     absError = 1 > errorCoefficient ? kronrodIntegralDifference * errorCoefficient : kronrodIntegralDifference;
   }
-  if (absKronrodIntegral > max/(50.0 * epsilon)) {
+  if (absKronrodIntegral > max/((T)50.0 * epsilon)) {
     T minError = epsilon * 50 * absKronrodIntegral;
     absError = absError > minError ? absError : minError;
   }

--- a/poincare/src/logarithm.cpp
+++ b/poincare/src/logarithm.cpp
@@ -279,7 +279,7 @@ Expression Logarithm::simpleShallowReduce(Context * context, Preferences::Comple
       if (logDenominator.imag() != 0.0f || logDenominator.real() == 0.0f) {
         result = Undefined::Builder();
       }
-      isNegative = logDenominator.real() > 0.0;
+      isNegative = logDenominator.real() > 0.0f;
       result = result.isUninitialized() ? Infinity::Builder(isNegative) : result;
       replaceWithInPlace(result);
       return result;

--- a/poincare/src/matrix.cpp
+++ b/poincare/src/matrix.cpp
@@ -261,7 +261,7 @@ void Matrix::ArrayRowCanonize(T * array, int numberOfRows, int numberOfColumns, 
       // No non-null coefficient in this column, skip
       k++;
       // Update determinant: det *= 0
-      if (determinant) { *determinant *= 0.0; }
+      if (determinant) { *determinant *= (T)0.0; }
     } else {
       // Swap row h and iPivot
       if (iPivot != h) {
@@ -272,7 +272,7 @@ void Matrix::ArrayRowCanonize(T * array, int numberOfRows, int numberOfColumns, 
           array[h*numberOfColumns+col] = temp;
         }
         // Update determinant: det *= -1
-        if (determinant) { *determinant *= -1.0; }
+        if (determinant) { *determinant *= (T)-1.0; }
       }
       // Set to 1 array[h][k] by linear combination
       T divisor = array[h*numberOfColumns+k];

--- a/poincare/src/normal_distribution.cpp
+++ b/poincare/src/normal_distribution.cpp
@@ -5,6 +5,8 @@
 #include <float.h>
 #include <assert.h>
 
+#define M_SQRT_2PI 2.506628274631000502415765284811
+
 namespace Poincare {
 
 template<typename T>
@@ -13,7 +15,7 @@ T NormalDistribution::EvaluateAtAbscissa(T x, T mu, T sigma) {
     return NAN;
   }
   const float xMinusMuOverVar = (x - mu)/sigma;
-  return ((T)1.0)/(std::fabs(sigma) * std::sqrt(((T)2.0) * M_PI)) * std::exp(-((T)0.5) * xMinusMuOverVar * xMinusMuOverVar);
+  return ((T)1.0)/(std::fabs(sigma) * (T)M_SQRT_2PI) * std::exp(-((T)0.5) * xMinusMuOverVar * xMinusMuOverVar);
 }
 
 template<typename T>
@@ -95,7 +97,7 @@ T NormalDistribution::StandardNormalCumulativeDistributiveFunctionAtAbscissa(T a
   if (abscissa < (T)0.0) {
     return ((T)1.0) - StandardNormalCumulativeDistributiveFunctionAtAbscissa(-abscissa);
   }
-  return ((T)0.5) + ((T)0.5) * std::erf(abscissa/std::sqrt(((T)2.0)));
+  return ((T)0.5) + ((T)0.5) * std::erf(abscissa/(T)M_SQRT2);
 }
 
 template<typename T>
@@ -113,7 +115,7 @@ T NormalDistribution::StandardNormalCumulativeDistributiveInverseForProbability(
   if (probability < (T)0.5) {
     return -StandardNormalCumulativeDistributiveInverseForProbability(((T)1.0)-probability);
   }
-  return std::sqrt((T)2.0) * erfInv(((T)2.0) * probability - (T)1.0);
+  return (T)M_SQRT2 * erfInv(((T)2.0) * probability - (T)1.0);
 }
 
 template float NormalDistribution::EvaluateAtAbscissa<float>(float, float, float);

--- a/poincare/src/nth_root.cpp
+++ b/poincare/src/nth_root.cpp
@@ -48,13 +48,13 @@ Evaluation<T> NthRootNode::templatedApproximate(Context * context, Preferences::
      * correspond to the principale angle. */
     if (complexFormat == Preferences::ComplexFormat::Real) {
       // root(x, q) with q integer and x real
-      if (basec.imag() == 0.0 && indexc.imag() == 0.0 && std::round(indexc.real()) == indexc.real()) {
+      if (basec.imag() == (T)0.0 && indexc.imag() == (T)0.0 && std::round(indexc.real()) == indexc.real()) {
         std::complex<T> absBasec = basec;
         absBasec.real(std::fabs(absBasec.real()));
         // compute root(|x|, q)
         Complex<T> absBasePowIndex = PowerNode::compute(absBasec, std::complex<T>(1.0)/(indexc), complexFormat);
         // q odd if (-1)^q = -1
-        if (std::pow((T)-1.0, (T)indexc.real()) < 0.0) {
+        if (std::pow((T)-1.0, (T)indexc.real()) < (T)0.0) {
           return basec.real() < 0 ? Complex<T>::Builder(-absBasePowIndex.stdComplex()) : absBasePowIndex;
         }
       }

--- a/poincare/src/number.cpp
+++ b/poincare/src/number.cpp
@@ -72,7 +72,7 @@ Number Number::DecimalNumber(T f) {
     return Undefined::Builder();
   }
   if (std::isinf(f)) {
-    return Infinity::Builder(f < 0.0);
+    return Infinity::Builder(f < (T)0.0);
   }
   return Decimal::Builder(f);
 }

--- a/poincare/src/power.cpp
+++ b/poincare/src/power.cpp
@@ -130,7 +130,7 @@ bool PowerNode::childAtIndexNeedsUserParentheses(const Expression & child, int c
 template<typename T>
 Complex<T> PowerNode::compute(const std::complex<T> c, const std::complex<T> d, Preferences::ComplexFormat complexFormat) {
   std::complex<T> result;
-  if (c.imag() == 0.0 && d.imag() == 0.0 && c.real() != 0.0 && (c.real() > 0.0 || std::round(d.real()) == d.real())) {
+  if (c.imag() == (T)0.0 && d.imag() == (T)0.0 && c.real() != (T)0.0 && (c.real() > (T)0.0 || std::round(d.real()) == d.real())) {
     /* pow: (R+, R) -> R+ (2^1.3 ~ 2.46)
      * pow: (R-, N) -> R+ ((-2)^3 = -8)
      * In these cases we rather use std::pow(double, double) because:

--- a/poincare/src/prediction_interval.cpp
+++ b/poincare/src/prediction_interval.cpp
@@ -40,8 +40,8 @@ Evaluation<T> PredictionIntervalNode::templatedApproximate(Context * context, Pr
     return Complex<T>::RealUndefined();
   }
   std::complex<T> operands[2];
-  operands[0] = std::complex<T>(p - 1.96*std::sqrt(p*(1.0-p))/std::sqrt(n));
-  operands[1] = std::complex<T>(p + 1.96*std::sqrt(p*(1.0-p))/std::sqrt(n));
+  operands[0] = std::complex<T>(p - (T)1.96*std::sqrt(p*((T)1.0-p))/std::sqrt(n));
+  operands[1] = std::complex<T>(p + (T)1.96*std::sqrt(p*((T)1.0-p))/std::sqrt(n));
   return MatrixComplex<T>::Builder(operands, 1, 2);
 }
 

--- a/poincare/src/print_float.cpp
+++ b/poincare/src/print_float.cpp
@@ -238,7 +238,7 @@ PrintFloat::TextLengths PrintFloat::ConvertFloatToTextPrivate(T f, char * buffer
 
   // Correct the number of digits in mantissa after rounding
   if (IEEE754<T>::exponentBase10(mantissa) >= numberOfSignificantDigits) {
-    mantissa = mantissa/10.0;
+    mantissa = mantissa / (T)10.0;
   }
 
   // Number of chars for the mantissa

--- a/poincare/src/randint.cpp
+++ b/poincare/src/randint.cpp
@@ -49,10 +49,10 @@ template <typename T> Evaluation<T> RandintNode::templateApproximate(Context * c
   if (std::isnan(a) || std::isnan(b) || std::isinf(a) || std::isinf(b)
       || a > b
       || a != (int)a || b != (int)b
-      || (Expression::Epsilon<T>()*(b+1.0-a) > 1.0)) {
+      || (Expression::Epsilon<T>()*(b+(T)1.0-a) > (T)1.0)) {
     return Complex<T>::RealUndefined();
   }
-  T result = std::floor(Random::random<T>()*(b+1.0-a)+a);
+  T result = std::floor(Random::random<T>()*(b+(T)1.0-a)+a);
   return Complex<T>::Builder(result);
 }
 

--- a/poincare/src/solver.cpp
+++ b/poincare/src/solver.cpp
@@ -230,11 +230,11 @@ T Solver::CumulativeDistributiveInverseForNDefinedFunction(T * probability, Valu
   do {
     delta = std::fabs(*probability-p);
     p += evaluation(k++, context, complexFormat, angleUnit, context1, context2, context3);
-    if (p >= k_maxProbability && std::fabs(*probability-1.0) <= delta) {
+    if (p >= k_maxProbability && std::fabs(*probability-(T)1.0) <= delta) {
       *probability = (T)1.0;
       return (T)(k-1);
     }
-  } while (std::fabs(*probability-p) <= delta && k < k_maxNumberOfOperations && p < 1.0);
+  } while (std::fabs(*probability-p) <= delta && k < k_maxNumberOfOperations && p < (T)1.0);
   p -= evaluation(--k, context, complexFormat, angleUnit, context1, context2, context3);
   if (k == k_maxNumberOfOperations) {
     *probability = (T)1.0;

--- a/poincare/src/trigonometry.cpp
+++ b/poincare/src/trigonometry.cpp
@@ -399,7 +399,7 @@ Expression Trigonometry::shallowReduceInverseFunction(Expression & e,  Expressio
 template <typename T>
 std::complex<T> Trigonometry::ConvertToRadian(const std::complex<T> c, Preferences::AngleUnit angleUnit) {
   if (angleUnit != Preferences::AngleUnit::Radian) {
-    return c * std::complex<T>(M_PI/Trigonometry::PiInAngleUnit(angleUnit));
+    return c * std::complex<T>((T)M_PI/(T)Trigonometry::PiInAngleUnit(angleUnit));
   }
   return c;
 }
@@ -407,7 +407,7 @@ std::complex<T> Trigonometry::ConvertToRadian(const std::complex<T> c, Preferenc
 template <typename T>
 std::complex<T> Trigonometry::ConvertRadianToAngleUnit(const std::complex<T> c, Preferences::AngleUnit angleUnit) {
   if (angleUnit != Preferences::AngleUnit::Radian) {
-    return c * std::complex<T>(Trigonometry::PiInAngleUnit(angleUnit)/M_PI);
+    return c * std::complex<T>((T)Trigonometry::PiInAngleUnit(angleUnit)/(T)M_PI);
   }
   return c;
 }
@@ -423,7 +423,7 @@ T Trigonometry::RoundToMeaningfulDigits(T result, T input) {
    * sin(1E-15)=1E-15.
    * We can't do that for all evaluation as the user can operate on values as
    * small as 1E-308 (in double) and most results still be correct. */
-  if (input == 0.0 || std::fabs(result/input) <= Expression::Epsilon<T>()) {
+  if (input == (T)0.0 || std::fabs(result/input) <= Expression::Epsilon<T>()) {
      T precision = 10*Expression::Epsilon<T>();
      result = std::round(result/precision)*precision;
   }

--- a/poincare/test/approximation.cpp
+++ b/poincare/test/approximation.cpp
@@ -575,9 +575,9 @@ QUIZ_CASE(poincare_approximation_trigonometry_functions) {
   assert_expression_approximates_to<double>("asin(0)", "0", Degree);
   assert_expression_approximates_to<double>("asin(0)", "0", Gradian);
   assert_expression_approximates_to<float>("asin(-1)", "-90", Degree, Cartesian, 6);
-  assert_expression_approximates_to<float>("asin(-1)", "-100", Gradian, Cartesian, 3);
+  assert_expression_approximates_to<float>("asin(-1)", "-100", Gradian, Cartesian, 6);
   assert_expression_approximates_to<double>("asin(1)", "90", Degree);
-  assert_expression_approximates_to<double>("asin(1)", "100", Gradian, Cartesian, 3);
+  assert_expression_approximates_to<double>("asin(1)", "100", Gradian, Cartesian);
 
   /* atan: R         ->  R (odd)
    *       [-𝐢,𝐢]    ->  R×𝐢 (odd)

--- a/poincare/test/approximation.cpp
+++ b/poincare/test/approximation.cpp
@@ -574,7 +574,7 @@ QUIZ_CASE(poincare_approximation_trigonometry_functions) {
   // Key values
   assert_expression_approximates_to<double>("asin(0)", "0", Degree);
   assert_expression_approximates_to<double>("asin(0)", "0", Gradian);
-  assert_expression_approximates_to<float>("asin(-1)", "-90", Degree);
+  assert_expression_approximates_to<float>("asin(-1)", "-90", Degree, Cartesian, 6);
   assert_expression_approximates_to<float>("asin(-1)", "-100", Gradian, Cartesian, 3);
   assert_expression_approximates_to<double>("asin(1)", "90", Degree);
   assert_expression_approximates_to<double>("asin(1)", "100", Gradian, Cartesian, 3);

--- a/python/port/mod/turtle/turtle.cpp
+++ b/python/port/mod/turtle/turtle.cpp
@@ -377,7 +377,7 @@ void Turtle::drawPaw(PawType type, PawPosition pos) {
   assert(m_underneathPixelBuffer != nullptr);
   KDCoordinate pawOffset = 5;
   constexpr float crawlOffset = 0.6f;
-  constexpr float angles[] = {M_PI_2/2, M_PI_2+M_PI_2/2, -M_PI_2-M_PI_2/2, -M_PI_2/2};
+  constexpr float angles[] = {M_PI_4, 3*M_PI_4, -3*M_PI_4, -M_PI_4};
 
   // Compute the paw offset from the turtle center
   float currentAngle = angles[(int) type];


### PR DESCRIPTION
This replaces unnecessary double-precision soft-float operations with
single-precision floating-point operations, mainly by casting.

In a couple places I also replace a function call with a constant.