### PR TITLE
Fix simplification and approximation2

### DIFF
--- a/poincare/src/arithmetic.cpp
+++ b/poincare/src/arithmetic.cpp
@@ -7,6 +7,9 @@ Integer Arithmetic::LCM(const Integer & a, const Integer & b) {
   if (a.isZero() || b.isZero()) {
     return Integer(0);
   }
+  if (a.isEqualTo(b)) {
+    return a;
+  }
   Integer signResult = Integer::Division(Integer::Multiplication(a, b), GCD(a, b)).quotient;
   signResult.setNegative(false);
   return signResult;
@@ -16,7 +19,9 @@ Integer Arithmetic::GCD(const Integer & a, const Integer & b) {
   if (a.isOverflow() || b.isOverflow()) {
     return Integer::Overflow(false);
   }
-
+  if (a.isEqualTo(b)) {
+    return a;
+  }
   Integer i = a;
   Integer j = b;
   i.setNegative(false);

--- a/poincare/src/multiplication.cpp
+++ b/poincare/src/multiplication.cpp
@@ -588,8 +588,10 @@ Expression Multiplication::privateShallowReduce(ExpressionNode::ReductionContext
    * which also are multiplications themselves. */
   mergeMultiplicationChildrenInPlace();
 
+  Context * context = reductionContext.context();
+
   // Step 2: Sort the children
-  sortChildrenInPlace([](const ExpressionNode * e1, const ExpressionNode * e2, bool canBeInterrupted) { return ExpressionNode::SimplificationOrder(e1, e2, true, canBeInterrupted); }, reductionContext.context(), true);
+  sortChildrenInPlace([](const ExpressionNode * e1, const ExpressionNode * e2, bool canBeInterrupted) { return ExpressionNode::SimplificationOrder(e1, e2, true, canBeInterrupted); }, context, true);
 
   // Step 3: Handle matrices
   /* Thanks to the simplification order, all matrix children (if any) are the
@@ -664,7 +666,7 @@ Expression Multiplication::privateShallowReduce(ExpressionNode::ReductionContext
      * interval). */
 
     if (multiplicationChildIndex >= 0) {
-      if (childAtIndex(multiplicationChildIndex).deepIsMatrix(reductionContext.context())) {
+      if (childAtIndex(multiplicationChildIndex).deepIsMatrix(context)) {
         return *this;
       }
       removeChildInPlace(resultMatrix, resultMatrix.numberOfChildren());
@@ -677,7 +679,7 @@ Expression Multiplication::privateShallowReduce(ExpressionNode::ReductionContext
       }
     }
     replaceWithInPlace(resultMatrix);
-    return resultMatrix.shallowReduce(reductionContext.context());
+    return resultMatrix.shallowReduce(context);
   }
 
   /* Step 4: Gather like terms. For example, turn pi^2*pi^3 into pi^5. Thanks to
@@ -687,7 +689,7 @@ Expression Multiplication::privateShallowReduce(ExpressionNode::ReductionContext
   while (i < numberOfChildren()-1) {
     Expression oi = childAtIndex(i);
     Expression oi1 = childAtIndex(i+1);
-    if (oi.recursivelyMatches(Expression::IsRandom, reductionContext.context(), true)) {
+    if (oi.recursivelyMatches(Expression::IsRandom, context, true)) {
       // Do not factorize random or randint
       i++;
       continue;
@@ -735,7 +737,7 @@ Expression Multiplication::privateShallowReduce(ExpressionNode::ReductionContext
     /* Replacing sin/cos by tan factors may have mixed factors and factors are
      * guaranteed to be sorted (according ot SimplificationOrder) at the end of
      * shallowReduce */
-    sortChildrenInPlace([](const ExpressionNode * e1, const ExpressionNode * e2, bool canBeInterrupted) { return ExpressionNode::SimplificationOrder(e1, e2, true, canBeInterrupted); }, reductionContext.context(), true);
+    sortChildrenInPlace([](const ExpressionNode * e1, const ExpressionNode * e2, bool canBeInterrupted) { return ExpressionNode::SimplificationOrder(e1, e2, true, canBeInterrupted); }, context, true);
   }
 
   /* Step 6: We remove rational children that appeared in the middle of sorted
@@ -779,7 +781,7 @@ Expression Multiplication::privateShallowReduce(ExpressionNode::ReductionContext
     const Expression c = childAtIndex(0);
     if (c.type() == ExpressionNode::Type::Rational && static_cast<const Rational &>(c).isZero()) {
       // Check that other children don't match inf or unit
-      bool infiniteOrUnitFactor = recursivelyMatches([](const Expression e, Context * context) { return Expression::IsInfinity(e,context) || e.type() == ExpressionNode::Type::Unit; }, reductionContext.context());
+      bool infiniteOrUnitFactor = recursivelyMatches([](const Expression e, Context * context) { return Expression::IsInfinity(e,context) || e.type() == ExpressionNode::Type::Unit; }, context);
       if (!infiniteOrUnitFactor) {
         replaceWithInPlace(c);
         return c;
@@ -798,7 +800,7 @@ Expression Multiplication::privateShallowReduce(ExpressionNode::ReductionContext
    * reduce expressions such as (x+y)^(-1)*(x+y)(a+b).
    * If there is a random somewhere, do not expand. */
   Expression p = parent();
-  bool hasRandom = recursivelyMatches(Expression::IsRandom, reductionContext.context(), true);
+  bool hasRandom = recursivelyMatches(Expression::IsRandom, context, true);
   if (shouldExpand
       && (p.isUninitialized() || p.type() != ExpressionNode::Type::Multiplication)
       && !hasRandom)
@@ -825,7 +827,7 @@ Expression Multiplication::privateShallowReduce(ExpressionNode::ReductionContext
    * - All children are either real or ComplexCartesian (allChildrenAreReal == 0)
    *   We can bubble up ComplexCartesian nodes.
    * Do not simplify if there are randoms !*/
-  if (!hasRandom && allChildrenAreReal(reductionContext.context()) == 0) {
+  if (!hasRandom && allChildrenAreReal(context) == 0) {
     int nbChildren = numberOfChildren();
     int i = nbChildren-1;
     // Children are sorted so ComplexCartesian nodes are at the end

--- a/poincare/src/multiplication.cpp
+++ b/poincare/src/multiplication.cpp
@@ -760,6 +760,14 @@ Expression Multiplication::privateShallowReduce(ExpressionNode::ReductionContext
       if (childAtIndex(0).isNumber()) {
         Number o0 = childAtIndex(0).convert<Rational>();
         Number m = Number::Multiplication(o0, static_cast<Number &>(o));
+        if ((IsInfinity(m, context) || m.isUndefined())
+            && !IsInfinity(o0, context) && !o0.isUndefined()
+            && !IsInfinity(o, context) && !o.isUndefined())
+        {
+          // Stop the reduction due to a multiplication overflow
+          SetInterruption(true);
+          return *this;
+        }
         replaceChildAtIndexInPlace(0, m);
         removeChildAtIndexInPlace(i);
       } else {

--- a/poincare/test/approximation.cpp
+++ b/poincare/test/approximation.cpp
@@ -938,6 +938,9 @@ QUIZ_CASE(poincare_approximation_mix) {
   assert_expression_approximates_to<double>("sin(3)2(4+2)", "1.6934400967184", Radian);
   assert_expression_approximates_to<float>("4/2×(2+3)", "10");
   assert_expression_approximates_to<double>("4/2×(2+3)", "10");
+
+  assert_expression_simplifies_and_approximates_to("1.0092^(20)", "1.2010050593402");
+  assert_expression_simplifies_and_approximates_to("1.0092^(50)×ln(3/2)", "6.4093734888993ᴇ-1");
 }
 
 

--- a/poincare/test/approximation.cpp
+++ b/poincare/test/approximation.cpp
@@ -941,6 +941,14 @@ QUIZ_CASE(poincare_approximation_mix) {
 
   assert_expression_simplifies_and_approximates_to("1.0092^(20)", "1.2010050593402");
   assert_expression_simplifies_and_approximates_to("1.0092^(50)×ln(3/2)", "6.4093734888993ᴇ-1");
+  assert_expression_approximates_to<double>("1.0092^(20)", "1.2010050593402");
+  assert_expression_approximates_to<double>("1.0092^(50)×ln(3/2)", "6.4093734888993ᴇ-1");
+  assert_expression_simplifies_approximates_to<double>("1.0092^(20)", "1.2010050593402");
+  assert_expression_simplifies_approximates_to<double>("1.0092^(50)×ln(3/2)", "6.4093734888993ᴇ-1");
+  //assert_expression_approximates_to<float>("1.0092^(20)", "1.201005"); TODO does not work
+  assert_expression_approximates_to<float>("1.0092^(50)×ln(3/2)", "0.6409366");
+  //assert_expression_simplifies_approximates_to<float>("1.0092^(20)", "1.2010050593402"); TODO does not work
+  //assert_expression_simplifies_approximates_to<float>("1.0092^(50)×ln(3/2)", "6.4093734888993ᴇ-1"); TODO does not work
 }
 
 

--- a/poincare/test/approximation.cpp
+++ b/poincare/test/approximation.cpp
@@ -940,11 +940,11 @@ QUIZ_CASE(poincare_approximation_mix) {
   assert_expression_approximates_to<double>("4/2×(2+3)", "10");
 
   assert_expression_simplifies_and_approximates_to("1.0092^(20)", "1.2010050593402");
-  assert_expression_simplifies_and_approximates_to("1.0092^(50)×ln(3/2)", "6.4093734888993ᴇ-1");
+  assert_expression_simplifies_and_approximates_to("1.0092^(50)×ln(3/2)", "0.6409373488899", Degree, Cartesian, 13);
   assert_expression_approximates_to<double>("1.0092^(20)", "1.2010050593402");
-  assert_expression_approximates_to<double>("1.0092^(50)×ln(3/2)", "6.4093734888993ᴇ-1");
+  assert_expression_approximates_to<double>("1.0092^(50)×ln(3/2)", "0.6409373488899", Degree, Cartesian, 13);
   assert_expression_simplifies_approximates_to<double>("1.0092^(20)", "1.2010050593402");
-  assert_expression_simplifies_approximates_to<double>("1.0092^(50)×ln(3/2)", "6.4093734888993ᴇ-1");
+  assert_expression_simplifies_approximates_to<double>("1.0092^(50)×ln(3/2)", "0.6409373488899", Degree, Cartesian, 13);
   //assert_expression_approximates_to<float>("1.0092^(20)", "1.201005"); TODO does not work
   assert_expression_approximates_to<float>("1.0092^(50)×ln(3/2)", "0.6409366");
   //assert_expression_simplifies_approximates_to<float>("1.0092^(20)", "1.2010050593402"); TODO does not work

--- a/poincare/test/approximation.cpp
+++ b/poincare/test/approximation.cpp
@@ -941,8 +941,10 @@ QUIZ_CASE(poincare_approximation_mix) {
 
   assert_expression_simplifies_and_approximates_to("1.0092^(20)", "1.2010050593402");
   assert_expression_simplifies_and_approximates_to("1.0092^(50)×ln(3/2)", "0.6409373488899", Degree, Cartesian, 13);
+  assert_expression_simplifies_and_approximates_to("1.0092^(50)×ln(1.0092)", "1.447637354655ᴇ-2", Degree, Cartesian, 13);
   assert_expression_approximates_to<double>("1.0092^(20)", "1.2010050593402");
   assert_expression_approximates_to<double>("1.0092^(50)×ln(3/2)", "0.6409373488899", Degree, Cartesian, 13);
+  assert_expression_approximates_to<double>("1.0092^(50)×ln(1.0092)", "1.447637354655ᴇ-2", Degree, Cartesian, 13);
   assert_expression_simplifies_approximates_to<double>("1.0092^(20)", "1.2010050593402");
   assert_expression_simplifies_approximates_to<double>("1.0092^(50)×ln(3/2)", "0.6409373488899", Degree, Cartesian, 13);
   //assert_expression_approximates_to<float>("1.0092^(20)", "1.201005"); TODO does not work

--- a/poincare/test/helper.cpp
+++ b/poincare/test/helper.cpp
@@ -108,6 +108,16 @@ void assert_expression_approximates_to(const char * expression, const char * app
     }, numberOfDigits);
 }
 
+void assert_expression_simplifies_and_approximates_to(const char * expression, const char * approximation, Preferences::AngleUnit angleUnit, Preferences::ComplexFormat complexFormat, int numberOfSignificantDigits) {
+  int numberOfDigits = numberOfSignificantDigits > 0 ? numberOfSignificantDigits : PrintFloat::k_numberOfStoredSignificantDigits;
+  assert_parsed_expression_process_to(expression, approximation, SystemForApproximation, complexFormat, angleUnit, ReplaceAllSymbolsWithDefinitionsOrUndefined, [](Expression e, ExpressionNode::ReductionContext reductionContext) {
+      Expression reduced;
+      Expression approximated;
+      e.simplifyAndApproximate(&reduced, &approximated, reductionContext.context(), reductionContext.complexFormat(), reductionContext.angleUnit(), reductionContext.symbolicComputation());
+      return approximated;
+    }, numberOfDigits);
+}
+
 template<typename T>
 void assert_expression_simplifies_approximates_to(const char * expression, const char * approximation, Preferences::AngleUnit angleUnit, Preferences::ComplexFormat complexFormat, int numberOfSignificantDigits) {
   int numberOfDigits = sizeof(T) == sizeof(double) ? PrintFloat::k_numberOfStoredSignificantDigits : PrintFloat::k_numberOfPrintedSignificantDigits;

--- a/poincare/test/helper.h
+++ b/poincare/test/helper.h
@@ -43,6 +43,7 @@ void assert_parsed_expression_simplify_to(const char * expression, const char * 
 
 template<typename T>
 void assert_expression_approximates_to(const char * expression, const char * approximation, Poincare::Preferences::AngleUnit angleUnit = Degree, Poincare::Preferences::ComplexFormat complexFormat = Cartesian, int numberOfSignificantDigits = -1);
+void assert_expression_simplifies_and_approximates_to(const char * expression, const char * approximation, Poincare::Preferences::AngleUnit angleUnit = Degree, Poincare::Preferences::ComplexFormat complexFormat = Cartesian, int numberOfSignificantDigits = -1);
 template<typename T>
 void assert_expression_simplifies_approximates_to(const char * expression, const char * approximation, Poincare::Preferences::AngleUnit angleUnit = Degree, Poincare::Preferences::ComplexFormat complexFormat = Cartesian, int numberOfSignificantDigits = -1);
 


### PR DESCRIPTION
This fixes the computation of 1.0092^50*ln(3/2), that returned 0 due to an overflow when computing a LCM.