### PR TITLE
[python/modion] Allow interruption of modion_keyboard_keydown

### DIFF
--- a/python/port/mod/ion/modion.cpp
+++ b/python/port/mod/ion/modion.cpp
@@ -9,5 +9,6 @@ extern "C" {
 mp_obj_t modion_keyboard_keydown(mp_obj_t key_o) {
   Ion::Keyboard::Key key = static_cast<Ion::Keyboard::Key>(mp_obj_get_int(key_o));
   Ion::Keyboard::State state = Ion::Keyboard::scan();
+  micropython_port_interrupt_if_needed();
   return mp_obj_new_bool(state.keyDown(key));
 }


### PR DESCRIPTION
So that an infinite loop of keydown can be interrupted