### PR TITLE
[apps/statistics] EXE should open the histogram param controller

### DIFF
--- a/apps/statistics/histogram_controller.cpp
+++ b/apps/statistics/histogram_controller.cpp
@@ -42,7 +42,7 @@ const char * HistogramController::title() {
 
 bool HistogramController::handleEvent(Ion::Events::Event event) {
   assert(selectedSeriesIndex() >= 0);
-  if (event == Ion::Events::OK) {
+  if (event == Ion::Events::OK || event == Ion::Events::EXE) {
     stackController()->push(histogramParameterController());
     return true;
   }


### PR DESCRIPTION
The OK button already does it.