### PR TITLE
Fix poincare solver

### DIFF
--- a/poincare/include/poincare/expression.h
+++ b/poincare/include/poincare/expression.h
@@ -413,10 +413,8 @@ private:
   constexpr static double k_maxFloat = 1e100;
   Coordinate2D<double> nextMinimumOfExpression(const char * symbol, double start, double step, double max, Solver::ValueAtAbscissa evaluation, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit, const Expression expression = Expression(), bool lookForRootMinimum = false) const;
   void bracketMinimum(const char * symbol, double start, double step, double max, double result[3], Solver::ValueAtAbscissa evaluation, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit, const Expression expression = Expression()) const;
-  Coordinate2D<double> brentMinimum(const char * symbol, double ax, double bx, Solver::ValueAtAbscissa evaluation, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit, const Expression expression = Expression()) const;
   double nextIntersectionWithExpression(const char * symbol, double start, double step, double max, Solver::ValueAtAbscissa evaluation, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit, const Expression expression) const;
   void bracketRoot(const char * symbol, double start, double step, double max, double result[2], Solver::ValueAtAbscissa evaluation, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit, const Expression expression) const;
-  double brentRoot(const char * symbol, double ax, double bx, double precision, Solver::ValueAtAbscissa evaluation, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit, const Expression expression) const;
 };
 
 }

