### PR TITLE
Get key down events on simulator and fix events buffering

### DIFF
--- a/ion/include/ion/events.h
+++ b/ion/include/ion/events.h
@@ -53,6 +53,7 @@ Event getEvent(int * timeout);
 
 ShiftAlphaStatus shiftAlphaStatus();
 void setShiftAlphaStatus(ShiftAlphaStatus s);
+void removeShift();
 bool isShiftActive();
 bool isAlphaActive();
 void setLongRepetition(bool longRepetition);

--- a/ion/src/shared/events_modifier.cpp
+++ b/ion/src/shared/events_modifier.cpp
@@ -11,6 +11,16 @@ ShiftAlphaStatus shiftAlphaStatus() {
   return sShiftAlphaStatus;
 }
 
+void removeShift() {
+  if (sShiftAlphaStatus == ShiftAlphaStatus::Shift) {
+    sShiftAlphaStatus = ShiftAlphaStatus::Default;
+  } else if (sShiftAlphaStatus == ShiftAlphaStatus::ShiftAlpha ) {
+    sShiftAlphaStatus = ShiftAlphaStatus::Alpha;
+  } else if (sShiftAlphaStatus == ShiftAlphaStatus::ShiftAlphaLock) {
+    sShiftAlphaStatus = ShiftAlphaStatus::AlphaLock;
+  }
+}
+
 bool isShiftActive() {
   return sShiftAlphaStatus == ShiftAlphaStatus::Shift || sShiftAlphaStatus == ShiftAlphaStatus::ShiftAlpha || sShiftAlphaStatus == ShiftAlphaStatus::ShiftAlphaLock;
 }

--- a/ion/src/simulator/shared/events_keyboard.cpp
+++ b/ion/src/simulator/shared/events_keyboard.cpp
@@ -188,14 +188,12 @@ static Event eventFromSDLTextInputEvent(SDL_TextInputEvent event) {
   }
   char character = event.text[0];
   if (character >= 32 && character < 127) {
-#if EPSILON_SDL_SCREEN_ONLY
     /* We remove the shift, otherwise it might stay activated when it shouldn't.
      * For instance on a French keyboard, to input "1", we first press "Shift"
      * (which activates the Shift modifier on the calculator), then we press
      * "&", transformed by eventFromSDLTextInputEvent into the text "1". If we
      * do not remove the Shift here, it would still be pressed afterwards. */
     Ion::Events::removeShift();
-#endif
     return sEventForASCIICharAbove32[character-32];
   }
   return None;
