### PR TITLE
Fix sequence sum layout

### DIFF
--- a/apps/sequence/sequence.cpp
+++ b/apps/sequence/sequence.cpp
@@ -28,7 +28,6 @@ void Sequence::tidy() {
   m_firstInitialCondition.tidyName();
   m_secondInitialCondition.tidy();
   m_secondInitialCondition.tidyName();
-  m_nameLayout = Layout();
 }
 
 Sequence::Type Sequence::type() const {
@@ -81,13 +80,10 @@ void Sequence::setInitialRank(int rank) {
 }
 
 Poincare::Layout Sequence::nameLayout() {
-  if (m_nameLayout.isUninitialized()) {
-    m_nameLayout = HorizontalLayout::Builder(
-        CodePointLayout::Builder(fullName()[0], KDFont::SmallFont),
-        VerticalOffsetLayout::Builder(CodePointLayout::Builder(symbol(), KDFont::SmallFont), VerticalOffsetLayoutNode::Position::Subscript)
-      );
-  }
-  return m_nameLayout;
+  return HorizontalLayout::Builder(
+      CodePointLayout::Builder(fullName()[0], KDFont::SmallFont),
+      VerticalOffsetLayout::Builder(CodePointLayout::Builder(symbol(), KDFont::SmallFont), VerticalOffsetLayoutNode::Position::Subscript)
+    );
 }
 
 bool Sequence::isDefined() {

--- a/apps/sequence/sequence.h
+++ b/apps/sequence/sequence.h
@@ -112,7 +112,7 @@ private:
   public:
     SequenceModel() : Shared::ExpressionModel(), m_name() {}
     void tidyName() { m_name = Poincare::Layout(); }
-    virtual Poincare::Layout name(Sequence * sequence);
+    Poincare::Layout name(Sequence * sequence);
   protected:
     virtual void buildName(Sequence * sequence) = 0;
     Poincare::Layout m_name;

--- a/apps/sequence/sequence.h
+++ b/apps/sequence/sequence.h
@@ -24,8 +24,9 @@ public:
     DoubleRecurrence = 2
   };
   Sequence(Ion::Storage::Record record = Record()) :
-    Function(record),
-    m_nameLayout() {}
+    Function(record)
+  {
+  }
   I18n::Message parameterMessageName() const override;
   CodePoint symbol() const override { return 'n'; }
   void tidy() override;
@@ -153,7 +154,6 @@ private:
   DefinitionModel m_definition;
   FirstInitialConditionModel m_firstInitialCondition;
   SecondInitialConditionModel m_secondInitialCondition;
-  Poincare::Layout m_nameLayout;
 };
 
 }

