### PR TITLE
[apps/interactive_curve_view_range] Recompute yRange after setDefault

### DIFF
--- a/apps/shared/interactive_curve_view_range.cpp
+++ b/apps/shared/interactive_curve_view_range.cpp
@@ -131,9 +131,9 @@ void InteractiveCurveViewRange::setDefault() {
     return;
   }
   if (!m_delegate->defautRangeIsNormalized()) {
+    m_yAuto = true;
     m_xRange.setMax(m_delegate->interestingXHalfRange(), k_lowerMaxFloat, k_upperMaxFloat);
     setXMin(-xMax());
-    m_yAuto = true;
     return;
   }
 


### PR DESCRIPTION
Scenario : f(x)=8x, scroll to the right until the window range has
changed, then set the preadjustment to default -> the x change had no
impact on the yRange because we did not set the yAuto before doing the
changes.