@@ -220,11 +218,9 @@ Event getPlatformEvent() {
       return Termination;
     }
     if (event.type == SDL_KEYDOWN) {
-#if EPSILON_SDL_SCREEN_ONLY
       if (IonSimulatorSDLKeyDetectedByScan(event.key.keysym.scancode)) {
         continue;
       }
-#endif
       return eventFromSDLKeyboardEvent(event.key);
     }
     if (event.type == SDL_TEXTINPUT) {

--- a/ion/src/simulator/shared/events_keyboard.cpp
+++ b/ion/src/simulator/shared/events_keyboard.cpp
@@ -204,6 +204,11 @@ Event getPlatformEvent() {
       return Termination;
     }
     if (event.type == SDL_KEYDOWN) {
+#if EPSILON_SDL_SCREEN_ONLY
+      if (IonSimulatorSDLKeyDetectedByScan(event.key.keysym.scancode)) {
+        continue;
+      }
+#endif
       return eventFromSDLKeyboardEvent(event.key);
     }
     if (event.type == SDL_TEXTINPUT) {

--- a/ion/src/simulator/shared/events_keyboard.cpp
+++ b/ion/src/simulator/shared/events_keyboard.cpp
@@ -72,8 +72,6 @@ static Event eventFromSDLKeyboardEvent(SDL_KeyboardEvent event) {
 
   if (event.keysym.mod & KMOD_CTRL) {
     switch (event.keysym.sym) {
-      case SDLK_BACKSPACE:
-        return Clear;
       case SDLK_x:
         return Cut;
       case SDLK_c:
@@ -94,14 +92,8 @@ static Event eventFromSDLKeyboardEvent(SDL_KeyboardEvent event) {
       }
     }
     switch (event.keysym.sym) {
-      case SDLK_ESCAPE:
-        return Home;
-      case SDLK_RETURN:
-        return OK;
       case SDLK_v:
         return Var;
-      case SDLK_BACKSPACE:
-        return Clear;
       case SDLK_x:
         return Exp;
       case SDLK_n:
@@ -130,35 +122,7 @@ static Event eventFromSDLKeyboardEvent(SDL_KeyboardEvent event) {
         return Ans;
     }
   }
-  if (event.keysym.mod & KMOD_SHIFT) {
-    switch(event.keysym.sym) {
-      case SDLK_UP:
-        return ShiftUp;
-      case SDLK_DOWN:
-        return ShiftDown;
-      case SDLK_LEFT:
-        return ShiftLeft;
-      case SDLK_RIGHT:
-        return ShiftRight;
-    }
-  }
   switch(event.keysym.sym) {
-    case SDLK_UP:
-      return Up;
-    case SDLK_DOWN:
-      return Down;
-    case SDLK_LEFT:
-      return Left;
-    case SDLK_RIGHT:
-      return Right;
-    case SDLK_RETURN:
-      return EXE;
-    case SDLK_ESCAPE:
-      return Back;
-    case SDLK_TAB:
-      return Toolbox;
-    case SDLK_BACKSPACE:
-      return Backspace;
     case SDLK_AC_BACK:
       return Termination;
   }

--- a/ion/src/simulator/shared/keyboard_sdl.cpp
+++ b/ion/src/simulator/shared/keyboard_sdl.cpp
@@ -17,40 +17,53 @@ void IonSimulatorKeyboardKeyUp(int keyNumber) {
   Ion::Keyboard::Key key = static_cast<Ion::Keyboard::Key>(keyNumber);
   sKeyboardState.clearKey(key);
 }
-#endif
 
 namespace Ion {
 namespace Keyboard {
 
-#if EPSILON_SDL_SCREEN_ONLY
-  class KeySDLKeyPair {
-  public:
-    constexpr KeySDLKeyPair(Ion::Keyboard::Key key, SDL_Scancode SDLKey) :
-      m_key(key),
-      m_SDLKey(SDLKey)
-    {}
-    Ion::Keyboard::Key key() const { return m_key; }
-    SDL_Scancode SDLKey() const { return m_SDLKey; }
-  private:
-    Ion::Keyboard::Key m_key;
-    SDL_Scancode m_SDLKey;
-  };
+class KeySDLKeyPair {
+public:
+  constexpr KeySDLKeyPair(Ion::Keyboard::Key key, SDL_Scancode SDLKey) :
+    m_key(key),
+    m_SDLKey(SDLKey)
+  {}
+  Ion::Keyboard::Key key() const { return m_key; }
+  SDL_Scancode SDLKey() const { return m_SDLKey; }
+private:
+  Ion::Keyboard::Key m_key;
+  SDL_Scancode m_SDLKey;
+};
 
-  constexpr static KeySDLKeyPair sKeyPairs[] = {
-    KeySDLKeyPair(Ion::Keyboard::Key::Down,      SDL_SCANCODE_DOWN),
-    KeySDLKeyPair(Ion::Keyboard::Key::Up,        SDL_SCANCODE_UP),
-    KeySDLKeyPair(Ion::Keyboard::Key::Left,      SDL_SCANCODE_LEFT),
-    KeySDLKeyPair(Ion::Keyboard::Key::Right,     SDL_SCANCODE_RIGHT),
-    KeySDLKeyPair(Ion::Keyboard::Key::Shift,     SDL_SCANCODE_LSHIFT),
-    KeySDLKeyPair(Ion::Keyboard::Key::Shift,     SDL_SCANCODE_RSHIFT),
-    KeySDLKeyPair(Ion::Keyboard::Key::EXE,       SDL_SCANCODE_RETURN),
-    KeySDLKeyPair(Ion::Keyboard::Key::Back,      SDL_SCANCODE_ESCAPE),
-    KeySDLKeyPair(Ion::Keyboard::Key::Toolbox,   SDL_SCANCODE_TAB),
-    KeySDLKeyPair(Ion::Keyboard::Key::Backspace, SDL_SCANCODE_BACKSPACE)
-  };
+constexpr static KeySDLKeyPair sKeyPairs[] = {
+  KeySDLKeyPair(Ion::Keyboard::Key::Down,      SDL_SCANCODE_DOWN),
+  KeySDLKeyPair(Ion::Keyboard::Key::Up,        SDL_SCANCODE_UP),
+  KeySDLKeyPair(Ion::Keyboard::Key::Left,      SDL_SCANCODE_LEFT),
+  KeySDLKeyPair(Ion::Keyboard::Key::Right,     SDL_SCANCODE_RIGHT),
+  KeySDLKeyPair(Ion::Keyboard::Key::Shift,     SDL_SCANCODE_LSHIFT),
+  KeySDLKeyPair(Ion::Keyboard::Key::Shift,     SDL_SCANCODE_RSHIFT),
+  KeySDLKeyPair(Ion::Keyboard::Key::EXE,       SDL_SCANCODE_RETURN),
+  KeySDLKeyPair(Ion::Keyboard::Key::Back,      SDL_SCANCODE_ESCAPE),
+  KeySDLKeyPair(Ion::Keyboard::Key::Toolbox,   SDL_SCANCODE_TAB),
+  KeySDLKeyPair(Ion::Keyboard::Key::Backspace, SDL_SCANCODE_BACKSPACE)
+};
 
-  constexpr int sNumberOfKeyPairs = sizeof(sKeyPairs)/sizeof(KeySDLKeyPair);
+constexpr int sNumberOfKeyPairs = sizeof(sKeyPairs)/sizeof(KeySDLKeyPair);
+
+}
+}
+
+bool IonSimulatorSDLKeyDetectedByScan(SDL_Scancode key) {
+  for (int i = 0; i < Ion::Keyboard::sNumberOfKeyPairs; i++) {
+    if (key == Ion::Keyboard::sKeyPairs[i].SDLKey()) {
+      return true;
+    }
+  }
+  return false;
+}
 #endif
+
+namespace Ion {
+namespace Keyboard {
 
 State scan() {
   // We need to tell SDL to get new state from the host OS

--- a/ion/src/simulator/shared/platform.h
+++ b/ion/src/simulator/shared/platform.h
@@ -20,6 +20,8 @@ void IonSimulatorKeyboardKeyUp(int keyNumber);
 
 void IonSimulatorEventsPushEvent(int eventNumber);
 
+bool IonSimulatorSDLKeyDetectedByScan(SDL_Scancode key);
+
 #endif
 
 void IonSimulatorCallbackDidRefresh();

--- a/ion/src/simulator/shared/platform.h
+++ b/ion/src/simulator/shared/platform.h
@@ -2,6 +2,7 @@
 #define ION_SIMULATOR_PLATFORM_H
 
 #include <SDL.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -14,16 +15,12 @@ SDL_Texture * IonSimulatorLoadImage(SDL_Renderer * renderer, const char * identi
 char * IonSimulatorGetLanguageCode();
 
 #if EPSILON_SDL_SCREEN_ONLY
-
 void IonSimulatorKeyboardKeyDown(int keyNumber);
 void IonSimulatorKeyboardKeyUp(int keyNumber);
-
 void IonSimulatorEventsPushEvent(int eventNumber);
-
-bool IonSimulatorSDLKeyDetectedByScan(SDL_Scancode key);
-
 #endif
 
+bool IonSimulatorSDLKeyDetectedByScan(SDL_Scancode key);
 void IonSimulatorCallbackDidRefresh();
 void IonSimulatorCallbackDidScanKeyboard();
 


### PR DESCRIPTION
This PR fixes two things :
- Detect (some) physical keyboard events with the Python ion module, for the simulator platforms (including web)
- Stop buffering events when they cannot be processed