### PR TITLE
[apps/statistics] Remove unused variable in HistogramView

### DIFF
--- a/apps/statistics/histogram_view.h
+++ b/apps/statistics/histogram_view.h
@@ -23,7 +23,6 @@ public:
 private:
   HistogramController * m_controller;
   Store * m_store;
-  char m_labels[k_maxNumberOfXLabels][k_labelBufferMaxSize];
   static float EvaluateHistogramAtAbscissa(float abscissa, void * model, void * context);
   float m_highlightedBarStart;
   float m_highlightedBarEnd;


### PR DESCRIPTION
It is unused as HistogramView now inherits Shared::HorizontallyLabeledCurveView