### PR TITLE
Fix cursor view in sequence

### DIFF
--- a/apps/shared/cursor_view.h
+++ b/apps/shared/cursor_view.h
@@ -1,11 +1,11 @@
 #ifndef SHARED_CURSOR_VIEW_H
 #define SHARED_CURSOR_VIEW_H
 
-#include <escher.h>
+#include <escher/transparent_view.h>
 
 namespace Shared {
 
-class CursorView : public View {
+class CursorView : public TransparentView {
 public:
   virtual void setCursorFrame(KDRect frame, bool force) { View::setFrame(frame, force); }
   void drawRect(KDContext * ctx, KDRect rect) const override;

--- a/apps/shared/round_cursor_view.cpp
+++ b/apps/shared/round_cursor_view.cpp
@@ -50,6 +50,10 @@ void RoundCursorView::setCursorFrame(KDRect f, bool force) {
 }
 
 void RoundCursorView::markRectAsDirty(KDRect rect) {
+  /* The CursorView class inherits from TransparentView, so does
+   * RoundCursorView. The method markRectAsDirty is thus overriden to avoid
+   * marking as dirty the background of the RoundCursorView in its superview.
+   */
   View::markRectAsDirty(rect);
 }
 

--- a/apps/shared/round_cursor_view.cpp
+++ b/apps/shared/round_cursor_view.cpp
@@ -49,6 +49,10 @@ void RoundCursorView::setCursorFrame(KDRect f, bool force) {
   CursorView::setCursorFrame(f, force);
 }
 
+void RoundCursorView::markRectAsDirty(KDRect rect) {
+  View::markRectAsDirty(rect);
+}
+
 #ifdef GRAPH_CURSOR_SPEEDUP
 bool RoundCursorView::eraseCursorIfPossible() {
   if (!m_underneathPixelBufferLoaded) {

--- a/apps/shared/round_cursor_view.h
+++ b/apps/shared/round_cursor_view.h
@@ -24,6 +24,7 @@ public:
   void resetMemoization() const { m_underneathPixelBufferLoaded = false; }
 #endif
 private:
+  void markRectAsDirty(KDRect rect) override;
 #ifdef GRAPH_CURSOR_SPEEDUP
   bool eraseCursorIfPossible();
 #endif

--- a/escher/include/escher/transparent_view.h
+++ b/escher/include/escher/transparent_view.h
@@ -4,7 +4,7 @@
 #include <escher/view.h>
 
 class TransparentView : public View {
-public:
+protected:
   void markRectAsDirty(KDRect rect) override;
 };
 

--- a/escher/src/transparent_view.cpp
+++ b/escher/src/transparent_view.cpp
@@ -2,7 +2,7 @@
 
 void TransparentView::markRectAsDirty(KDRect rect) {
   if (m_superview) {
-    m_superview->markRectAsDirty(KDRect(rect.translatedBy(m_frame.origin())));
+    m_superview->markRectAsDirty(rect.translatedBy(m_frame.origin()));
   }
   View::markRectAsDirty(rect);
 }


### PR DESCRIPTION
CursorView's background was not redrawn.

Scenario:
In the Sequences app, say with the sequence u_n = 0, make the x-range large enough (`xmax - xmin > 50`) so that the successive points are very close to each other. Observe that after moving the cursor with left and right arrow keys, the background of the cursor is not redrawn.
The same probably went in the Regression app.