--- a/apps/shared/sum_graph_controller.cpp
+++ b/apps/shared/sum_graph_controller.cpp
@@ -190,34 +190,30 @@ void SumGraphController::LegendView::setSumLayout(Step step, double start, doubl
   constexpr int sigmaLength = 2;
   const CodePoint sigma[sigmaLength] = {' ', m_sumSymbol};
   Poincare::Layout sumLayout = LayoutHelper::CodePointString(sigma, sigmaLength);
-  if (step == Step::FirstParameter) {
-  } else if (step == Step::SecondParameter) {
+  if (step != Step::FirstParameter) {
     constexpr int precision = Preferences::MediumNumberOfSignificantDigits;
     constexpr int bufferSize = PrintFloat::charSizeForFloatsWithPrecision(precision);
     char buffer[bufferSize];
+    Layout endLayout;
+    if (step == Step::SecondParameter) {
+      endLayout = EmptyLayout::Builder(EmptyLayoutNode::Color::Yellow, false, k_font, false);
+    } else {
+      PoincareHelpers::ConvertFloatToTextWithDisplayMode<double>(end, buffer, bufferSize, precision, Preferences::PrintFloatMode::Decimal);
+      endLayout = LayoutHelper::String(buffer, strlen(buffer), k_font);
+    }
     PoincareHelpers::ConvertFloatToTextWithDisplayMode<double>(start, buffer, bufferSize, precision, Preferences::PrintFloatMode::Decimal);
     sumLayout = CondensedSumLayout::Builder(
         sumLayout,
         LayoutHelper::String(buffer, strlen(buffer), k_font),
-        EmptyLayout::Builder(EmptyLayoutNode::Color::Yellow, false, k_font, false));
-  } else {
-    constexpr int precision = Preferences::MediumNumberOfSignificantDigits;
-    constexpr int bufferSize = PrintFloat::charSizeForFloatsWithPrecision(precision);
-    char buffer[bufferSize];
-    PoincareHelpers::ConvertFloatToTextWithDisplayMode<double>(start, buffer, bufferSize, precision, Preferences::PrintFloatMode::Decimal);
-    Layout start = LayoutHelper::String(buffer, strlen(buffer), k_font);
-    PoincareHelpers::ConvertFloatToTextWithDisplayMode<double>(end, buffer, bufferSize, precision, Preferences::PrintFloatMode::Decimal);
-    Layout end = LayoutHelper::String(buffer, strlen(buffer), k_font);
-    sumLayout = CondensedSumLayout::Builder(
-        sumLayout,
-        start,
-        end);
-    PoincareHelpers::ConvertFloatToText<double>(result, buffer, bufferSize, precision);
-    sumLayout = HorizontalLayout::Builder(
-        sumLayout,
-        functionLayout,
-        LayoutHelper::String("= ", 2, k_font),
-        LayoutHelper::String(buffer, strlen(buffer), k_font));
+        endLayout);
+    if (step == Step::Result) {
+      PoincareHelpers::ConvertFloatToText<double>(result, buffer, bufferSize, precision);
+      sumLayout = HorizontalLayout::Builder(
+          sumLayout,
+          functionLayout,
+          LayoutHelper::String("= ", 2, k_font),
+          LayoutHelper::String(buffer, strlen(buffer), k_font));
+    }
   }
   m_sum.setLayout(sumLayout);
   m_sum.setAlignment(0.5f * (step == Step::Result), 0.5f);

--- a/apps/shared/sum_graph_controller.cpp
+++ b/apps/shared/sum_graph_controller.cpp
@@ -157,7 +157,6 @@ void SumGraphController::reloadBannerView() {
 
 SumGraphController::LegendView::LegendView(SumGraphController * controller, InputEventHandlerDelegate * inputEventHandlerDelegate, CodePoint sumSymbol) :
   m_sum(0.0f, 0.5f, KDColorBlack, Palette::GreyMiddle),
-  m_sumLayout(),
   m_legend(k_font, I18n::Message::Default, 0.0f, 0.5f, KDColorBlack, Palette::GreyMiddle),
   m_editableZone(controller, m_textBuffer, k_editableZoneBufferSize, TextField::maxBufferSize(), inputEventHandlerDelegate, controller, k_font, 0.0f, 0.5f, KDColorBlack, Palette::GreyMiddle),
   m_sumSymbol(sumSymbol)
@@ -190,14 +189,15 @@ void SumGraphController::LegendView::setSumSymbol(Step step, double start, doubl
   assert(step == Step::Result || functionLayout.isUninitialized());
   constexpr int sigmaLength = 2;
   const CodePoint sigma[sigmaLength] = {' ', m_sumSymbol};
+  Poincare::Layout sumLayout;
   if (step == Step::FirstParameter) {
-    m_sumLayout = LayoutHelper::CodePointString(sigma, sigmaLength);
+    sumLayout = LayoutHelper::CodePointString(sigma, sigmaLength);
   } else if (step == Step::SecondParameter) {
     constexpr int precision = Preferences::MediumNumberOfSignificantDigits;
     constexpr int bufferSize = PrintFloat::charSizeForFloatsWithPrecision(precision);
     char buffer[bufferSize];
     PoincareHelpers::ConvertFloatToTextWithDisplayMode<double>(start, buffer, bufferSize, precision, Preferences::PrintFloatMode::Decimal);
-    m_sumLayout = CondensedSumLayout::Builder(
+    sumLayout = CondensedSumLayout::Builder(
         LayoutHelper::CodePointString(sigma, sigmaLength),
         LayoutHelper::String(buffer, strlen(buffer), k_font),
         EmptyLayout::Builder(EmptyLayoutNode::Color::Yellow, false, k_font, false));
@@ -210,18 +210,18 @@ void SumGraphController::LegendView::setSumSymbol(Step step, double start, doubl
     Layout start = LayoutHelper::String(buffer, strlen(buffer), k_font);
     PoincareHelpers::ConvertFloatToTextWithDisplayMode<double>(end, buffer, bufferSize, precision, Preferences::PrintFloatMode::Decimal);
     Layout end = LayoutHelper::String(buffer, strlen(buffer), k_font);
-    m_sumLayout = CondensedSumLayout::Builder(
+    sumLayout = CondensedSumLayout::Builder(
         LayoutHelper::CodePointString(sigma, sigmaLength),
         start,
         end);
     strlcpy(buffer, "= ", 3);
     PoincareHelpers::ConvertFloatToText<double>(result, buffer+2, bufferSize-2, precision);
-    m_sumLayout = HorizontalLayout::Builder(
-        m_sumLayout,
+    sumLayout = HorizontalLayout::Builder(
+        sumLayout,
         functionLayout,
         LayoutHelper::String(buffer, strlen(buffer), k_font));
   }
-  m_sum.setLayout(m_sumLayout);
+  m_sum.setLayout(sumLayout);
   if (step == Step::Result) {
     m_sum.setAlignment(0.5f, 0.5f);
   } else {

--- a/apps/shared/sum_graph_controller.cpp
+++ b/apps/shared/sum_graph_controller.cpp
@@ -201,7 +201,7 @@ void SumGraphController::LegendView::setSumLayout(Step step, double start, doubl
         LayoutHelper::String(buffer, strlen(buffer), k_font),
         EmptyLayout::Builder(EmptyLayoutNode::Color::Yellow, false, k_font, false));
   } else {
-    constexpr int precision = Preferences::LargeNumberOfSignificantDigits;
+    constexpr int precision = Preferences::MediumNumberOfSignificantDigits;
     constexpr int sizeForPrecision = PrintFloat::charSizeForFloatsWithPrecision(precision);
     constexpr int bufferSize = 2 + sizeForPrecision;
     char buffer[bufferSize];

--- a/apps/shared/sum_graph_controller.cpp
+++ b/apps/shared/sum_graph_controller.cpp
@@ -150,7 +150,7 @@ void SumGraphController::reloadBannerView() {
     m_legendView.setEditableZone(m_cursor->x());
     result = NAN;
   }
-  m_legendView.setSumSymbol(m_step, m_startSum, endSum, result, functionLayout);
+  m_legendView.setSumLayout(m_step, m_startSum, endSum, result, functionLayout);
 }
 
 /* Legend View */
@@ -185,7 +185,7 @@ void SumGraphController::LegendView::setEditableZone(double d) {
   m_editableZone.setText(buffer);
 }
 
-void SumGraphController::LegendView::setSumSymbol(Step step, double start, double end, double result, Layout functionLayout) {
+void SumGraphController::LegendView::setSumLayout(Step step, double start, double end, double result, Layout functionLayout) {
   assert(step == Step::Result || functionLayout.isUninitialized());
   constexpr int sigmaLength = 2;
   const CodePoint sigma[sigmaLength] = {' ', m_sumSymbol};

--- a/apps/shared/sum_graph_controller.cpp
+++ b/apps/shared/sum_graph_controller.cpp
@@ -189,16 +189,15 @@ void SumGraphController::LegendView::setSumLayout(Step step, double start, doubl
   assert(step == Step::Result || functionLayout.isUninitialized());
   constexpr int sigmaLength = 2;
   const CodePoint sigma[sigmaLength] = {' ', m_sumSymbol};
-  Poincare::Layout sumLayout;
+  Poincare::Layout sumLayout = LayoutHelper::CodePointString(sigma, sigmaLength);
   if (step == Step::FirstParameter) {
-    sumLayout = LayoutHelper::CodePointString(sigma, sigmaLength);
   } else if (step == Step::SecondParameter) {
     constexpr int precision = Preferences::MediumNumberOfSignificantDigits;
     constexpr int bufferSize = PrintFloat::charSizeForFloatsWithPrecision(precision);
     char buffer[bufferSize];
     PoincareHelpers::ConvertFloatToTextWithDisplayMode<double>(start, buffer, bufferSize, precision, Preferences::PrintFloatMode::Decimal);
     sumLayout = CondensedSumLayout::Builder(
-        LayoutHelper::CodePointString(sigma, sigmaLength),
+        sumLayout,
         LayoutHelper::String(buffer, strlen(buffer), k_font),
         EmptyLayout::Builder(EmptyLayoutNode::Color::Yellow, false, k_font, false));
   } else {
@@ -211,7 +210,7 @@ void SumGraphController::LegendView::setSumLayout(Step step, double start, doubl
     PoincareHelpers::ConvertFloatToTextWithDisplayMode<double>(end, buffer, bufferSize, precision, Preferences::PrintFloatMode::Decimal);
     Layout end = LayoutHelper::String(buffer, strlen(buffer), k_font);
     sumLayout = CondensedSumLayout::Builder(
-        LayoutHelper::CodePointString(sigma, sigmaLength),
+        sumLayout,
         start,
         end);
     strlcpy(buffer, "= ", 3);

--- a/apps/shared/sum_graph_controller.cpp
+++ b/apps/shared/sum_graph_controller.cpp
@@ -202,8 +202,7 @@ void SumGraphController::LegendView::setSumLayout(Step step, double start, doubl
         EmptyLayout::Builder(EmptyLayoutNode::Color::Yellow, false, k_font, false));
   } else {
     constexpr int precision = Preferences::MediumNumberOfSignificantDigits;
-    constexpr int sizeForPrecision = PrintFloat::charSizeForFloatsWithPrecision(precision);
-    constexpr int bufferSize = 2 + sizeForPrecision;
+    constexpr int bufferSize = PrintFloat::charSizeForFloatsWithPrecision(precision);
     char buffer[bufferSize];
     PoincareHelpers::ConvertFloatToTextWithDisplayMode<double>(start, buffer, bufferSize, precision, Preferences::PrintFloatMode::Decimal);
     Layout start = LayoutHelper::String(buffer, strlen(buffer), k_font);
@@ -213,11 +212,11 @@ void SumGraphController::LegendView::setSumLayout(Step step, double start, doubl
         sumLayout,
         start,
         end);
-    strlcpy(buffer, "= ", 3);
-    PoincareHelpers::ConvertFloatToText<double>(result, buffer+2, bufferSize-2, precision);
+    PoincareHelpers::ConvertFloatToText<double>(result, buffer, bufferSize, precision);
     sumLayout = HorizontalLayout::Builder(
         sumLayout,
         functionLayout,
+        LayoutHelper::String("= ", 2, k_font),
         LayoutHelper::String(buffer, strlen(buffer), k_font));
   }
   m_sum.setLayout(sumLayout);

--- a/apps/shared/sum_graph_controller.cpp
+++ b/apps/shared/sum_graph_controller.cpp
@@ -222,11 +222,7 @@ void SumGraphController::LegendView::setSumLayout(Step step, double start, doubl
         LayoutHelper::String(buffer, strlen(buffer), k_font));
   }
   m_sum.setLayout(sumLayout);
-  if (step == Step::Result) {
-    m_sum.setAlignment(0.5f, 0.5f);
-  } else {
-    m_sum.setAlignment(0.0f, 0.5f);
-  }
+  m_sum.setAlignment(0.5f * (step == Step::Result), 0.5f);
   layoutSubviews(step, false);
 }
 

--- a/apps/shared/sum_graph_controller.cpp
+++ b/apps/shared/sum_graph_controller.cpp
@@ -3,7 +3,6 @@
 #include <poincare/empty_layout.h>
 #include <poincare/condensed_sum_layout.h>
 #include <poincare/layout_helper.h>
-#include <poincare/preferences.h>
 #include "poincare_helpers.h"
 
 #include <assert.h>
@@ -178,10 +177,8 @@ void SumGraphController::LegendView::setLegendMessage(I18n::Message message, Ste
 }
 
 void SumGraphController::LegendView::setEditableZone(double d) {
-  constexpr int precision = Preferences::MediumNumberOfSignificantDigits;
-  constexpr int bufferSize = PrintFloat::charSizeForFloatsWithPrecision(precision);
-  char buffer[bufferSize];
-  PoincareHelpers::ConvertFloatToTextWithDisplayMode<double>(d, buffer, bufferSize, precision, Preferences::PrintFloatMode::Decimal);
+  char buffer[k_valuesBufferSize];
+  PoincareHelpers::ConvertFloatToTextWithDisplayMode<double>(d, buffer, k_valuesBufferSize, k_valuesPrecision, Preferences::PrintFloatMode::Decimal);
   m_editableZone.setText(buffer);
 }
 
@@ -191,23 +188,21 @@ void SumGraphController::LegendView::setSumLayout(Step step, double start, doubl
   const CodePoint sigma[sigmaLength] = {' ', m_sumSymbol};
   Poincare::Layout sumLayout = LayoutHelper::CodePointString(sigma, sigmaLength);
   if (step != Step::FirstParameter) {
-    constexpr int precision = Preferences::MediumNumberOfSignificantDigits;
-    constexpr int bufferSize = PrintFloat::charSizeForFloatsWithPrecision(precision);
-    char buffer[bufferSize];
+    char buffer[k_valuesBufferSize];
     Layout endLayout;
     if (step == Step::SecondParameter) {
       endLayout = EmptyLayout::Builder(EmptyLayoutNode::Color::Yellow, false, k_font, false);
     } else {
-      PoincareHelpers::ConvertFloatToTextWithDisplayMode<double>(end, buffer, bufferSize, precision, Preferences::PrintFloatMode::Decimal);
+      PoincareHelpers::ConvertFloatToTextWithDisplayMode<double>(end, buffer, k_valuesBufferSize, k_valuesPrecision, Preferences::PrintFloatMode::Decimal);
       endLayout = LayoutHelper::String(buffer, strlen(buffer), k_font);
     }
-    PoincareHelpers::ConvertFloatToTextWithDisplayMode<double>(start, buffer, bufferSize, precision, Preferences::PrintFloatMode::Decimal);
+    PoincareHelpers::ConvertFloatToTextWithDisplayMode<double>(start, buffer, k_valuesBufferSize, k_valuesPrecision, Preferences::PrintFloatMode::Decimal);
     sumLayout = CondensedSumLayout::Builder(
         sumLayout,
         LayoutHelper::String(buffer, strlen(buffer), k_font),
         endLayout);
     if (step == Step::Result) {
-      PoincareHelpers::ConvertFloatToText<double>(result, buffer, bufferSize, precision);
+      PoincareHelpers::ConvertFloatToText<double>(result, buffer, k_valuesBufferSize, k_valuesPrecision);
       sumLayout = HorizontalLayout::Builder(
           sumLayout,
           functionLayout,

--- a/apps/shared/sum_graph_controller.h
+++ b/apps/shared/sum_graph_controller.h
@@ -57,7 +57,7 @@ private:
     void setEditableZone(double d);
     void setSumLayout(Step step, double start, double end, double result, Poincare::Layout functionLayout);
   private:
-    constexpr static KDCoordinate k_editableZoneBufferSize = Poincare::PrintFloat::k_maxFloatCharSize;
+    constexpr static size_t k_editableZoneBufferSize = Poincare::PrintFloat::k_maxFloatCharSize;
     constexpr static KDCoordinate k_legendHeight = 35;
     constexpr static const KDFont * k_font = KDFont::SmallFont;
     static KDCoordinate editableZoneWidth() { return 12*k_font->glyphSize().width(); }

--- a/apps/shared/sum_graph_controller.h
+++ b/apps/shared/sum_graph_controller.h
@@ -55,7 +55,7 @@ private:
     void drawRect(KDContext * ctx, KDRect rect) const override;
     void setLegendMessage(I18n::Message message, Step step);
     void setEditableZone(double d);
-    void setSumSymbol(Step step, double start, double end, double result, Poincare::Layout functionLayout);
+    void setSumLayout(Step step, double start, double end, double result, Poincare::Layout functionLayout);
   private:
     constexpr static KDCoordinate k_editableZoneBufferSize = Poincare::PrintFloat::k_maxFloatCharSize;
     constexpr static KDCoordinate k_legendHeight = 35;

--- a/apps/shared/sum_graph_controller.h
+++ b/apps/shared/sum_graph_controller.h
@@ -58,6 +58,8 @@ private:
     void setSumLayout(Step step, double start, double end, double result, Poincare::Layout functionLayout);
   private:
     constexpr static size_t k_editableZoneBufferSize = Poincare::PrintFloat::k_maxFloatCharSize;
+    constexpr static int k_valuesPrecision = Poincare::Preferences::MediumNumberOfSignificantDigits;
+    constexpr static int k_valuesBufferSize = Poincare::PrintFloat::charSizeForFloatsWithPrecision(k_valuesPrecision);
     constexpr static KDCoordinate k_legendHeight = 35;
     constexpr static const KDFont * k_font = KDFont::SmallFont;
     static KDCoordinate editableZoneWidth() { return 12*k_font->glyphSize().width(); }

--- a/apps/shared/sum_graph_controller.h
+++ b/apps/shared/sum_graph_controller.h
@@ -69,7 +69,6 @@ private:
     void layoutSubviews(bool force = false) override;
     void layoutSubviews(Step step, bool force);
     ExpressionView m_sum;
-    Poincare::Layout m_sumLayout;
     MessageTextView m_legend;
     TextField m_editableZone;
     char m_textBuffer[k_editableZoneBufferSize];

--- a/poincare/include/poincare/grid_layout.h
+++ b/poincare/include/poincare/grid_layout.h
@@ -95,9 +95,7 @@ public:
   static GridLayout Builder() { return TreeHandle::NAryBuilder<GridLayout,GridLayoutNode>(); }
 
   void setDimensions(int rows, int columns);
-  void addChildAtIndex(Layout l, int index, int currentNumberOfChildren, LayoutCursor * cursor) {
-    Layout::addChildAtIndex(l, index, currentNumberOfChildren, cursor);
-  }
+  using Layout::addChildAtIndex;
   int numberOfRows() const { return node()->numberOfRows(); }
   int numberOfColumns() const { return node()->numberOfColumns(); }
 private:

--- a/poincare/include/poincare/layout_node.h
+++ b/poincare/include/poincare/layout_node.h
@@ -61,7 +61,6 @@ public:
 
   // Rendering
   void draw(KDContext * ctx, KDPoint p, KDColor expressionColor = KDColorBlack, KDColor backgroundColor = KDColorWhite, Layout * selectionStart = nullptr, Layout * selectionEnd = nullptr, KDColor selectionColor = KDColorRed);
-  KDPoint origin();
   KDPoint absoluteOrigin();
   KDSize layoutSize();
   KDCoordinate baseline();

--- a/poincare/src/layout_node.cpp
+++ b/poincare/src/layout_node.cpp
@@ -39,16 +39,6 @@ void LayoutNode::draw(KDContext * ctx, KDPoint p, KDColor expressionColor, KDCol
   }
 }
 
-KDPoint LayoutNode::origin() {
-  LayoutNode * p = parent();
-  if (p == nullptr) {
-    return absoluteOrigin();
-  } else {
-    return KDPoint(absoluteOrigin().x() - p->absoluteOrigin().x(),
-        absoluteOrigin().y() - p->absoluteOrigin().y());
-  }
-}
-
 KDPoint LayoutNode::absoluteOrigin() {
   LayoutNode * p = parent();
   if (!m_positioned) {


### PR DESCRIPTION
Fixes the following bug:
In the graph tab of the Sequence app, compute the sum of the terms of
a sequence from 1 to 9 and then from 1 to 10. The Layout is memoized
after the first time and mispositioned the second time since it is
not recomputed.