### PR TITLE
Regression round cursor view bug

### DIFF
--- a/apps/regression/graph_controller.cpp
+++ b/apps/regression/graph_controller.cpp
@@ -87,10 +87,6 @@ void GraphController::viewWillAppear() {
   setRoundCrossCursorView(*m_selectedDotIndex < 0);
 }
 
-void GraphController::selectRegressionCurve() {
-  *m_selectedDotIndex = -1;
-}
-
 // Private
 
 Poincare::Context * GraphController::globalContext() {

--- a/apps/regression/graph_controller.cpp
+++ b/apps/regression/graph_controller.cpp
@@ -84,11 +84,7 @@ void GraphController::viewWillAppear() {
 
   /* Since *m_selectedDotIndex is altered by initCursorParameters(),
    * the following must absolutely come at the end. */
-  if (*m_selectedDotIndex >= 0) {
-    setRoundCrossCursorView(false);
-  } else {
-    setRoundCrossCursorView(true);
-  }
+  setRoundCrossCursorView(*m_selectedDotIndex < 0);
 }
 
 void GraphController::selectRegressionCurve() {

--- a/apps/regression/graph_controller.cpp
+++ b/apps/regression/graph_controller.cpp
@@ -313,6 +313,8 @@ bool GraphController::moveCursorVertically(int direction) {
 
   assert(!validDot || !validRegression);
 
+  /* The model should be up to date before setting the cursor view. */
+
   if (validRegression) {
     // Select the regression
     *m_selectedSeriesIndex = closestRegressionSeries;
@@ -324,9 +326,9 @@ bool GraphController::moveCursorVertically(int direction) {
 
   if (validDot) {
     // Select the dot
-    setRoundCrossCursorView(false);
     *m_selectedSeriesIndex = closestDotSeries;
     *m_selectedDotIndex = dotSelected;
+    setRoundCrossCursorView(false);
     if (dotSelected == m_store->numberOfPairsOfSeries(*m_selectedSeriesIndex)) {
       // Select the mean dot
       double x = m_store->meanOfColumn(*m_selectedSeriesIndex, 0);
@@ -395,6 +397,8 @@ InteractiveCurveViewRangeDelegate::Range GraphController::computeYRange(Interact
 }
 
 void GraphController::setRoundCrossCursorView(bool round) {
+  /* At this point, the model (selected series and dot indices) should be up
+   * to date. */
   if (round) {
     // Set the color although the cursor view stays round
     m_roundCursorView.setColor(Palette::DataColor[*m_selectedSeriesIndex]);

--- a/apps/regression/graph_controller.cpp
+++ b/apps/regression/graph_controller.cpp
@@ -89,7 +89,6 @@ void GraphController::viewWillAppear() {
 
 void GraphController::selectRegressionCurve() {
   *m_selectedDotIndex = -1;
-  setRoundCrossCursorView(true);
 }
 
 // Private

--- a/apps/regression/graph_controller.cpp
+++ b/apps/regression/graph_controller.cpp
@@ -88,14 +88,12 @@ void GraphController::viewWillAppear() {
     setRoundCrossCursorView(false);
   } else {
     setRoundCrossCursorView(true);
-    m_roundCursorView.setColor(Palette::DataColor[*m_selectedSeriesIndex]);
   }
 }
 
 void GraphController::selectRegressionCurve() {
   *m_selectedDotIndex = -1;
   setRoundCrossCursorView(true);
-  m_roundCursorView.setColor(Palette::DataColor[*m_selectedSeriesIndex]);
 }
 
 // Private
@@ -405,7 +403,12 @@ InteractiveCurveViewRangeDelegate::Range GraphController::computeYRange(Interact
 }
 
 void GraphController::setRoundCrossCursorView(bool round) {
+  if (round) {
+    // Set the color although the cursor view stays round
+    m_roundCursorView.setColor(Palette::DataColor[*m_selectedSeriesIndex]);
+  }
   CursorView * nextCursorView = round ? static_cast<Shared::CursorView *>(&m_roundCursorView) : static_cast<Shared::CursorView *>(&m_crossCursorView);
+  // Escape if the cursor view stays the same
   if (m_view.cursorView() == nextCursorView) {
     return;
   }

--- a/apps/regression/graph_controller.cpp
+++ b/apps/regression/graph_controller.cpp
@@ -84,7 +84,7 @@ void GraphController::viewWillAppear() {
 
   /* Since *m_selectedDotIndex is altered by initCursorParameters(),
    * the following must absolutely come at the end. */
-  setRoundCrossCursorView(*m_selectedDotIndex < 0);
+  setRoundCrossCursorView();
 }
 
 // Private
@@ -319,7 +319,7 @@ bool GraphController::moveCursorVertically(int direction) {
     // Select the regression
     *m_selectedSeriesIndex = closestRegressionSeries;
     *m_selectedDotIndex = -1;
-    setRoundCrossCursorView(true);
+    setRoundCrossCursorView();
     m_cursor->moveTo(x, x, yValue(*m_selectedSeriesIndex, x, context));
     return true;
   }
@@ -328,7 +328,7 @@ bool GraphController::moveCursorVertically(int direction) {
     // Select the dot
     *m_selectedSeriesIndex = closestDotSeries;
     *m_selectedDotIndex = dotSelected;
-    setRoundCrossCursorView(false);
+    setRoundCrossCursorView();
     if (dotSelected == m_store->numberOfPairsOfSeries(*m_selectedSeriesIndex)) {
       // Select the mean dot
       double x = m_store->meanOfColumn(*m_selectedSeriesIndex, 0);
@@ -396,9 +396,10 @@ InteractiveCurveViewRangeDelegate::Range GraphController::computeYRange(Interact
   return range;
 }
 
-void GraphController::setRoundCrossCursorView(bool round) {
+void GraphController::setRoundCrossCursorView() {
   /* At this point, the model (selected series and dot indices) should be up
    * to date. */
+  bool round = *m_selectedDotIndex < 0;
   if (round) {
     // Set the color although the cursor view stays round
     m_roundCursorView.setColor(Palette::DataColor[*m_selectedSeriesIndex]);

--- a/apps/regression/graph_controller.cpp
+++ b/apps/regression/graph_controller.cpp
@@ -321,7 +321,8 @@ bool GraphController::moveCursorVertically(int direction) {
   if (validRegression) {
     // Select the regression
     *m_selectedSeriesIndex = closestRegressionSeries;
-    selectRegressionCurve();
+    *m_selectedDotIndex = -1;
+    setRoundCrossCursorView(true);
     m_cursor->moveTo(x, x, yValue(*m_selectedSeriesIndex, x, context));
     return true;
   }

--- a/apps/regression/graph_controller.h
+++ b/apps/regression/graph_controller.h
@@ -21,7 +21,7 @@ public:
   bool isEmpty() const override;
   I18n::Message emptyMessage() override;
   void viewWillAppear() override;
-  void selectRegressionCurve();
+  void selectRegressionCurve() { *m_selectedDotIndex = -1; }
   int selectedSeriesIndex() const { return *m_selectedSeriesIndex; }
 
   // moveCursorHorizontally and Vertically are public to be used in tests

--- a/apps/regression/graph_controller.h
+++ b/apps/regression/graph_controller.h
@@ -55,7 +55,7 @@ private:
   // InteractiveCurveViewRangeDelegate
   Shared::InteractiveCurveViewRangeDelegate::Range computeYRange(Shared::InteractiveCurveViewRange * interactiveCurveViewRange) override;
 
-  void setRoundCrossCursorView(bool round);
+  void setRoundCrossCursorView();
   Shared::CursorView m_crossCursorView;
   Shared::RoundCursorView m_roundCursorView;
   BannerView m_bannerView;


### PR DESCRIPTION
Fixes a bug in 'Prediction given X/Y' menu where the RoundCursorView's underneath pixels were drawn after text field finishes editing.

Scenario:
Enter a quite generic data
   X1  Y1
    1   0
    2   0
    3   0
In the graph view, select the regression curve and move the cursor as close as possible to the left or right edge of the view.
Press OK and enter the 'Prediction given X/Y' menu.
Alter the value in the text field, say 0.
Press the down arrow.
Observe that a piece of curve has been drawn.