### PR TITLE
Remove useless uses of const for return types

### DIFF
--- a/apps/shared/curve_view.cpp
+++ b/apps/shared/curve_view.cpp
@@ -106,11 +106,11 @@ void CurveView::setOkView(View * okView) {
  *       m_frame.height() - 1            yMin()
  */
 
-const float CurveView::pixelWidth() const {
+float CurveView::pixelWidth() const {
   return (m_curveViewRange->xMax() - m_curveViewRange->xMin()) / (m_frame.width() - 1);
 }
 
-const float CurveView::pixelHeight() const {
+float CurveView::pixelHeight() const {
   return (m_curveViewRange->yMax() - m_curveViewRange->yMin()) / (m_frame.height() - 1);
 }
 

--- a/apps/shared/curve_view.h
+++ b/apps/shared/curve_view.h
@@ -38,8 +38,8 @@ public:
   void setBannerView(View * bannerView);
   void setOkView(View * okView);
   void setForceOkDisplay(bool force) { m_forceOkDisplay = force; }
-  const float pixelWidth() const;
-  const float pixelHeight() const;
+  float pixelWidth() const;
+  float pixelHeight() const;
 protected:
   CurveViewRange * curveViewRange() const { return m_curveViewRange; }
   void setCurveViewRange(CurveViewRange * curveViewRange);

--- a/apps/shared/curve_view_range.h
+++ b/apps/shared/curve_view_range.h
@@ -17,8 +17,8 @@ public:
   virtual float xMax() const = 0;
   virtual float yMin() const = 0;
   virtual float yMax() const = 0;
-  const float xCenter() const { return (xMin() + xMax()) / 2; }
-  const float yCenter() const { return (yMin() + yMax()) / 2; }
+  float xCenter() const { return (xMin() + xMax()) / 2; }
+  float yCenter() const { return (yMin() + yMax()) / 2; }
   virtual float xGridUnit() const {
     return computeGridUnit(k_minNumberOfXGridUnits, k_maxNumberOfXGridUnits, xMax() - xMin());
   }

--- a/poincare/include/poincare/expression.h
+++ b/poincare/include/poincare/expression.h
@@ -274,7 +274,7 @@ public:
       m_numberOfChildren(numberOfChildren),
       m_untypedBuilder(builder) {}
     const char * name() const { return m_name; }
-    const int numberOfChildren() const { return m_numberOfChildren; }
+    int numberOfChildren() const { return m_numberOfChildren; }
     Expression build(Expression children) const { return (*m_untypedBuilder)(children); }
   private:
     const char * m_name;

--- a/poincare/include/poincare/unit.h
+++ b/poincare/include/poincare/unit.h
@@ -29,7 +29,7 @@ public:
       m_exponent(exponent)
     {}
     const char * symbol() const { return m_symbol; }
-    const int8_t exponent() const { return m_exponent; }
+    int8_t exponent() const { return m_exponent; }
     int serialize(char * buffer, int bufferSize) const;
   private:
     const char * m_symbol;


### PR DESCRIPTION
An integer or float value can not be assigned to, so there is no point
in qualifying it as const.