### PR TITLE
[ion] Fix error check in the USB stack

### DIFF
--- a/ion/src/device/shared/usb/stack/endpoint0.cpp
+++ b/ion/src/device/shared/usb/stack/endpoint0.cpp
@@ -259,7 +259,7 @@ void Endpoint0::clearForOutTransactions(uint16_t wLength) {
   setOutNAK(false);
 }
 
-uint16_t Endpoint0::receiveSomeData() {
+int Endpoint0::receiveSomeData() {
   // If it is the first chunk of data to be received, m_transferBufferLength is 0.
   uint16_t packetSize = MIN(k_maxPacketSize, m_request.wLength() - m_transferBufferLength);
   uint16_t sizeOfPacketRead = readPacket(m_largeBuffer + m_transferBufferLength, packetSize);

--- a/ion/src/device/shared/usb/stack/endpoint0.h
+++ b/ion/src/device/shared/usb/stack/endpoint0.h
@@ -57,7 +57,7 @@ public:
   void clearForOutTransactions(uint16_t wLength);
 
 private:
-  uint16_t receiveSomeData();
+  int receiveSomeData();
   uint16_t readPacket(void * buffer, uint16_t length);
   uint16_t writePacket(const void * buffer, uint16_t length);
 


### PR DESCRIPTION
The return type of the function needs to be wider so the -1 error value
could fit.

Fixes #1335