### PR TITLE
Updated the month definition

### DIFF
--- a/poincare/include/poincare/unit.h
+++ b/poincare/include/poincare/unit.h
@@ -235,7 +235,7 @@ public:
         Representative("week", "7*24*60*60*_s",
             Representative::Prefixable::No,
             NoPrefix),
-        Representative("month", "30*24*60*60*_s",
+        Representative("month", "365.25/12*24*60*60*_s",
             Representative::Prefixable::No,
             NoPrefix),
         Representative("year", "365.25*24*60*60*_s",

--- a/poincare/include/poincare/unit.h
+++ b/poincare/include/poincare/unit.h
@@ -235,7 +235,7 @@ public:
         Representative("week", "7*24*60*60*_s",
             Representative::Prefixable::No,
             NoPrefix),
-        Representative("month", "30*7*24*60*60*_s",
+        Representative("month", "30*24*60*60*_s",
             Representative::Prefixable::No,
             NoPrefix),
         Representative("year", "365.25*24*60*60*_s",


### PR DESCRIPTION
Based on : https://github.com/numworks/epsilon/pull/1367#issuecomment-594035282

- Updated the month to 30 days, and not 30*7 days

- Updated the month to 1 year / 12