### PR TITLE
[build] Signing android apps is easier

### DIFF
--- a/ion/src/simulator/android/Makefile
+++ b/ion/src/simulator/android/Makefile
@@ -72,14 +72,13 @@ $(eval $(call rule_for_gradle,assembleRelease,.official.))
 
 DEFAULT = epsilon.apk
 
-.PHONY: epsilon%apk
-ifdef ANDROID_SIGNING_STORE_FILE
-epsilon%apk: gradle_assembleCodesigned_%
-else
-epsilon%apk: gradle_assembleRelease_%
-	$(warning Building without code signing. Define ANDROID_SIGNING_STORE_FILE, ANDROID_SIGNING_STORE_PASSWORD, ANDROID_SIGNING_KEY_ALIAS and  ANDROID_SIGNING_KEY_PASSWORD for a signed build.)
-endif
+.PHONY: epsilon%signed.apk
+epsilon%signed.apk: gradle_assembleCodesigned_%
+	$(warning This is a signed build.)
 
+.PHONY: epsilon%apk
+epsilon%apk: gradle_assembleRelease_%
+	$(warning Building without code signing. Build epsilon$*signed.apk to generate a signed version.)
 
 .PHONY: epsilon_run
 epsilon_run: gradle_installDebug

--- a/ion/src/simulator/android/build.gradle
+++ b/ion/src/simulator/android/build.gradle
@@ -1,5 +1,15 @@
 def BUILD_DIR = '../../../../'+System.getenv('BUILD_DIR')+'/app'
 
+def projectVariable(name) {
+  /* This function retrieves a variable from the environment and falls back
+   * to the Gradle projects's properties (e.g. ~/.gradle/gradle.properties) */
+  return System.getenv('ANDROID_'+name) ?: project.findProperty('EPSILON_'+name)
+}
+
+def fileIfPath(path) {
+  return path ? new File(path) : null
+}
+
 buildscript {
   repositories {
     jcenter()
@@ -33,10 +43,10 @@ android {
   }
   signingConfigs {
     environment {
-      storeFile System.getenv('ANDROID_SIGNING_STORE_FILE') ? new File(System.getenv('RELEASE_STORE_FILE')) : null
-      storePassword System.getenv('ANDROID_SIGNING_STORE_PASSWORD')
-      keyAlias System.getenv('ANDROID_SIGNING_KEY_ALIAS')
-      keyPassword System.getenv('ANDROID_SIGNING_KEY_PASSWORD')
+      storeFile fileIfPath(projectVariable('SIGNING_STORE_FILE'))
+      storePassword projectVariable('SIGNING_STORE_PASSWORD')
+      keyAlias projectVariable('SIGNING_KEY_ALIAS')
+      keyPassword projectVariable('SIGNING_KEY_PASSWORD')
     }
   }
   buildTypes {


### PR DESCRIPTION
Signing parameters can be passed on the command line, e.g. "ANDROID_SIGNING_STORE_FILE=foobar", or they can be written to a ~/.gradle/gradle.properties file using the "EPSILON_SIGNING_STORE_FILE=foobar" syntax.