--- a/poincare/src/expression.cpp
+++ b/poincare/src/expression.cpp
@@ -1019,7 +1019,7 @@ Coordinate2D<double> Expression::nextMinimumOfExpression(const char * symbol, do
   bool endCondition = false;
   do {
     bracketMinimum(symbol, x, step, max, bracket, evaluate, context, complexFormat, angleUnit, expression);
-    result = brentMinimum(symbol, bracket[0], bracket[2], evaluate, context, complexFormat, angleUnit, expression);
+    result = Solver::BrentMinimum(bracket[0], bracket[2], evaluate, context, complexFormat, angleUnit, this, symbol, &expression);
     x = bracket[1];
     // Because of float approximation, exact zero is never reached
     if (std::fabs(result.x1()) < std::fabs(step)*k_solverPrecision) {
@@ -1077,19 +1077,6 @@ void Expression::bracketMinimum(const char * symbol, double start, double step, 
   result[2] = NAN;
 }
 
-Coordinate2D<double> Expression::brentMinimum(const char * symbol, double ax, double bx, Solver::ValueAtAbscissa evaluation, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit, const Expression expression) const {
-  return Solver::BrentMinimum(
-      ax,
-      bx,
-      evaluation,
-      context,
-      complexFormat,
-      angleUnit,
-      this,
-      symbol,
-      &expression);
-}
-
 double Expression::nextIntersectionWithExpression(const char * symbol, double start, double step, double max, Solver::ValueAtAbscissa evaluation, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit, const Expression expression) const {
   if (start == max || step == 0.0) {
     return NAN;
@@ -1100,7 +1087,7 @@ double Expression::nextIntersectionWithExpression(const char * symbol, double st
   double x = start+step;
   do {
     bracketRoot(symbol, x, step, max, bracket, evaluation, context, complexFormat, angleUnit, expression);
-    result = brentRoot(symbol, bracket[0], bracket[1], std::fabs(step/precisionByGradUnit), evaluation, context, complexFormat, angleUnit, expression);
+    result = Solver::BrentRoot(bracket[0], bracket[1], std::fabs(step/precisionByGradUnit), evaluation, context, complexFormat, angleUnit, this, symbol, &expression);
     x = bracket[1];
   } while (std::isnan(result) && (step > 0.0 ? x <= max : x >= max));
 
@@ -1147,20 +1134,6 @@ void Expression::bracketRoot(const char * symbol, double start, double step, dou
   }
   result[0] = NAN;
   result[1] = NAN;
-}
-
-double Expression::brentRoot(const char * symbol, double ax, double bx, double precision, Solver::ValueAtAbscissa evaluation, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit, const Expression expression) const {
-  return Solver::BrentRoot(
-      ax,
-      bx,
-      precision,
-      evaluation,
-      context,
-      complexFormat,
-      angleUnit,
-      this,
-      symbol,
-      &expression);
 }
 
 template float Expression::Epsilon<float>();

--- a/poincare/src/expression.cpp
+++ b/poincare/src/expression.cpp
@@ -1003,7 +1003,7 @@ Coordinate2D<double> Expression::nextIntersection(const char * symbol, double st
         return expression0->approximateWithValueForSymbol(symbol, x, context, complexFormat, angleUnit)-expression1->approximateWithValueForSymbol(symbol, x, context, complexFormat, angleUnit);
       }, context, complexFormat, angleUnit, expression);
   Coordinate2D<double> result(resultAbscissa, approximateWithValueForSymbol(symbol, resultAbscissa, context, complexFormat, angleUnit));
-  if (std::fabs(result.x2()) < step*k_solverPrecision) {
+  if (std::fabs(result.x2()) < std::fabs(step)*k_solverPrecision) {
     result.setX2(0.0);
   }
   return result;

--- a/poincare/src/solver.cpp
+++ b/poincare/src/solver.cpp
@@ -133,7 +133,7 @@ double Solver::BrentRoot(double ax, double bx, double precision, ValueAtAbscissa
     double xm = 0.5*(c-b);
     if (std::fabs(xm) <= tol1 || fb == 0.0) {
       double fbcMiddle = evaluation(0.5*(b+c), context, complexFormat, angleUnit, context1, context2, context3);
-      double isContinuous = (fb <= fbcMiddle && fbcMiddle <= fc) || (fc <= fbcMiddle && fbcMiddle <= fb);
+      bool isContinuous = (fb <= fbcMiddle && fbcMiddle <= fc) || (fc <= fbcMiddle && fbcMiddle <= fb);
       if (isContinuous) {
         return b;
       }

--- a/poincare/src/solver.cpp
+++ b/poincare/src/solver.cpp
@@ -138,7 +138,7 @@ double Solver::BrentRoot(double ax, double bx, double precision, ValueAtAbscissa
         return b;
       }
     }
-    if (std::fabs(e) >= tol1 && std::fabs(fa) > std::fabs(b)) {
+    if (std::fabs(e) >= tol1 && std::fabs(fa) > std::fabs(fb)) {
       double s = fb/fa;
       double p = 2.0*xm*s;
       double q = 1.0-s;
@@ -168,7 +168,7 @@ double Solver::BrentRoot(double ax, double bx, double precision, ValueAtAbscissa
     if (std::fabs(d) > tol1) {
       b += d;
     } else {
-      b += xm > 0.0 ? tol1 : tol1;
+      b += xm > 0.0 ? tol1 : -tol1;
     }
     fb = evaluation(b, context, complexFormat, angleUnit, context1, context2, context3);
   }

--- a/poincare/test/function_solver.cpp
+++ b/poincare/test/function_solver.cpp
@@ -26,9 +26,9 @@ void assert_next_extrema_are(
     Coordinate2D<double> * extrema,
     const char * expression,
     const char * symbol,
-    double start = -1.0,
-    double step = 0.1,
-    double max = 100.0,
+    double start,
+    double step,
+    double max,
     Preferences::ComplexFormat complexFormat = Preferences::ComplexFormat::Real,
     Preferences::AngleUnit angleUnit = Preferences::AngleUnit::Degree)
 {
@@ -75,13 +75,13 @@ QUIZ_CASE(poincare_function_extremum) {
       constexpr int numberOfMaxima = 1;
       Coordinate2D<double> maxima[numberOfMaxima] = {
         Coordinate2D<double>(NAN, NAN)};
-      assert_next_extrema_are(ExtremumType::Maximum, numberOfMaxima, maxima, "a^2", "a");
+      assert_next_extrema_are(ExtremumType::Maximum, numberOfMaxima, maxima, "a^2", "a", -1.0, 0.1, 100.0);
     }
     {
       constexpr int numberOfMinima = 1;
       Coordinate2D<double> minima[numberOfMinima] = {
         Coordinate2D<double>(0.0, 0.0)};
-      assert_next_extrema_are(ExtremumType::Minimum, numberOfMinima, minima, "a^2", "a");
+      assert_next_extrema_are(ExtremumType::Minimum, numberOfMinima, minima, "a^2", "a", -1.0, 0.1, 100.0);
     }
   }
   {
@@ -89,13 +89,13 @@ QUIZ_CASE(poincare_function_extremum) {
       constexpr int numberOfMaxima = 1;
       Coordinate2D<double> maxima[numberOfMaxima] = {
         Coordinate2D<double>(NAN, 3.0)};
-      assert_next_extrema_are(ExtremumType::Maximum, numberOfMaxima, maxima, "3", "a");
+      assert_next_extrema_are(ExtremumType::Maximum, numberOfMaxima, maxima, "3", "a", -1.0, 0.1, 100.0);
     }
     {
       constexpr int numberOfMinima = 1;
       Coordinate2D<double> minima[numberOfMinima] = {
         Coordinate2D<double>(NAN, 3.0)};
-      assert_next_extrema_are(ExtremumType::Minimum, numberOfMinima, minima, "3", "a");
+      assert_next_extrema_are(ExtremumType::Minimum, numberOfMinima, minima, "3", "a", -1.0, 0.1, 100.0);
     }
   }
   {
@@ -103,13 +103,13 @@ QUIZ_CASE(poincare_function_extremum) {
       constexpr int numberOfMaxima = 1;
       Coordinate2D<double> maxima[numberOfMaxima] = {
         Coordinate2D<double>(NAN, 0.0)};
-      assert_next_extrema_are(ExtremumType::Maximum, numberOfMaxima, maxima, "0", "a");
+      assert_next_extrema_are(ExtremumType::Maximum, numberOfMaxima, maxima, "0", "a", -1.0, 0.1, 100.0);
     }
     {
       constexpr int numberOfMinima = 1;
       Coordinate2D<double> minima[numberOfMinima] = {
         Coordinate2D<double>(NAN, 0.0)};
-      assert_next_extrema_are(ExtremumType::Minimum, numberOfMinima, minima, "0", "a");
+      assert_next_extrema_are(ExtremumType::Minimum, numberOfMinima, minima, "0", "a", -1.0, 0.1, 100.0);
     }
   }
 }
@@ -127,26 +127,26 @@ QUIZ_CASE(poincare_function_root) {
     constexpr int numberOfRoots = 1;
     Coordinate2D<double> roots[numberOfRoots] = {
       Coordinate2D<double>(0.0, 0.0)};
-    assert_next_extrema_are(ExtremumType::Root, numberOfRoots, roots, "a^2", "a");
+    assert_next_extrema_are(ExtremumType::Root, numberOfRoots, roots, "a^2", "a", -1.0, 0.1, 100.0);
   }
   {
     constexpr int numberOfRoots = 2;
     Coordinate2D<double> roots[numberOfRoots] = {
       Coordinate2D<double>(-2.0, 0.0),
       Coordinate2D<double>(2.0, 0.0)};
-    assert_next_extrema_are(ExtremumType::Root, numberOfRoots, roots, "a^2-4", "a", -5.0);
+    assert_next_extrema_are(ExtremumType::Root, numberOfRoots, roots, "a^2-4", "a", -5.0, 0.1, 100.0);
   }
   {
     constexpr int numberOfRoots = 1;
     Coordinate2D<double> roots[numberOfRoots] = {
       Coordinate2D<double>(NAN, 0.0)};
-    assert_next_extrema_are(ExtremumType::Root, numberOfRoots, roots, "3", "a");
+    assert_next_extrema_are(ExtremumType::Root, numberOfRoots, roots, "3", "a", -1.0, 0.1, 100.0);
   }
   {
     constexpr int numberOfRoots = 1;
     Coordinate2D<double> roots[numberOfRoots] = {
       Coordinate2D<double>(-0.9, 0.0)};
-    assert_next_extrema_are(ExtremumType::Root, numberOfRoots, roots, "0", "a");
+    assert_next_extrema_are(ExtremumType::Root, numberOfRoots, roots, "0", "a", -1.0, 0.1, 100.0);
   }
 }
 
@@ -156,9 +156,9 @@ void assert_next_intersections_are(
     Coordinate2D<double> * intersections,
     const char * expression,
     const char * symbol,
-    double start = -1.0,
-    double step = 0.1,
-    double max = 500.0,
+    double start,
+    double step,
+    double max,
     Preferences::ComplexFormat complexFormat = Preferences::ComplexFormat::Real,
     Preferences::AngleUnit angleUnit = Preferences::AngleUnit::Degree)
 {
@@ -182,14 +182,14 @@ QUIZ_CASE(poincare_function_intersection) {
     constexpr int numberOfIntersections = 1;
     Coordinate2D<double> intersections[numberOfIntersections] = {
       Coordinate2D<double>(NAN, NAN)};
-    assert_next_intersections_are("2", numberOfIntersections, intersections, "cos(a)", "a");
+    assert_next_intersections_are("2", numberOfIntersections, intersections, "cos(a)", "a", -1.0, 0.1, 500.0);
   }
   {
     constexpr int numberOfIntersections = 2;
     Coordinate2D<double> intersections[numberOfIntersections] = {
       Coordinate2D<double>(0.0, 1.0),
       Coordinate2D<double>(360.0, 1.0)};
-    assert_next_intersections_are("1", numberOfIntersections, intersections, "cos(a)", "a");
+    assert_next_intersections_are("1", numberOfIntersections, intersections, "cos(a)", "a", -1.0, 0.1, 500.0);
   }
   {
     constexpr int numberOfIntersections = 3;
@@ -197,6 +197,6 @@ QUIZ_CASE(poincare_function_intersection) {
       Coordinate2D<double>(90.0, 0.0),
       Coordinate2D<double>(270.0, 0.0),
       Coordinate2D<double>(450.0, 0.0)};
-    assert_next_intersections_are("0", numberOfIntersections, intersections, "cos(a)", "a");
+    assert_next_intersections_are("0", numberOfIntersections, intersections, "cos(a)", "a", -1.0, 0.1, 500.0);
   }
 }

--- a/poincare/test/function_solver.cpp
+++ b/poincare/test/function_solver.cpp
@@ -27,23 +27,23 @@ void assert_next_extrema_are(
     Coordinate2D<double> * extrema,
     Expression e,
     const char * symbol,
-    Context * context,
     double start = -1.0,
     double step = 0.1,
     double max = 100.0,
     Preferences::ComplexFormat complexFormat = Preferences::ComplexFormat::Real,
     Preferences::AngleUnit angleUnit = Preferences::AngleUnit::Degree)
 {
+  Shared::GlobalContext context;
   double currentStart = start;
   for (int i = 0; i < numberOfExtrema; i++) {
     quiz_assert_log_if_failure(!std::isnan(currentStart), e);
     Coordinate2D<double> nextExtrema;
     if (extremumType == ExtremumType::Maximum) {
-      nextExtrema = e.nextMaximum(symbol, currentStart, step, max, context, complexFormat, angleUnit);
+      nextExtrema = e.nextMaximum(symbol, currentStart, step, max, &context, complexFormat, angleUnit);
     } else if (extremumType == ExtremumType::Minimum) {
-      nextExtrema = e.nextMinimum(symbol, currentStart, step, max, context, complexFormat, angleUnit);
+      nextExtrema = e.nextMinimum(symbol, currentStart, step, max, &context, complexFormat, angleUnit);
     } else if (extremumType == ExtremumType::Root) {
-      nextExtrema = Coordinate2D<double>(e.nextRoot(symbol, currentStart, step, max, context, complexFormat, angleUnit), 0.0 );
+      nextExtrema = Coordinate2D<double>(e.nextRoot(symbol, currentStart, step, max, &context, complexFormat, angleUnit), 0.0 );
     }
     currentStart = nextExtrema.x1() + step;
     quiz_assert_log_if_failure(
@@ -56,7 +56,6 @@ void assert_next_extrema_are(
 QUIZ_CASE(poincare_function_extremum) {
   const char * symbol = "a";
   int symbolLength = strlen(symbol);
-  Shared::GlobalContext globalContext;
   {
     // cos
     Expression e = Cosine::Builder(Symbol::Builder(symbol, symbolLength));
@@ -66,13 +65,13 @@ QUIZ_CASE(poincare_function_extremum) {
         Coordinate2D<double>(0.0, 1.0),
         Coordinate2D<double>(360.0, 1.0),
         Coordinate2D<double>(NAN, NAN)};
-      assert_next_extrema_are(ExtremumType::Maximum, numberOfMaxima, maxima, e, symbol, &globalContext, -1.0, 0.1, 500.0);
+      assert_next_extrema_are(ExtremumType::Maximum, numberOfMaxima, maxima, e, symbol, -1.0, 0.1, 500.0);
     }
     {
       constexpr int numberOfMinima = 1;
       Coordinate2D<double> minima[numberOfMinima] = {
         Coordinate2D<double>(180.0, -1.0)};
-      assert_next_extrema_are(ExtremumType::Minimum, numberOfMinima, minima, e, symbol, &globalContext, 0.0, 0.1, 300.0);
+      assert_next_extrema_are(ExtremumType::Minimum, numberOfMinima, minima, e, symbol, 0.0, 0.1, 300.0);
     }
   }
   {
@@ -82,13 +81,13 @@ QUIZ_CASE(poincare_function_extremum) {
       constexpr int numberOfMaxima = 1;
       Coordinate2D<double> maxima[numberOfMaxima] = {
         Coordinate2D<double>(NAN, NAN)};
-      assert_next_extrema_are(ExtremumType::Maximum, numberOfMaxima, maxima, e, symbol, &globalContext);
+      assert_next_extrema_are(ExtremumType::Maximum, numberOfMaxima, maxima, e, symbol);
     }
     {
       constexpr int numberOfMinima = 1;
       Coordinate2D<double> minima[numberOfMinima] = {
         Coordinate2D<double>(0.0, 0.0)};
-      assert_next_extrema_are(ExtremumType::Minimum, numberOfMinima, minima, e, symbol, &globalContext);
+      assert_next_extrema_are(ExtremumType::Minimum, numberOfMinima, minima, e, symbol);
     }
   }
 
@@ -99,13 +98,13 @@ QUIZ_CASE(poincare_function_extremum) {
       constexpr int numberOfMaxima = 1;
       Coordinate2D<double> maxima[numberOfMaxima] = {
         Coordinate2D<double>(NAN, 3.0)};
-      assert_next_extrema_are(ExtremumType::Maximum, numberOfMaxima, maxima, e, symbol, &globalContext);
+      assert_next_extrema_are(ExtremumType::Maximum, numberOfMaxima, maxima, e, symbol);
     }
     {
       constexpr int numberOfMinima = 1;
       Coordinate2D<double> minima[numberOfMinima] = {
         Coordinate2D<double>(NAN, 3.0)};
-      assert_next_extrema_are(ExtremumType::Minimum, numberOfMinima, minima, e, symbol, &globalContext);
+      assert_next_extrema_are(ExtremumType::Minimum, numberOfMinima, minima, e, symbol);
     }
   }
 
@@ -116,13 +115,13 @@ QUIZ_CASE(poincare_function_extremum) {
       constexpr int numberOfMaxima = 1;
       Coordinate2D<double> maxima[numberOfMaxima] = {
         Coordinate2D<double>(NAN, 0.0)};
-      assert_next_extrema_are(ExtremumType::Maximum, numberOfMaxima, maxima, e, symbol, &globalContext);
+      assert_next_extrema_are(ExtremumType::Maximum, numberOfMaxima, maxima, e, symbol);
     }
     {
       constexpr int numberOfMinima = 1;
       Coordinate2D<double> minima[numberOfMinima] = {
         Coordinate2D<double>(NAN, 0.0)};
-      assert_next_extrema_are(ExtremumType::Minimum, numberOfMinima, minima, e, symbol, &globalContext);
+      assert_next_extrema_are(ExtremumType::Minimum, numberOfMinima, minima, e, symbol);
     }
   }
 }
@@ -130,7 +129,6 @@ QUIZ_CASE(poincare_function_extremum) {
 QUIZ_CASE(poincare_function_root) {
   const char * symbol = "a";
   int symbolLength = strlen(symbol);
-  Shared::GlobalContext globalContext;
   {
     // cos
     Expression e = Cosine::Builder(Symbol::Builder(symbol, symbolLength));
@@ -139,7 +137,7 @@ QUIZ_CASE(poincare_function_root) {
       Coordinate2D<double>(90.0, 0.0),
       Coordinate2D<double>(270.0, 0.0),
       Coordinate2D<double>(450.0, 0.0)};
-    assert_next_extrema_are(ExtremumType::Root, numberOfRoots, roots, e, symbol, &globalContext, 0.0, 0.1, 500.0);
+    assert_next_extrema_are(ExtremumType::Root, numberOfRoots, roots, e, symbol, 0.0, 0.1, 500.0);
   }
   {
     // x^2
@@ -147,7 +145,7 @@ QUIZ_CASE(poincare_function_root) {
     constexpr int numberOfRoots = 1;
     Coordinate2D<double> roots[numberOfRoots] = {
       Coordinate2D<double>(0.0, 0.0)};
-    assert_next_extrema_are(ExtremumType::Root, numberOfRoots, roots, e, symbol, &globalContext);
+    assert_next_extrema_are(ExtremumType::Root, numberOfRoots, roots, e, symbol);
   }
   {
     // x^2-4
@@ -156,7 +154,7 @@ QUIZ_CASE(poincare_function_root) {
     Coordinate2D<double> roots[numberOfRoots] = {
       Coordinate2D<double>(-2.0, 0.0),
       Coordinate2D<double>(2.0, 0.0)};
-    assert_next_extrema_are(ExtremumType::Root, numberOfRoots, roots, e, symbol, &globalContext, -5.0);
+    assert_next_extrema_are(ExtremumType::Root, numberOfRoots, roots, e, symbol, -5.0);
   }
   {
     // 3
@@ -164,7 +162,7 @@ QUIZ_CASE(poincare_function_root) {
     constexpr int numberOfRoots = 1;
     Coordinate2D<double> roots[numberOfRoots] = {
       Coordinate2D<double>(NAN, 0.0)};
-    assert_next_extrema_are(ExtremumType::Root, numberOfRoots, roots, e, symbol, &globalContext);
+    assert_next_extrema_are(ExtremumType::Root, numberOfRoots, roots, e, symbol);
   }
 
   {
@@ -173,7 +171,7 @@ QUIZ_CASE(poincare_function_root) {
     constexpr int numberOfRoots = 1;
     Coordinate2D<double> roots[numberOfRoots] = {
       Coordinate2D<double>(-0.9, 0.0)};
-    assert_next_extrema_are(ExtremumType::Root, numberOfRoots, roots, e, symbol, &globalContext);
+    assert_next_extrema_are(ExtremumType::Root, numberOfRoots, roots, e, symbol);
   }
 
 }
@@ -184,17 +182,17 @@ void assert_next_intersections_are(
     Coordinate2D<double> * intersections,
     Expression e,
     const char * symbol,
-    Context * context,
     double start = -1.0,
     double step = 0.1,
     double max = 500.0,
     Preferences::ComplexFormat complexFormat = Preferences::ComplexFormat::Real,
     Preferences::AngleUnit angleUnit = Preferences::AngleUnit::Degree)
 {
+  Shared::GlobalContext context;
   double currentStart = start;
   for (int i = 0; i < numberOfIntersections; i++) {
     quiz_assert_log_if_failure(!std::isnan(currentStart), e);
-    Coordinate2D<double> nextIntersection = e.nextIntersection(symbol, currentStart, step, max, context, complexFormat, angleUnit, otherExpression);
+    Coordinate2D<double> nextIntersection = e.nextIntersection(symbol, currentStart, step, max, &context, complexFormat, angleUnit, otherExpression);
     currentStart = nextIntersection.x1() + step;
     quiz_assert_log_if_failure(
         (doubles_are_approximately_equal(intersections[i].x1(), nextIntersection.x1()))
@@ -205,7 +203,6 @@ void assert_next_intersections_are(
 QUIZ_CASE(poincare_function_intersection) {
   const char * symbol = "a";
   int symbolLength = strlen(symbol);
-  Shared::GlobalContext globalContext;
   Expression e = Cosine::Builder(Symbol::Builder(symbol, symbolLength));
 
   {
@@ -214,7 +211,7 @@ QUIZ_CASE(poincare_function_intersection) {
     constexpr int numberOfIntersections = 1;
     Coordinate2D<double> intersections[numberOfIntersections] = {
       Coordinate2D<double>(NAN, NAN)};
-    assert_next_intersections_are(otherExpression, numberOfIntersections, intersections, e, symbol, &globalContext);
+    assert_next_intersections_are(otherExpression, numberOfIntersections, intersections, e, symbol);
   }
 
   {
@@ -224,7 +221,7 @@ QUIZ_CASE(poincare_function_intersection) {
     Coordinate2D<double> intersections[numberOfIntersections] = {
       Coordinate2D<double>(0.0, 1.0),
       Coordinate2D<double>(360.0, 1.0)};
-    assert_next_intersections_are(otherExpression, numberOfIntersections, intersections, e, symbol, &globalContext);
+    assert_next_intersections_are(otherExpression, numberOfIntersections, intersections, e, symbol);
   }
 
   {
@@ -235,6 +232,6 @@ QUIZ_CASE(poincare_function_intersection) {
       Coordinate2D<double>(90.0, 0.0),
       Coordinate2D<double>(270.0, 0.0),
       Coordinate2D<double>(450.0, 0.0)};
-    assert_next_intersections_are(otherExpression, numberOfIntersections, intersections, e, symbol, &globalContext);
+    assert_next_intersections_are(otherExpression, numberOfIntersections, intersections, e, symbol);
   }
 }

--- a/poincare/test/function_solver.cpp
+++ b/poincare/test/function_solver.cpp
@@ -1,5 +1,4 @@
 #include <apps/shared/global_context.h>
-#include <poincare/expression.h>
 #include "helper.h"
 
 using namespace Poincare;
@@ -25,7 +24,7 @@ void assert_next_extrema_are(
     ExtremumType extremumType,
     int numberOfExtrema,
     Coordinate2D<double> * extrema,
-    Expression e,
+    const char * expression,
     const char * symbol,
     double start = -1.0,
     double step = 0.1,
@@ -34,6 +33,7 @@ void assert_next_extrema_are(
     Preferences::AngleUnit angleUnit = Preferences::AngleUnit::Degree)
 {
   Shared::GlobalContext context;
+  Poincare::Expression e = parse_expression(expression, &context, false);
   double currentStart = start;
   for (int i = 0; i < numberOfExtrema; i++) {
     quiz_assert_log_if_failure(!std::isnan(currentStart), e);
@@ -54,133 +54,107 @@ void assert_next_extrema_are(
 }
 
 QUIZ_CASE(poincare_function_extremum) {
-  const char * symbol = "a";
-  int symbolLength = strlen(symbol);
   {
-    // cos
-    Expression e = Cosine::Builder(Symbol::Builder(symbol, symbolLength));
     {
       constexpr int numberOfMaxima = 3;
       Coordinate2D<double> maxima[numberOfMaxima] = {
         Coordinate2D<double>(0.0, 1.0),
         Coordinate2D<double>(360.0, 1.0),
         Coordinate2D<double>(NAN, NAN)};
-      assert_next_extrema_are(ExtremumType::Maximum, numberOfMaxima, maxima, e, symbol, -1.0, 0.1, 500.0);
+      assert_next_extrema_are(ExtremumType::Maximum, numberOfMaxima, maxima, "cos(a)", "a", -1.0, 0.1, 500.0);
     }
     {
       constexpr int numberOfMinima = 1;
       Coordinate2D<double> minima[numberOfMinima] = {
         Coordinate2D<double>(180.0, -1.0)};
-      assert_next_extrema_are(ExtremumType::Minimum, numberOfMinima, minima, e, symbol, 0.0, 0.1, 300.0);
+      assert_next_extrema_are(ExtremumType::Minimum, numberOfMinima, minima, "cos(a)", "a", 0.0, 0.1, 300.0);
     }
   }
   {
-    // x^2
-    Expression e = Power::Builder(Symbol::Builder(symbol, symbolLength), Rational::Builder(2));
     {
       constexpr int numberOfMaxima = 1;
       Coordinate2D<double> maxima[numberOfMaxima] = {
         Coordinate2D<double>(NAN, NAN)};
-      assert_next_extrema_are(ExtremumType::Maximum, numberOfMaxima, maxima, e, symbol);
+      assert_next_extrema_are(ExtremumType::Maximum, numberOfMaxima, maxima, "a^2", "a");
     }
     {
       constexpr int numberOfMinima = 1;
       Coordinate2D<double> minima[numberOfMinima] = {
         Coordinate2D<double>(0.0, 0.0)};
-      assert_next_extrema_are(ExtremumType::Minimum, numberOfMinima, minima, e, symbol);
+      assert_next_extrema_are(ExtremumType::Minimum, numberOfMinima, minima, "a^2", "a");
     }
   }
-
   {
-    // 3
-    Expression e = Rational::Builder(3);
     {
       constexpr int numberOfMaxima = 1;
       Coordinate2D<double> maxima[numberOfMaxima] = {
         Coordinate2D<double>(NAN, 3.0)};
-      assert_next_extrema_are(ExtremumType::Maximum, numberOfMaxima, maxima, e, symbol);
+      assert_next_extrema_are(ExtremumType::Maximum, numberOfMaxima, maxima, "3", "a");
     }
     {
       constexpr int numberOfMinima = 1;
       Coordinate2D<double> minima[numberOfMinima] = {
         Coordinate2D<double>(NAN, 3.0)};
-      assert_next_extrema_are(ExtremumType::Minimum, numberOfMinima, minima, e, symbol);
+      assert_next_extrema_are(ExtremumType::Minimum, numberOfMinima, minima, "3", "a");
     }
   }
-
   {
-    // 0
-    Expression e = Rational::Builder(0);
     {
       constexpr int numberOfMaxima = 1;
       Coordinate2D<double> maxima[numberOfMaxima] = {
         Coordinate2D<double>(NAN, 0.0)};
-      assert_next_extrema_are(ExtremumType::Maximum, numberOfMaxima, maxima, e, symbol);
+      assert_next_extrema_are(ExtremumType::Maximum, numberOfMaxima, maxima, "0", "a");
     }
     {
       constexpr int numberOfMinima = 1;
       Coordinate2D<double> minima[numberOfMinima] = {
         Coordinate2D<double>(NAN, 0.0)};
-      assert_next_extrema_are(ExtremumType::Minimum, numberOfMinima, minima, e, symbol);
+      assert_next_extrema_are(ExtremumType::Minimum, numberOfMinima, minima, "0", "a");
     }
   }
 }
 
 QUIZ_CASE(poincare_function_root) {
-  const char * symbol = "a";
-  int symbolLength = strlen(symbol);
   {
-    // cos
-    Expression e = Cosine::Builder(Symbol::Builder(symbol, symbolLength));
     constexpr int numberOfRoots = 3;
     Coordinate2D<double> roots[numberOfRoots] = {
       Coordinate2D<double>(90.0, 0.0),
       Coordinate2D<double>(270.0, 0.0),
       Coordinate2D<double>(450.0, 0.0)};
-    assert_next_extrema_are(ExtremumType::Root, numberOfRoots, roots, e, symbol, 0.0, 0.1, 500.0);
+    assert_next_extrema_are(ExtremumType::Root, numberOfRoots, roots, "cos(a)", "a", 0.0, 0.1, 500.0);
   }
   {
-    // x^2
-    Expression e = Power::Builder(Symbol::Builder(symbol, symbolLength), Rational::Builder(2));
     constexpr int numberOfRoots = 1;
     Coordinate2D<double> roots[numberOfRoots] = {
       Coordinate2D<double>(0.0, 0.0)};
-    assert_next_extrema_are(ExtremumType::Root, numberOfRoots, roots, e, symbol);
+    assert_next_extrema_are(ExtremumType::Root, numberOfRoots, roots, "a^2", "a");
   }
   {
-    // x^2-4
-    Expression e = Subtraction::Builder(Power::Builder(Symbol::Builder(symbol, symbolLength), Rational::Builder(2)), Rational::Builder(4));
     constexpr int numberOfRoots = 2;
     Coordinate2D<double> roots[numberOfRoots] = {
       Coordinate2D<double>(-2.0, 0.0),
       Coordinate2D<double>(2.0, 0.0)};
-    assert_next_extrema_are(ExtremumType::Root, numberOfRoots, roots, e, symbol, -5.0);
+    assert_next_extrema_are(ExtremumType::Root, numberOfRoots, roots, "a^2-4", "a", -5.0);
   }
   {
-    // 3
-    Expression e = Rational::Builder(3);
     constexpr int numberOfRoots = 1;
     Coordinate2D<double> roots[numberOfRoots] = {
       Coordinate2D<double>(NAN, 0.0)};
-    assert_next_extrema_are(ExtremumType::Root, numberOfRoots, roots, e, symbol);
+    assert_next_extrema_are(ExtremumType::Root, numberOfRoots, roots, "3", "a");
   }
-
   {
-    // 0
-    Expression e = Rational::Builder(0);
     constexpr int numberOfRoots = 1;
     Coordinate2D<double> roots[numberOfRoots] = {
       Coordinate2D<double>(-0.9, 0.0)};
-    assert_next_extrema_are(ExtremumType::Root, numberOfRoots, roots, e, symbol);
+    assert_next_extrema_are(ExtremumType::Root, numberOfRoots, roots, "0", "a");
   }
-
 }
 
 void assert_next_intersections_are(
-    Expression otherExpression,
+    const char * otherExpression,
     int numberOfIntersections,
     Coordinate2D<double> * intersections,
-    Expression e,
+    const char * expression,
     const char * symbol,
     double start = -1.0,
     double step = 0.1,
@@ -189,10 +163,12 @@ void assert_next_intersections_are(
     Preferences::AngleUnit angleUnit = Preferences::AngleUnit::Degree)
 {
   Shared::GlobalContext context;
+  Poincare::Expression e = parse_expression(expression, &context, false);
+  Poincare::Expression other = parse_expression(otherExpression, &context, false);
   double currentStart = start;
   for (int i = 0; i < numberOfIntersections; i++) {
     quiz_assert_log_if_failure(!std::isnan(currentStart), e);
-    Coordinate2D<double> nextIntersection = e.nextIntersection(symbol, currentStart, step, max, &context, complexFormat, angleUnit, otherExpression);
+    Coordinate2D<double> nextIntersection = e.nextIntersection(symbol, currentStart, step, max, &context, complexFormat, angleUnit, other);
     currentStart = nextIntersection.x1() + step;
     quiz_assert_log_if_failure(
         (doubles_are_approximately_equal(intersections[i].x1(), nextIntersection.x1()))
@@ -200,38 +176,27 @@ void assert_next_intersections_are(
         e);
   }
 }
-QUIZ_CASE(poincare_function_intersection) {
-  const char * symbol = "a";
-  int symbolLength = strlen(symbol);
-  Expression e = Cosine::Builder(Symbol::Builder(symbol, symbolLength));
 
+QUIZ_CASE(poincare_function_intersection) {
   {
-    // cos with y=2
-    Expression otherExpression = Rational::Builder(2);
     constexpr int numberOfIntersections = 1;
     Coordinate2D<double> intersections[numberOfIntersections] = {
       Coordinate2D<double>(NAN, NAN)};
-    assert_next_intersections_are(otherExpression, numberOfIntersections, intersections, e, symbol);
+    assert_next_intersections_are("2", numberOfIntersections, intersections, "cos(a)", "a");
   }
-
   {
-    // cos with y=1
-    Expression otherExpression = Rational::Builder(1);
     constexpr int numberOfIntersections = 2;
     Coordinate2D<double> intersections[numberOfIntersections] = {
       Coordinate2D<double>(0.0, 1.0),
       Coordinate2D<double>(360.0, 1.0)};
-    assert_next_intersections_are(otherExpression, numberOfIntersections, intersections, e, symbol);
+    assert_next_intersections_are("1", numberOfIntersections, intersections, "cos(a)", "a");
   }
-
   {
-    // cos with y=0
-    Expression otherExpression = Rational::Builder(0);
     constexpr int numberOfIntersections = 3;
     Coordinate2D<double> intersections[numberOfIntersections] = {
       Coordinate2D<double>(90.0, 0.0),
       Coordinate2D<double>(270.0, 0.0),
       Coordinate2D<double>(450.0, 0.0)};
-    assert_next_intersections_are(otherExpression, numberOfIntersections, intersections, e, symbol);
+    assert_next_intersections_are("0", numberOfIntersections, intersections, "cos(a)", "a");
   }
 }

--- a/poincare/test/function_solver.cpp
+++ b/poincare/test/function_solver.cpp
@@ -72,10 +72,24 @@ QUIZ_CASE(poincare_function_extremum) {
       assert_points_of_interest_are(PointOfInterestType::Maximum, numberOfMaxima, maxima, "cos(a)", nullptr, "a", -1.0, 0.1, 500.0);
     }
     {
+      constexpr int numberOfMaxima = 3;
+      Coordinate2D<double> maxima[numberOfMaxima] = {
+        Coordinate2D<double>(360.0, 1.0),
+        Coordinate2D<double>(0.0, 1.0),
+        Coordinate2D<double>(NAN, NAN)};
+      assert_points_of_interest_are(PointOfInterestType::Maximum, numberOfMaxima, maxima, "cos(a)", nullptr, "a", 500.0, -0.1, -1.0);
+    }
+    {
       constexpr int numberOfMinima = 1;
       Coordinate2D<double> minima[numberOfMinima] = {
         Coordinate2D<double>(180.0, -1.0)};
       assert_points_of_interest_are(PointOfInterestType::Minimum, numberOfMinima, minima, "cos(a)", nullptr, "a", 0.0, 0.1, 300.0);
+    }
+    {
+      constexpr int numberOfMinima = 1;
+      Coordinate2D<double> minima[numberOfMinima] = {
+        Coordinate2D<double>(180.0, -1.0)};
+      assert_points_of_interest_are(PointOfInterestType::Minimum, numberOfMinima, minima, "cos(a)", nullptr, "a", 300.0, -0.1, 0.0);
     }
   }
   {
@@ -86,10 +100,22 @@ QUIZ_CASE(poincare_function_extremum) {
       assert_points_of_interest_are(PointOfInterestType::Maximum, numberOfMaxima, maxima, "a^2", nullptr, "a", -1.0, 0.1, 100.0);
     }
     {
+      constexpr int numberOfMaxima = 1;
+      Coordinate2D<double> maxima[numberOfMaxima] = {
+        Coordinate2D<double>(NAN, NAN)};
+      assert_points_of_interest_are(PointOfInterestType::Maximum, numberOfMaxima, maxima, "a^2", nullptr, "a", 100.0, -0.1, -1.0);
+    }
+    {
       constexpr int numberOfMinima = 1;
       Coordinate2D<double> minima[numberOfMinima] = {
         Coordinate2D<double>(0.0, 0.0)};
       assert_points_of_interest_are(PointOfInterestType::Minimum, numberOfMinima, minima, "a^2", nullptr, "a", -1.0, 0.1, 100.0);
+    }
+    {
+      constexpr int numberOfMinima = 1;
+      Coordinate2D<double> minima[numberOfMinima] = {
+        Coordinate2D<double>(0.0, 0.0)};
+      assert_points_of_interest_are(PointOfInterestType::Minimum, numberOfMinima, minima, "a^2", nullptr, "a", 100.0, -0.1, -1.0);
     }
   }
   {
@@ -100,10 +126,22 @@ QUIZ_CASE(poincare_function_extremum) {
       assert_points_of_interest_are(PointOfInterestType::Maximum, numberOfMaxima, maxima, "3", nullptr, "a", -1.0, 0.1, 100.0);
     }
     {
+      constexpr int numberOfMaxima = 1;
+      Coordinate2D<double> maxima[numberOfMaxima] = {
+        Coordinate2D<double>(NAN, 3.0)};
+      assert_points_of_interest_are(PointOfInterestType::Maximum, numberOfMaxima, maxima, "3", nullptr, "a", 100.0, -0.1, -1.0);
+    }
+    {
       constexpr int numberOfMinima = 1;
       Coordinate2D<double> minima[numberOfMinima] = {
         Coordinate2D<double>(NAN, 3.0)};
       assert_points_of_interest_are(PointOfInterestType::Minimum, numberOfMinima, minima, "3", nullptr, "a", -1.0, 0.1, 100.0);
+    }
+    {
+      constexpr int numberOfMinima = 1;
+      Coordinate2D<double> minima[numberOfMinima] = {
+        Coordinate2D<double>(NAN, 3.0)};
+      assert_points_of_interest_are(PointOfInterestType::Minimum, numberOfMinima, minima, "3", nullptr, "a", 100.0, -0.1, -1.0);
     }
   }
   {
@@ -114,10 +152,22 @@ QUIZ_CASE(poincare_function_extremum) {
       assert_points_of_interest_are(PointOfInterestType::Maximum, numberOfMaxima, maxima, "0", nullptr, "a", -1.0, 0.1, 100.0);
     }
     {
+      constexpr int numberOfMaxima = 1;
+      Coordinate2D<double> maxima[numberOfMaxima] = {
+        Coordinate2D<double>(NAN, 0.0)};
+      assert_points_of_interest_are(PointOfInterestType::Maximum, numberOfMaxima, maxima, "0", nullptr, "a", 100.0, -0.1, -1.0);
+    }
+    {
       constexpr int numberOfMinima = 1;
       Coordinate2D<double> minima[numberOfMinima] = {
         Coordinate2D<double>(NAN, 0.0)};
       assert_points_of_interest_are(PointOfInterestType::Minimum, numberOfMinima, minima, "0", nullptr, "a", -1.0, 0.1, 100.0);
+    }
+    {
+      constexpr int numberOfMinima = 1;
+      Coordinate2D<double> minima[numberOfMinima] = {
+        Coordinate2D<double>(NAN, 0.0)};
+      assert_points_of_interest_are(PointOfInterestType::Minimum, numberOfMinima, minima, "0", nullptr, "a", 100.0, -0.1, -1.0);
     }
   }
 }
@@ -132,10 +182,24 @@ QUIZ_CASE(poincare_function_root) {
     assert_points_of_interest_are(PointOfInterestType::Root, numberOfRoots, roots, "cos(a)", nullptr, "a", 0.0, 0.1, 500.0);
   }
   {
+    constexpr int numberOfRoots = 3;
+    Coordinate2D<double> roots[numberOfRoots] = {
+      Coordinate2D<double>(450.0, 0.0),
+      Coordinate2D<double>(270.0, 0.0),
+      Coordinate2D<double>(90.0, 0.0)};
+    assert_points_of_interest_are(PointOfInterestType::Root, numberOfRoots, roots, "cos(a)", nullptr, "a", 500.0, -0.1, 0.0);
+  }
+  {
     constexpr int numberOfRoots = 1;
     Coordinate2D<double> roots[numberOfRoots] = {
       Coordinate2D<double>(0.0, 0.0)};
     assert_points_of_interest_are(PointOfInterestType::Root, numberOfRoots, roots, "a^2", nullptr, "a", -1.0, 0.1, 100.0);
+  }
+  {
+    constexpr int numberOfRoots = 1;
+    Coordinate2D<double> roots[numberOfRoots] = {
+      Coordinate2D<double>(0.0, 0.0)};
+    assert_points_of_interest_are(PointOfInterestType::Root, numberOfRoots, roots, "a^2", nullptr, "a", 100.0, -0.1, -1.0);
   }
   {
     constexpr int numberOfRoots = 2;
@@ -143,6 +207,13 @@ QUIZ_CASE(poincare_function_root) {
       Coordinate2D<double>(-2.0, 0.0),
       Coordinate2D<double>(2.0, 0.0)};
     assert_points_of_interest_are(PointOfInterestType::Root, numberOfRoots, roots, "a^2-4", nullptr, "a", -5.0, 0.1, 100.0);
+  }
+  {
+    constexpr int numberOfRoots = 2;
+    Coordinate2D<double> roots[numberOfRoots] = {
+      Coordinate2D<double>(2.0, 0.0),
+      Coordinate2D<double>(-2.0, 0.0)};
+    assert_points_of_interest_are(PointOfInterestType::Root, numberOfRoots, roots, "a^2-4", nullptr, "a", 100.0, -0.1, -5.0);
   }
   {
     constexpr int numberOfRoots = 1;
@@ -153,8 +224,20 @@ QUIZ_CASE(poincare_function_root) {
   {
     constexpr int numberOfRoots = 1;
     Coordinate2D<double> roots[numberOfRoots] = {
+      Coordinate2D<double>(NAN, 0.0)};
+    assert_points_of_interest_are(PointOfInterestType::Root, numberOfRoots, roots, "3", nullptr, "a", 100.0, -0.1, -1.0);
+  }
+  {
+    constexpr int numberOfRoots = 1;
+    Coordinate2D<double> roots[numberOfRoots] = {
       Coordinate2D<double>(-0.9, 0.0)};
     assert_points_of_interest_are(PointOfInterestType::Root, numberOfRoots, roots, "0", nullptr, "a", -1.0, 0.1, 100.0);
+  }
+  {
+    constexpr int numberOfRoots = 1;
+    Coordinate2D<double> roots[numberOfRoots] = {
+      Coordinate2D<double>(99.8, 0.0)};
+    assert_points_of_interest_are(PointOfInterestType::Root, numberOfRoots, roots, "0", nullptr, "a", 100.0, -0.1, -1.0);
   }
 }
 
@@ -166,11 +249,24 @@ QUIZ_CASE(poincare_function_intersection) {
     assert_points_of_interest_are(PointOfInterestType::Intersection, numberOfIntersections, intersections, "cos(a)", "2", "a", -1.0, 0.1, 500.0);
   }
   {
+    constexpr int numberOfIntersections = 1;
+    Coordinate2D<double> intersections[numberOfIntersections] = {
+      Coordinate2D<double>(NAN, NAN)};
+    assert_points_of_interest_are(PointOfInterestType::Intersection, numberOfIntersections, intersections, "cos(a)", "2", "a", 500.0, -0.1, -1.0);
+  }
+  {
     constexpr int numberOfIntersections = 2;
     Coordinate2D<double> intersections[numberOfIntersections] = {
       Coordinate2D<double>(0.0, 1.0),
       Coordinate2D<double>(360.0, 1.0)};
     assert_points_of_interest_are(PointOfInterestType::Intersection, numberOfIntersections, intersections, "cos(a)", "1", "a", -1.0, 0.1, 500.0);
+  }
+  {
+    constexpr int numberOfIntersections = 2;
+    Coordinate2D<double> intersections[numberOfIntersections] = {
+      Coordinate2D<double>(360.0, 1.0),
+      Coordinate2D<double>(0.0, 1.0)};
+    assert_points_of_interest_are(PointOfInterestType::Intersection, numberOfIntersections, intersections, "cos(a)", "1", "a", 500.0, -0.1, -1.0);
   }
   {
     constexpr int numberOfIntersections = 3;
@@ -179,5 +275,13 @@ QUIZ_CASE(poincare_function_intersection) {
       Coordinate2D<double>(270.0, 0.0),
       Coordinate2D<double>(450.0, 0.0)};
     assert_points_of_interest_are(PointOfInterestType::Intersection, numberOfIntersections, intersections, "cos(a)", "0", "a", -1.0, 0.1, 500.0);
+  }
+  {
+    constexpr int numberOfIntersections = 3;
+    Coordinate2D<double> intersections[numberOfIntersections] = {
+      Coordinate2D<double>(450.0, 0.0),
+      Coordinate2D<double>(270.0, 0.0),
+      Coordinate2D<double>(90.0, 0.0)};
+    assert_points_of_interest_are(PointOfInterestType::Intersection, numberOfIntersections, intersections, "cos(a)", "0", "a", 500.0, -0.1, -1.0);
   }
 }

--- a/poincare/test/function_solver.cpp
+++ b/poincare/test/function_solver.cpp
@@ -34,22 +34,21 @@ void assert_next_extrema_are(
 {
   Shared::GlobalContext context;
   Poincare::Expression e = parse_expression(expression, &context, false);
-  double currentStart = start;
   for (int i = 0; i < numberOfExtrema; i++) {
-    quiz_assert_log_if_failure(!std::isnan(currentStart), e);
+    quiz_assert_log_if_failure(!std::isnan(start), e);
     Coordinate2D<double> nextExtrema;
     if (extremumType == ExtremumType::Maximum) {
-      nextExtrema = e.nextMaximum(symbol, currentStart, step, max, &context, complexFormat, angleUnit);
+      nextExtrema = e.nextMaximum(symbol, start, step, max, &context, complexFormat, angleUnit);
     } else if (extremumType == ExtremumType::Minimum) {
-      nextExtrema = e.nextMinimum(symbol, currentStart, step, max, &context, complexFormat, angleUnit);
+      nextExtrema = e.nextMinimum(symbol, start, step, max, &context, complexFormat, angleUnit);
     } else if (extremumType == ExtremumType::Root) {
-      nextExtrema = Coordinate2D<double>(e.nextRoot(symbol, currentStart, step, max, &context, complexFormat, angleUnit), 0.0 );
+      nextExtrema = Coordinate2D<double>(e.nextRoot(symbol, start, step, max, &context, complexFormat, angleUnit), 0.0);
     }
-    currentStart = nextExtrema.x1() + step;
     quiz_assert_log_if_failure(
         (doubles_are_approximately_equal(extrema[i].x1(), nextExtrema.x1()))
         && (doubles_are_approximately_equal(extrema[i].x2(), nextExtrema.x2())),
         e);
+    start = nextExtrema.x1() + step;
   }
 }
 
@@ -165,15 +164,14 @@ void assert_next_intersections_are(
   Shared::GlobalContext context;
   Poincare::Expression e = parse_expression(expression, &context, false);
   Poincare::Expression other = parse_expression(otherExpression, &context, false);
-  double currentStart = start;
   for (int i = 0; i < numberOfIntersections; i++) {
-    quiz_assert_log_if_failure(!std::isnan(currentStart), e);
-    Coordinate2D<double> nextIntersection = e.nextIntersection(symbol, currentStart, step, max, &context, complexFormat, angleUnit, other);
-    currentStart = nextIntersection.x1() + step;
+    quiz_assert_log_if_failure(!std::isnan(start), e);
+    Coordinate2D<double> nextIntersection = e.nextIntersection(symbol, start, step, max, &context, complexFormat, angleUnit, other);
     quiz_assert_log_if_failure(
         (doubles_are_approximately_equal(intersections[i].x1(), nextIntersection.x1()))
         && (doubles_are_approximately_equal(intersections[i].x2(), nextIntersection.x2())),
         e);
+    start = nextIntersection.x1() + step;
   }
 }
 

--- a/poincare/test/function_solver.cpp
+++ b/poincare/test/function_solver.cpp
@@ -3,7 +3,7 @@
 
 using namespace Poincare;
 
-enum class ExtremumType : uint8_t {
+enum class PointOfInterestType {
   Maximum,
   Minimum,
   Root
@@ -20,10 +20,10 @@ bool doubles_are_approximately_equal(double d1, double d2) {
   return std::abs(d1-d2) < 0.00001;
 }
 
-void assert_next_extrema_are(
-    ExtremumType extremumType,
-    int numberOfExtrema,
-    Coordinate2D<double> * extrema,
+void assert_points_of_interest_are(
+    PointOfInterestType type,
+    int numberOfPointsOfInterest,
+    Coordinate2D<double> * pointsOfInterest,
     const char * expression,
     const char * symbol,
     double start,
@@ -34,21 +34,21 @@ void assert_next_extrema_are(
 {
   Shared::GlobalContext context;
   Poincare::Expression e = parse_expression(expression, &context, false);
-  for (int i = 0; i < numberOfExtrema; i++) {
+  for (int i = 0; i < numberOfPointsOfInterest; i++) {
     quiz_assert_log_if_failure(!std::isnan(start), e);
-    Coordinate2D<double> nextExtrema;
-    if (extremumType == ExtremumType::Maximum) {
-      nextExtrema = e.nextMaximum(symbol, start, step, max, &context, complexFormat, angleUnit);
-    } else if (extremumType == ExtremumType::Minimum) {
-      nextExtrema = e.nextMinimum(symbol, start, step, max, &context, complexFormat, angleUnit);
-    } else if (extremumType == ExtremumType::Root) {
-      nextExtrema = Coordinate2D<double>(e.nextRoot(symbol, start, step, max, &context, complexFormat, angleUnit), 0.0);
+    Coordinate2D<double> nextPointOfInterest;
+    if (type == PointOfInterestType::Maximum) {
+      nextPointOfInterest = e.nextMaximum(symbol, start, step, max, &context, complexFormat, angleUnit);
+    } else if (type == PointOfInterestType::Minimum) {
+      nextPointOfInterest = e.nextMinimum(symbol, start, step, max, &context, complexFormat, angleUnit);
+    } else if (type == PointOfInterestType::Root) {
+      nextPointOfInterest = Coordinate2D<double>(e.nextRoot(symbol, start, step, max, &context, complexFormat, angleUnit), 0.0);
     }
     quiz_assert_log_if_failure(
-        (doubles_are_approximately_equal(extrema[i].x1(), nextExtrema.x1()))
-        && (doubles_are_approximately_equal(extrema[i].x2(), nextExtrema.x2())),
+        doubles_are_approximately_equal(pointsOfInterest[i].x1(), nextPointOfInterest.x1()) &&
+        doubles_are_approximately_equal(pointsOfInterest[i].x2(), nextPointOfInterest.x2()),
         e);
-    start = nextExtrema.x1() + step;
+    start = nextPointOfInterest.x1() + step;
   }
 }
 
@@ -60,13 +60,13 @@ QUIZ_CASE(poincare_function_extremum) {
         Coordinate2D<double>(0.0, 1.0),
         Coordinate2D<double>(360.0, 1.0),
         Coordinate2D<double>(NAN, NAN)};
-      assert_next_extrema_are(ExtremumType::Maximum, numberOfMaxima, maxima, "cos(a)", "a", -1.0, 0.1, 500.0);
+      assert_points_of_interest_are(PointOfInterestType::Maximum, numberOfMaxima, maxima, "cos(a)", "a", -1.0, 0.1, 500.0);
     }
     {
       constexpr int numberOfMinima = 1;
       Coordinate2D<double> minima[numberOfMinima] = {
         Coordinate2D<double>(180.0, -1.0)};
-      assert_next_extrema_are(ExtremumType::Minimum, numberOfMinima, minima, "cos(a)", "a", 0.0, 0.1, 300.0);
+      assert_points_of_interest_are(PointOfInterestType::Minimum, numberOfMinima, minima, "cos(a)", "a", 0.0, 0.1, 300.0);
     }
   }
   {
@@ -74,13 +74,13 @@ QUIZ_CASE(poincare_function_extremum) {
       constexpr int numberOfMaxima = 1;
       Coordinate2D<double> maxima[numberOfMaxima] = {
         Coordinate2D<double>(NAN, NAN)};
-      assert_next_extrema_are(ExtremumType::Maximum, numberOfMaxima, maxima, "a^2", "a", -1.0, 0.1, 100.0);
+      assert_points_of_interest_are(PointOfInterestType::Maximum, numberOfMaxima, maxima, "a^2", "a", -1.0, 0.1, 100.0);
     }
     {
       constexpr int numberOfMinima = 1;
       Coordinate2D<double> minima[numberOfMinima] = {
         Coordinate2D<double>(0.0, 0.0)};
-      assert_next_extrema_are(ExtremumType::Minimum, numberOfMinima, minima, "a^2", "a", -1.0, 0.1, 100.0);
+      assert_points_of_interest_are(PointOfInterestType::Minimum, numberOfMinima, minima, "a^2", "a", -1.0, 0.1, 100.0);
     }
   }
   {
@@ -88,13 +88,13 @@ QUIZ_CASE(poincare_function_extremum) {
       constexpr int numberOfMaxima = 1;
       Coordinate2D<double> maxima[numberOfMaxima] = {
         Coordinate2D<double>(NAN, 3.0)};
-      assert_next_extrema_are(ExtremumType::Maximum, numberOfMaxima, maxima, "3", "a", -1.0, 0.1, 100.0);
+      assert_points_of_interest_are(PointOfInterestType::Maximum, numberOfMaxima, maxima, "3", "a", -1.0, 0.1, 100.0);
     }
     {
       constexpr int numberOfMinima = 1;
       Coordinate2D<double> minima[numberOfMinima] = {
         Coordinate2D<double>(NAN, 3.0)};
-      assert_next_extrema_are(ExtremumType::Minimum, numberOfMinima, minima, "3", "a", -1.0, 0.1, 100.0);
+      assert_points_of_interest_are(PointOfInterestType::Minimum, numberOfMinima, minima, "3", "a", -1.0, 0.1, 100.0);
     }
   }
   {
@@ -102,13 +102,13 @@ QUIZ_CASE(poincare_function_extremum) {
       constexpr int numberOfMaxima = 1;
       Coordinate2D<double> maxima[numberOfMaxima] = {
         Coordinate2D<double>(NAN, 0.0)};
-      assert_next_extrema_are(ExtremumType::Maximum, numberOfMaxima, maxima, "0", "a", -1.0, 0.1, 100.0);
+      assert_points_of_interest_are(PointOfInterestType::Maximum, numberOfMaxima, maxima, "0", "a", -1.0, 0.1, 100.0);
     }
     {
       constexpr int numberOfMinima = 1;
       Coordinate2D<double> minima[numberOfMinima] = {
         Coordinate2D<double>(NAN, 0.0)};
-      assert_next_extrema_are(ExtremumType::Minimum, numberOfMinima, minima, "0", "a", -1.0, 0.1, 100.0);
+      assert_points_of_interest_are(PointOfInterestType::Minimum, numberOfMinima, minima, "0", "a", -1.0, 0.1, 100.0);
     }
   }
 }
@@ -120,32 +120,32 @@ QUIZ_CASE(poincare_function_root) {
       Coordinate2D<double>(90.0, 0.0),
       Coordinate2D<double>(270.0, 0.0),
       Coordinate2D<double>(450.0, 0.0)};
-    assert_next_extrema_are(ExtremumType::Root, numberOfRoots, roots, "cos(a)", "a", 0.0, 0.1, 500.0);
+    assert_points_of_interest_are(PointOfInterestType::Root, numberOfRoots, roots, "cos(a)", "a", 0.0, 0.1, 500.0);
   }
   {
     constexpr int numberOfRoots = 1;
     Coordinate2D<double> roots[numberOfRoots] = {
       Coordinate2D<double>(0.0, 0.0)};
-    assert_next_extrema_are(ExtremumType::Root, numberOfRoots, roots, "a^2", "a", -1.0, 0.1, 100.0);
+    assert_points_of_interest_are(PointOfInterestType::Root, numberOfRoots, roots, "a^2", "a", -1.0, 0.1, 100.0);
   }
   {
     constexpr int numberOfRoots = 2;
     Coordinate2D<double> roots[numberOfRoots] = {
       Coordinate2D<double>(-2.0, 0.0),
       Coordinate2D<double>(2.0, 0.0)};
-    assert_next_extrema_are(ExtremumType::Root, numberOfRoots, roots, "a^2-4", "a", -5.0, 0.1, 100.0);
+    assert_points_of_interest_are(PointOfInterestType::Root, numberOfRoots, roots, "a^2-4", "a", -5.0, 0.1, 100.0);
   }
   {
     constexpr int numberOfRoots = 1;
     Coordinate2D<double> roots[numberOfRoots] = {
       Coordinate2D<double>(NAN, 0.0)};
-    assert_next_extrema_are(ExtremumType::Root, numberOfRoots, roots, "3", "a", -1.0, 0.1, 100.0);
+    assert_points_of_interest_are(PointOfInterestType::Root, numberOfRoots, roots, "3", "a", -1.0, 0.1, 100.0);
   }
   {
     constexpr int numberOfRoots = 1;
     Coordinate2D<double> roots[numberOfRoots] = {
       Coordinate2D<double>(-0.9, 0.0)};
-    assert_next_extrema_are(ExtremumType::Root, numberOfRoots, roots, "0", "a", -1.0, 0.1, 100.0);
+    assert_points_of_interest_are(PointOfInterestType::Root, numberOfRoots, roots, "0", "a", -1.0, 0.1, 100.0);
   }
 }
 


### PR DESCRIPTION
When looking for curve intersections or a function's inverse images, moving the cursor to the left can give unsatisfying results, whereas moving the cursor to the right does better.

Scenario:
Define the function f(x) = sin(x+0.0001) and look for the inverse images of 0, thanks to the corresponding menu.
Observe that when navigating the right, the images are always 0, whereas when navigating to the left, the images are close to 0 but not 0.