### PR TITLE
Changes for optionally disabling (most) float computation functions

### DIFF
--- a/apps/calculation/additional_outputs/complex_graph_cell.cpp
+++ b/apps/calculation/additional_outputs/complex_graph_cell.cpp
@@ -29,7 +29,11 @@ void ComplexGraphView::drawRect(KDContext * ctx, KDRect rect) const {
   drawCurve(ctx, rect, 0.0f, 1.0f, 0.01f,
       [](float t, void * model, void * context) {
         ComplexModel * complexModel = (ComplexModel *)model;
+#if POINCARE_FLOAT_SUPPORT
         return Poincare::Coordinate2D<float>(complexModel->real()*t, complexModel->imag()*t);
+#else
+        return Poincare::Coordinate2D<double>(complexModel->real()*t, complexModel->imag()*t);
+#endif
       }, m_complex, nullptr, false, Palette::GreyDark, false);
 
   /* Draw the partial ellipse indicating the angle θ
@@ -62,7 +66,11 @@ void ComplexGraphView::drawRect(KDContext * ctx, KDRect rect) const {
         float th = *(float *)context;
         float a = parameters.real();
         float b = parameters.imag();
+#if POINCARE_FLOAT_SUPPORT
         return Poincare::Coordinate2D<float>(a*std::cos(t*th), b*std::sin(t*th));
+#else
+        return Poincare::Coordinate2D<double>(a*std::cos(t*th), b*std::sin(t*th));
+#endif
     }, &parameters, &th, false, Palette::GreyDark, false);
 
   // Draw dashed segment to indicate real and imaginary

--- a/apps/calculation/additional_outputs/complex_list_controller.cpp
+++ b/apps/calculation/additional_outputs/complex_list_controller.cpp
@@ -33,9 +33,14 @@ void ComplexListController::setExpression(Poincare::Expression e) {
 
   // Set Complex illustration
   // Compute a and b as in Expression::hasDefinedComplexApproximation to ensure the same defined result
+#if POINCARE_FLOAT_SUPPORT
   float a = Shared::PoincareHelpers::ApproximateToScalar<float>(RealPart::Builder(e.clone()), context);
   float b = Shared::PoincareHelpers::ApproximateToScalar<float>(ImaginaryPart::Builder(e.clone()), context);
-  m_model.setComplex(std::complex<float>(a,b));
+#else
+  double a = Shared::PoincareHelpers::ApproximateToScalar<double>(RealPart::Builder(e.clone()), context);
+  double b = Shared::PoincareHelpers::ApproximateToScalar<double>(ImaginaryPart::Builder(e.clone()), context);
+#endif
+  m_model.setComplex(std::complex<float>((float)a, (float)b));
 
   // Reset complex format as before
   preferences->setComplexFormat(currentComplexFormat);

--- a/apps/calculation/additional_outputs/trigonometry_graph_cell.cpp
+++ b/apps/calculation/additional_outputs/trigonometry_graph_cell.cpp
@@ -19,7 +19,11 @@ void TrigonometryGraphView::drawRect(KDContext * ctx, KDRect rect) const {
   drawAxes(ctx, rect);
   // Draw the circle
   drawCurve(ctx, rect, 0.0f, 2.0f*M_PI, M_PI/180.0f, [](float t, void * model, void * context) {
+#if POINCARE_FLOAT_SUPPORT
       return Poincare::Coordinate2D<float>(std::cos(t), std::sin(t));
+#else
+      return Poincare::Coordinate2D<double>(std::cos(t), std::sin(t));
+#endif
     }, nullptr, nullptr, true, Palette::GreyDark, false);
   // Draw dashed segment to indicate sine and cosine
   drawSegment(ctx, rect, Axis::Vertical, c, 0.0f, s, Palette::Red, 1, 3);

--- a/apps/calculation/additional_outputs/trigonometry_list_controller.cpp
+++ b/apps/calculation/additional_outputs/trigonometry_list_controller.cpp
@@ -16,8 +16,12 @@ void TrigonometryListController::setExpression(Poincare::Expression e) {
   m_calculationStore.push("θ", context);
 
   // Set trigonometry illustration
+#if POINCARE_FLOAT_SUPPORT
   float angle = Shared::PoincareHelpers::ApproximateToScalar<float>(m_calculationStore.calculationAtIndex(0)->approximateOutput(context, Calculation::NumberOfSignificantDigits::Maximal), context);
-  m_model.setAngle(angle);
+#else
+  double angle = Shared::PoincareHelpers::ApproximateToScalar<double>(m_calculationStore.calculationAtIndex(0)->approximateOutput(context, Calculation::NumberOfSignificantDigits::Maximal), context);
+#endif
+  m_model.setAngle((float)angle);
 }
 
 }

--- a/apps/graph/graph/graph_controller.cpp
+++ b/apps/graph/graph/graph_controller.cpp
@@ -48,7 +48,11 @@ void GraphController::interestingFunctionRange(ExpiringPointer<ContinuousFunctio
   const int balancedBound = std::floor((tMax-tMin)/2/step);
   for (int j = -balancedBound; j <= balancedBound ; j++) {
     float t = (tMin+tMax)/2 + step * j;
+#if POINCARE_FLOAT_SUPPORT
     Coordinate2D<float> xy = f->evaluateXYAtParameter(t, context);
+#else
+    Coordinate2D<double> xy = f->evaluateXYAtParameter(t, context);
+#endif
     float x = xy.x1();
     float y = xy.x2();
     if (!std::isnan(x) && !std::isinf(x) && !std::isnan(y) && !std::isinf(y)) {

--- a/apps/graph/graph/graph_view.cpp
+++ b/apps/graph/graph/graph_view.cpp
@@ -65,7 +65,11 @@ void GraphView::drawRect(KDContext * ctx, KDRect rect) const {
         tangentParameter[1] = -tangentParameter[0]*m_curveViewCursor->x()+f->evaluateXYAtParameter(m_curveViewCursor->x(), context()).x2();
         drawCartesianCurve(ctx, rect, -INFINITY, INFINITY, [](float t, void * model, void * context) {
               float * tangent = (float *)model;
+#if POINCARE_FLOAT_SUPPORT
               return Poincare::Coordinate2D<float>(t, tangent[0]*t+tangent[1]);
+#else
+              return Poincare::Coordinate2D<double>(t, tangent[0]*t+tangent[1]);
+#endif
             }, tangentParameter, nullptr, Palette::GreyVeryDark);
       }
       continue;

--- a/apps/graph/list/domain_parameter_controller.cpp
+++ b/apps/graph/list/domain_parameter_controller.cpp
@@ -8,7 +8,11 @@ using namespace Shared;
 namespace Graph {
 
 DomainParameterController::DomainParameterController(Responder * parentResponder, InputEventHandlerDelegate * inputEventHandlerDelegate) :
+#if POINCARE_FLOAT_SUPPORT
   FloatParameterController<float>(parentResponder),
+#else
+  FloatParameterController<double>(parentResponder),
+#endif
   m_domainCells{},
   m_record()
 {
@@ -73,11 +77,19 @@ bool DomainParameterController::handleEvent(Ion::Events::Event event) {
   return false;
 }
 
+#if POINCARE_FLOAT_SUPPORT
 float DomainParameterController::parameterAtIndex(int index) {
+#else
+double DomainParameterController::parameterAtIndex(int index) {
+#endif
   return index == 0 ? function()->tMin() : function()->tMax();
 }
 
+#if POINCARE_FLOAT_SUPPORT
 bool DomainParameterController::setParameterAtIndex(int parameterIndex, float f) {
+#else
+bool DomainParameterController::setParameterAtIndex(int parameterIndex, double f) {
+#endif
   // TODO: what to do if the xmin > xmax?
   parameterIndex == 0 ? function()->setTMin(f) : function()->setTMax(f);
   return true;
@@ -95,6 +107,7 @@ Shared::ExpiringPointer<Shared::ContinuousFunction> DomainParameterController::f
   return myApp->functionStore()->modelForRecord(m_record);
 }
 
+#if POINCARE_FLOAT_SUPPORT
 FloatParameterController<float>::InfinityTolerance DomainParameterController::infinityAllowanceForRow(int row) const {
   Shared::ContinuousFunction::PlotType plotType = function()->plotType();
   if (plotType == Shared::ContinuousFunction::PlotType::Cartesian) {
@@ -102,5 +115,14 @@ FloatParameterController<float>::InfinityTolerance DomainParameterController::in
   }
   return FloatParameterController<float>::InfinityTolerance::None;
 }
+#else
+FloatParameterController<double>::InfinityTolerance DomainParameterController::infinityAllowanceForRow(int row) const {
+  Shared::ContinuousFunction::PlotType plotType = function()->plotType();
+  if (plotType == Shared::ContinuousFunction::PlotType::Cartesian) {
+    return row == 0 ? FloatParameterController<double>::InfinityTolerance::MinusInfinity : FloatParameterController<double>::InfinityTolerance::PlusInfinity;
+  }
+  return FloatParameterController<double>::InfinityTolerance::None;
+}
+#endif
 
 }

--- a/apps/graph/list/domain_parameter_controller.h
+++ b/apps/graph/list/domain_parameter_controller.h
@@ -9,7 +9,11 @@
 
 namespace Graph {
 
+#if POINCARE_FLOAT_SUPPORT
 class DomainParameterController : public Shared::FloatParameterController<float> {
+#else
+class DomainParameterController : public Shared::FloatParameterController<double> {
+#endif
 public:
   DomainParameterController(Responder * parentResponder, InputEventHandlerDelegate * inputEventHandlerDelegate);
 
@@ -27,8 +31,13 @@ private:
   int reusableParameterCellCount(int type) override;
   HighlightCell * reusableParameterCell(int index, int type) override;
   bool handleEvent(Ion::Events::Event event) override;
+#if POINCARE_FLOAT_SUPPORT
   bool setParameterAtIndex(int parameterIndex, float f) override;
   float parameterAtIndex(int index) override;
+#else
+  bool setParameterAtIndex(int parameterIndex, double f) override;
+  double parameterAtIndex(int index) override;
+#endif
   void buttonAction() override;
   InfinityTolerance infinityAllowanceForRow(int row) const override;
   Shared::ExpiringPointer<Shared::ContinuousFunction> function() const;

--- a/apps/probability/distribution_curve_view.cpp
+++ b/apps/probability/distribution_curve_view.cpp
@@ -42,14 +42,24 @@ char * DistributionCurveView::label(Axis axis, int index) const {
   return (char *)m_labels[index];
 }
 
+#if POINCARE_FLOAT_SUPPORT
 float DistributionCurveView::EvaluateAtAbscissa(float abscissa, void * model, void * context) {
+#else
+double DistributionCurveView::EvaluateAtAbscissa(float abscissa, void * model, void * context) {
+#endif
   Distribution * distribution = (Distribution *)model;
   return distribution->evaluateAtAbscissa(abscissa);
 }
 
+#if POINCARE_FLOAT_SUPPORT
 Poincare::Coordinate2D<float> DistributionCurveView::EvaluateXYAtAbscissa(float abscissa, void * model, void * context) {
   return Poincare::Coordinate2D<float>(abscissa, EvaluateAtAbscissa(abscissa, model, context));
 }
+#else
+Poincare::Coordinate2D<double> DistributionCurveView::EvaluateXYAtAbscissa(float abscissa, void * model, void * context) {
+  return Poincare::Coordinate2D<double>(abscissa, EvaluateAtAbscissa(abscissa, model, context));
+}
+#endif
 
 void DistributionCurveView::drawStandardNormal(KDContext * ctx, KDRect rect, float colorLowerBoundPixel, float colorUpperBoundPixel) const {
   // Save the previous curve view range

--- a/apps/probability/distribution_curve_view.h
+++ b/apps/probability/distribution_curve_view.h
@@ -28,8 +28,13 @@ public:
 protected:
   char * label(Axis axis, int index) const override;
 private:
+#if POINCARE_FLOAT_SUPPORT
   static float EvaluateAtAbscissa(float abscissa, void * model, void * context);
   static Poincare::Coordinate2D<float> EvaluateXYAtAbscissa(float abscissa, void * model, void * context);
+#else
+  static double EvaluateAtAbscissa(float abscissa, void * model, void * context);
+  static Poincare::Coordinate2D<double> EvaluateXYAtAbscissa(float abscissa, void * model, void * context);
+#endif
   static constexpr KDColor k_backgroundColor = Palette::WallScreen;
   void drawStandardNormal(KDContext * ctx, KDRect rect, float colorLowerBound, float colorUpperBound) const;
   char m_labels[k_maxNumberOfXLabels][k_labelBufferMaxSize];

--- a/apps/probability/parameters_controller.cpp
+++ b/apps/probability/parameters_controller.cpp
@@ -137,11 +137,19 @@ int ParametersController::reusableParameterCellCount(int type) {
   return m_distribution->numberOfParameter();
 }
 
+#if POINCARE_FLOAT_SUPPORT
 float ParametersController::parameterAtIndex(int index) {
+#else
+double ParametersController::parameterAtIndex(int index) {
+#endif
   return m_distribution->parameterValueAtIndex(index);
 }
 
+#if POINCARE_FLOAT_SUPPORT
 bool ParametersController::setParameterAtIndex(int parameterIndex, float f) {
+#else
+bool ParametersController::setParameterAtIndex(int parameterIndex, double f) {
+#endif
   if (!m_distribution->authorizedValueAtIndex(f, parameterIndex)) {
     Container::activeApp()->displayWarning(I18n::Message::ForbiddenValue);
     return false;

--- a/apps/probability/parameters_controller.h
+++ b/apps/probability/parameters_controller.h
@@ -8,7 +8,11 @@
 
 namespace Probability {
 
+#if POINCARE_FLOAT_SUPPORT
 class ParametersController : public Shared::FloatParameterController<float> {
+#else
+class ParametersController : public Shared::FloatParameterController<double> {
+#endif
 public:
   ParametersController(Responder * parentResponder, InputEventHandlerDelegate * inputEventHandlerDelegate, Distribution * m_distribution, CalculationController * calculationController);
   const char * title() override;
@@ -24,8 +28,13 @@ private:
   HighlightCell * reusableParameterCell(int index, int type) override;
   int reusableParameterCellCount(int type) override;
   void buttonAction() override;
+#if POINCARE_FLOAT_SUPPORT
   float parameterAtIndex(int index) override;
   bool setParameterAtIndex(int parameterIndex, float f) override;
+#else
+  double parameterAtIndex(int index) override;
+  bool setParameterAtIndex(int parameterIndex, double f) override;
+#endif
   bool textFieldDidFinishEditing(TextField * textField, const char * text, Ion::Events::Event event) override;
   class ContentView : public View {
   public:

--- a/apps/regression/graph_view.cpp
+++ b/apps/regression/graph_view.cpp
@@ -27,7 +27,11 @@ void GraphView::drawRect(KDContext * ctx, KDRect rect) const {
       drawCartesianCurve(ctx, rect, -INFINITY, INFINITY, [](float abscissa, void * model, void * context) {
           Model * regressionModel = static_cast<Model *>(model);
           double * regressionCoefficients = static_cast<double *>(context);
+#if POINCARE_FLOAT_SUPPORT
           return Poincare::Coordinate2D<float>(abscissa, (float)regressionModel->evaluate(regressionCoefficients, abscissa));
+#else
+          return Poincare::Coordinate2D<double>(abscissa, (float)regressionModel->evaluate(regressionCoefficients, abscissa));
+#endif
           },
           seriesModel, m_store->coefficientsForSeries(series, globContext), color);
       for (int index = 0; index < m_store->numberOfPairsOfSeries(series); index++) {

--- a/apps/sequence/cache_context.cpp
+++ b/apps/sequence/cache_context.cpp
@@ -50,7 +50,9 @@ int CacheContext<T>::rankIndexForSymbol(const Poincare::Symbol & symbol) {
   return 1;
 }
 
+#if POINCARE_FLOAT_SUPPORT
 template class CacheContext<float>;
+#endif
 template class CacheContext<double>;
 
 }

--- a/apps/sequence/sequence.cpp
+++ b/apps/sequence/sequence.cpp
@@ -291,9 +291,13 @@ void Sequence::InitialConditionModel::buildName(Sequence * sequence) {
       VerticalOffsetLayout::Builder(indexLayout, VerticalOffsetLayoutNode::Position::Subscript));
 }
 
-template double Sequence::templatedApproximateAtAbscissa<double>(double, SequenceContext*) const;
+#if POINCARE_FLOAT_SUPPORT
 template float Sequence::templatedApproximateAtAbscissa<float>(float, SequenceContext*) const;
-template double Sequence::approximateToNextRank<double>(int, SequenceContext*) const;
+#endif
+template double Sequence::templatedApproximateAtAbscissa<double>(double, SequenceContext*) const;
+#if POINCARE_FLOAT_SUPPORT
 template float Sequence::approximateToNextRank<float>(int, SequenceContext*) const;
+#endif
+template double Sequence::approximateToNextRank<double>(int, SequenceContext*) const;
 
 }

--- a/apps/sequence/sequence.h
+++ b/apps/sequence/sequence.h
@@ -59,9 +59,11 @@ public:
   bool isDefined() override;
   bool isEmpty() override;
   // Approximation
+#if POINCARE_FLOAT_SUPPORT
   Poincare::Coordinate2D<float> evaluateXYAtParameter(float x, Poincare::Context * context) const override {
     return Poincare::Coordinate2D<float>(x, templatedApproximateAtAbscissa(x, static_cast<SequenceContext *>(context)));
   }
+#endif
   Poincare::Coordinate2D<double> evaluateXYAtParameter(double x, Poincare::Context * context) const override {
     return Poincare::Coordinate2D<double>(x,templatedApproximateAtAbscissa(x, static_cast<SequenceContext *>(context)));
   }

--- a/apps/sequence/sequence_context.cpp
+++ b/apps/sequence/sequence_context.cpp
@@ -71,7 +71,9 @@ void TemplatedSequenceContext<T>::step(SequenceStore * sequenceStore, SequenceCo
   }
 }
 
+#if POINCARE_FLOAT_SUPPORT
 template class TemplatedSequenceContext<float>;
+#endif
 template class TemplatedSequenceContext<double>;
 
 }

--- a/apps/sequence/sequence_context.h
+++ b/apps/sequence/sequence_context.h
@@ -37,7 +37,9 @@ class SequenceContext : public Poincare::ContextWithParent {
 public:
   SequenceContext(Poincare::Context * parentContext, SequenceStore * sequenceStore) :
     ContextWithParent(parentContext),
+#if POINCARE_FLOAT_SUPPORT
     m_floatSequenceContext(),
+#endif
     m_doubleSequenceContext(),
     m_sequenceStore(sequenceStore) {}
   /* expressionForSymbolAbstract & setExpressionForSymbolAbstractName directly call the parent
@@ -45,23 +47,31 @@ public:
    * v(n), v(n+1) are taken into accound only when evaluating sequences which
    * is done in another context. */
   template<typename T> T valueOfSequenceAtPreviousRank(int sequenceIndex, int rank) const {
+#if POINCARE_FLOAT_SUPPORT
     if (sizeof(T) == sizeof(float)) {
       return m_floatSequenceContext.valueOfSequenceAtPreviousRank(sequenceIndex, rank);
     }
+#endif
     return m_doubleSequenceContext.valueOfSequenceAtPreviousRank(sequenceIndex, rank);
   }
   void resetCache() {
+#if POINCARE_FLOAT_SUPPORT
     m_floatSequenceContext.resetCache();
+#endif
     m_doubleSequenceContext.resetCache();
   }
   template<typename T> bool iterateUntilRank(int n) {
+#if POINCARE_FLOAT_SUPPORT
     if (sizeof(T) == sizeof(float)) {
       return m_floatSequenceContext.iterateUntilRank(n, m_sequenceStore, this);
     }
+#endif
     return m_doubleSequenceContext.iterateUntilRank(n, m_sequenceStore, this);
   }
 private:
+#if POINCARE_FLOAT_SUPPORT
   TemplatedSequenceContext<float> m_floatSequenceContext;
+#endif
   TemplatedSequenceContext<double> m_doubleSequenceContext;
   SequenceStore * m_sequenceStore;
 };

--- a/apps/shared/continuous_function.cpp
+++ b/apps/shared/continuous_function.cpp
@@ -350,7 +350,9 @@ Poincare::Expression ContinuousFunction::sumBetweenBounds(double start, double e
    * the derivative table. */
 }
 
+#if POINCARE_FLOAT_SUPPORT
 template Coordinate2D<float> ContinuousFunction::templatedApproximateAtParameter<float>(float, Poincare::Context *) const;
+#endif
 template Coordinate2D<double> ContinuousFunction::templatedApproximateAtParameter<double>(double, Poincare::Context *) const;
 
 }

--- a/apps/shared/continuous_function.h
+++ b/apps/shared/continuous_function.h
@@ -42,9 +42,11 @@ public:
   Poincare::Coordinate2D<double> evaluate2DAtParameter(double t, Poincare::Context * context) const {
     return templatedApproximateAtParameter(t, context);
   }
+#if POINCARE_FLOAT_SUPPORT
   Poincare::Coordinate2D<float> evaluateXYAtParameter(float t, Poincare::Context * context) const override {
     return privateEvaluateXYAtParameter<float>(t, context);
   }
+#endif
   Poincare::Coordinate2D<double> evaluateXYAtParameter(double t, Poincare::Context * context) const override {
     return privateEvaluateXYAtParameter<double>(t, context);
   }

--- a/apps/shared/curve_view.cpp
+++ b/apps/shared/curve_view.cpp
@@ -533,7 +533,11 @@ void CurveView::drawCurve(KDContext * ctx, KDRect rect, float tStart, float tEnd
     }
     previousX = x;
     previousY = y;
+#if POINCARE_FLOAT_SUPPORT
     Coordinate2D<float> xy = xyEvaluation(t, model, context);
+#else
+    Coordinate2D<double> xy = xyEvaluation(t, model, context);
+#endif
     x = xy.x1();
     y = xy.x2();
     if (colorUnderCurve && !std::isnan(x) && colorLowerBound < x && x < colorUpperBound && !(std::isnan(y) || std::isinf(y))) {
@@ -623,7 +627,11 @@ void CurveView::joinDots(KDContext * ctx, KDRect rect, EvaluateXYForParameter xy
   }
   // Middle point
   float ct = (t + s)/2.0f;
+#if POINCARE_FLOAT_SUPPORT
   Coordinate2D<float> cxy = xyEvaluation(ct, model, context);
+#else
+  Coordinate2D<double> cxy = xyEvaluation(ct, model, context);
+#endif
   float cx = cxy.x1();
   float cy = cxy.x2();
   if ((drawStraightLinesEarly || maxNumberOfRecursion == 0) && isRightDotValid && isLeftDotValid &&

--- a/apps/shared/curve_view.h
+++ b/apps/shared/curve_view.h
@@ -16,8 +16,13 @@ public:
   /* We want a 3 characters margin before the first label tick, so that most
    * labels appear completely. This gives 3*charWidth/320 = 3*7/320= 0.066 */
   static constexpr float k_labelsHorizontalMarginRatio = 0.066f;
+#if POINCARE_FLOAT_SUPPORT
   typedef Poincare::Coordinate2D<float> (*EvaluateXYForParameter)(float t, void * model, void * context);
   typedef float (*EvaluateYForX)(float x, void * model, void * context);
+#else
+  typedef Poincare::Coordinate2D<double> (*EvaluateXYForParameter)(float t, void * model, void * context);
+  typedef double (*EvaluateYForX)(float x, void * model, void * context);
+#endif
   enum class Axis {
     Horizontal = 0,
     Vertical = 1

--- a/apps/shared/float_parameter_controller.cpp
+++ b/apps/shared/float_parameter_controller.cpp
@@ -175,7 +175,9 @@ void FloatParameterController<T>::buttonAction() {
   stack->pop();
 }
 
+#if POINCARE_FLOAT_SUPPORT
 template class FloatParameterController<float>;
+#endif
 template class FloatParameterController<double>;
 
 }

--- a/apps/shared/function.h
+++ b/apps/shared/function.h
@@ -50,7 +50,9 @@ public:
   virtual I18n::Message parameterMessageName() const = 0;
 
   // Evaluation
+#if POINCARE_FLOAT_SUPPORT
   virtual Poincare::Coordinate2D<float> evaluateXYAtParameter(float t, Poincare::Context * context) const = 0;
+#endif
   virtual Poincare::Coordinate2D<double> evaluateXYAtParameter(double t, Poincare::Context * context) const = 0;
   virtual Poincare::Expression sumBetweenBounds(double start, double end, Poincare::Context * context) const = 0;
 protected:

--- a/apps/shared/function_graph_controller.cpp
+++ b/apps/shared/function_graph_controller.cpp
@@ -108,6 +108,7 @@ InteractiveCurveViewRangeDelegate::Range FunctionGraphController::computeYRange(
     const int balancedBound = std::floor((tMax-tMin)/2/step);
     for (int j = -balancedBound; j <= balancedBound ; j++) {
       float t = (tMin+tMax)/2 + step * j;
+#if POINCARE_FLOAT_SUPPORT
       Coordinate2D<float> xy = f->evaluateXYAtParameter(t, context);
       float x = xy.x1();
       if (!std::isnan(x) && !std::isinf(x) && x >= xMin && x <= xMax) {
@@ -117,6 +118,17 @@ InteractiveCurveViewRangeDelegate::Range FunctionGraphController::computeYRange(
           max = maxFloat(max, y);
         }
       }
+#else
+      Coordinate2D<double> xy = f->evaluateXYAtParameter(t, context);
+      double x = xy.x1();
+      if (!std::isnan(x) && !std::isinf(x) && x >= xMin && x <= xMax) {
+        double y = xy.x2();
+        if (!std::isnan(y) && !std::isinf(y)) {
+          min = minDouble(min, y);
+          max = maxDouble(max, y);
+        }
+      }
+#endif
     }
   }
   InteractiveCurveViewRangeDelegate::Range range;

--- a/apps/shared/range_parameter_controller.cpp
+++ b/apps/shared/range_parameter_controller.cpp
@@ -6,7 +6,11 @@ using namespace Poincare;
 namespace Shared {
 
 RangeParameterController::RangeParameterController(Responder * parentResponder, InputEventHandlerDelegate * inputEventHandlerDelegate, InteractiveCurveViewRange * interactiveRange) :
+#if POINCARE_FLOAT_SUPPORT
   FloatParameterController<float>(parentResponder),
+#else
+  FloatParameterController<double>(parentResponder),
+#endif
   m_interactiveRange(interactiveRange),
   m_xRangeCells{},
   m_yRangeCells{},
@@ -79,14 +83,22 @@ bool RangeParameterController::handleEvent(Ion::Events::Event event) {
   return FloatParameterController::handleEvent(event);
 }
 
+#if POINCARE_FLOAT_SUPPORT
 float RangeParameterController::parameterAtIndex(int parameterIndex) {
+#else
+double RangeParameterController::parameterAtIndex(int parameterIndex) {
+#endif
   ParameterGetterPointer getters[k_numberOfTextCell] = {&InteractiveCurveViewRange::xMin,
     &InteractiveCurveViewRange::xMax, &InteractiveCurveViewRange::yMin, &InteractiveCurveViewRange::yMax};
   int index = parameterIndex > 2 ? parameterIndex - 1 : parameterIndex;
   return (m_interactiveRange->*getters[index])();
 }
 
+#if POINCARE_FLOAT_SUPPORT
 bool RangeParameterController::setParameterAtIndex(int parameterIndex, float f) {
+#else
+bool RangeParameterController::setParameterAtIndex(int parameterIndex, double f) {
+#endif
   ParameterSetterPointer setters[k_numberOfTextCell] = {&InteractiveCurveViewRange::setXMin,
     &InteractiveCurveViewRange::setXMax, &InteractiveCurveViewRange::setYMin, &InteractiveCurveViewRange::setYMax};
   int index = parameterIndex > 2 ? parameterIndex - 1 : parameterIndex;

--- a/apps/shared/range_parameter_controller.h
+++ b/apps/shared/range_parameter_controller.h
@@ -7,7 +7,11 @@
 
 namespace Shared {
 
+#if POINCARE_FLOAT_SUPPORT
 class RangeParameterController : public FloatParameterController<float> {
+#else
+class RangeParameterController : public FloatParameterController<double> {
+#endif
 public:
   RangeParameterController(Responder * parentResponder, InputEventHandlerDelegate * inputEventHandlerDelegate, InteractiveCurveViewRange * interactiveCurveViewRange);
   const char * title() override;
@@ -33,8 +37,13 @@ private:
   };
   HighlightCell * reusableParameterCell(int index, int type) override;
   int reusableParameterCellCount(int type) override;
+#if POINCARE_FLOAT_SUPPORT
   float parameterAtIndex(int index) override;
   bool setParameterAtIndex(int parameterIndex, float f) override;
+#else
+  double parameterAtIndex(int index) override;
+  bool setParameterAtIndex(int parameterIndex, double f) override;
+#endif
   constexpr static int k_numberOfEditableTextCell = 2;
   constexpr static int k_numberOfConvertibleTextCell = 2;
   constexpr static int k_numberOfTextCell = k_numberOfEditableTextCell+k_numberOfConvertibleTextCell;

--- a/apps/statistics/histogram_view.cpp
+++ b/apps/statistics/histogram_view.cpp
@@ -62,7 +62,11 @@ void HistogramView::setHighlight(float start, float end) {
   }
 }
 
+#if POINCARE_FLOAT_SUPPORT
 float HistogramView::EvaluateHistogramAtAbscissa(float abscissa, void * model, void * context) {
+#else
+double HistogramView::EvaluateHistogramAtAbscissa(float abscissa, void * model, void * context) {
+#endif
   Store * store = (Store *)model;
   float totalSize = ((float *)context)[0];
   int series = ((float *)context)[1];

--- a/apps/statistics/histogram_view.h
+++ b/apps/statistics/histogram_view.h
@@ -23,7 +23,11 @@ public:
 private:
   HistogramController * m_controller;
   Store * m_store;
+#if POINCARE_FLOAT_SUPPORT
   static float EvaluateHistogramAtAbscissa(float abscissa, void * model, void * context);
+#else
+  static double EvaluateHistogramAtAbscissa(float abscissa, void * model, void * context);
+#endif
   float m_highlightedBarStart;
   float m_highlightedBarEnd;
   int m_series;

--- a/poincare/include/poincare/absolute_value.h
+++ b/poincare/include/poincare/absolute_value.h
@@ -27,9 +27,11 @@ public:
   template<typename T> static Complex<T> computeOnComplex(const std::complex<T> c, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) {
     return Complex<T>::Builder(std::abs(c));
   }
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<float>(this, context, complexFormat, angleUnit, computeOnComplex<float>);
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<double>(this, context, complexFormat, angleUnit, computeOnComplex<double>);
   }

--- a/poincare/include/poincare/addition.h
+++ b/poincare/include/poincare/addition.h
@@ -62,9 +62,11 @@ private:
   template<typename T> static MatrixComplex<T> computeOnMatrixAndComplex(const MatrixComplex<T> m, const std::complex<T> c, Preferences::ComplexFormat complexFormat) {
     return MatrixComplex<T>::Undefined();
   }
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::MapReduce<float>(this, context, complexFormat, angleUnit, compute<float>, computeOnComplexAndMatrix<float>, computeOnMatrixAndComplex<float>, computeOnMatrices<float>);
    }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::MapReduce<double>(this, context, complexFormat, angleUnit, compute<double>, computeOnComplexAndMatrix<double>, computeOnMatrixAndComplex<double>, computeOnMatrices<double>);
    }

--- a/poincare/include/poincare/arc_cosine.h
+++ b/poincare/include/poincare/arc_cosine.h
@@ -34,9 +34,11 @@ private:
 
   //Evaluation
   template<typename T> static Complex<T> computeOnComplex(const std::complex<T> c, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit);
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<float>(this, context, complexFormat, angleUnit,computeOnComplex<float>);
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<double>(this, context, complexFormat, angleUnit, computeOnComplex<double>);
   }

--- a/poincare/include/poincare/arc_sine.h
+++ b/poincare/include/poincare/arc_sine.h
@@ -32,9 +32,11 @@ private:
 
   //Evaluation
   template<typename T> static Complex<T> computeOnComplex(const std::complex<T> c, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit);
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<float>(this, context, complexFormat, angleUnit,computeOnComplex<float>);
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<double>(this, context, complexFormat, angleUnit, computeOnComplex<double>);
   }

--- a/poincare/include/poincare/arc_tangent.h
+++ b/poincare/include/poincare/arc_tangent.h
@@ -33,9 +33,11 @@ private:
 
   //Evaluation
   template<typename T> static Complex<T> computeOnComplex(const std::complex<T> c, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit);
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<float>(this, context, complexFormat, angleUnit,computeOnComplex<float>);
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<double>(this, context, complexFormat, angleUnit, computeOnComplex<double>);
   }

--- a/poincare/include/poincare/based_integer.h
+++ b/poincare/include/poincare/based_integer.h
@@ -33,7 +33,9 @@ public:
   Layout createLayout(Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const override;
 
   // Approximation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return Complex<float>::Builder(templatedApproximate<float>()); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return Complex<double>::Builder(templatedApproximate<double>()); }
   template<typename T> T templatedApproximate() const;
 

--- a/poincare/include/poincare/binom_cdf.h
+++ b/poincare/include/poincare/binom_cdf.h
@@ -29,7 +29,9 @@ private:
   int serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const override;
 
   // Evaluation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
   template<typename T> Evaluation<T> templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
 };

--- a/poincare/include/poincare/binom_pdf.h
+++ b/poincare/include/poincare/binom_pdf.h
@@ -29,7 +29,9 @@ private:
   int serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const override;
 
   // Evaluation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
   template<typename T> Evaluation<T> templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
 };

--- a/poincare/include/poincare/binomial_coefficient.h
+++ b/poincare/include/poincare/binomial_coefficient.h
@@ -30,7 +30,9 @@ private:
   LayoutShape leftLayoutShape() const override { return LayoutShape::BoundaryPunctuation; };
 
   // Evaluation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
   template<typename T> Complex<T> templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
 };

--- a/poincare/include/poincare/ceiling.h
+++ b/poincare/include/poincare/ceiling.h
@@ -30,9 +30,11 @@ private:
 
   // Evaluation
   template<typename T> static Complex<T> computeOnComplex(const std::complex<T> c, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit);
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<float>(this, context, complexFormat, angleUnit, computeOnComplex<float>);
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<double>(this, context, complexFormat, angleUnit, computeOnComplex<double>);
   }

--- a/poincare/include/poincare/complex_argument.h
+++ b/poincare/include/poincare/complex_argument.h
@@ -31,9 +31,11 @@ private:
 
   // Evaluation
   template<typename T> static Complex<T> computeOnComplex(const std::complex<T> c, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit);
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<float>(this, context, complexFormat, angleUnit,computeOnComplex<float>);
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<double>(this, context, complexFormat, angleUnit, computeOnComplex<double>);
   }

--- a/poincare/include/poincare/complex_cartesian.h
+++ b/poincare/include/poincare/complex_cartesian.h
@@ -24,7 +24,9 @@ private:
   // Layout
   Layout createLayout(Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const override { assert(false); return Layout(); }
   // Evaluation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
   // Simplification
   Expression shallowReduce(ReductionContext reductionContext) override;

--- a/poincare/include/poincare/confidence_interval.h
+++ b/poincare/include/poincare/confidence_interval.h
@@ -32,7 +32,9 @@ private:
   LayoutShape rightLayoutShape() const override { return LayoutShape::BoundaryPunctuation; }
 
   // Evaluation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
   template<typename T> Evaluation<T> templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
 };

--- a/poincare/include/poincare/conjugate.h
+++ b/poincare/include/poincare/conjugate.h
@@ -31,9 +31,11 @@ private:
 
   // Evaluation
   template<typename T> static Complex<T> computeOnComplex(const std::complex<T> c, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit);
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<float>(this, context, complexFormat, angleUnit,computeOnComplex<float>);
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<double>(this, context, complexFormat, angleUnit, computeOnComplex<double>);
   }

--- a/poincare/include/poincare/constant.h
+++ b/poincare/include/poincare/constant.h
@@ -33,7 +33,9 @@ public:
   Layout createLayout(Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const override;
 
   /* Approximation */
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(); }
 
   /* Symbol properties */

--- a/poincare/include/poincare/cosine.h
+++ b/poincare/include/poincare/cosine.h
@@ -35,9 +35,11 @@ private:
   LayoutShape rightLayoutShape() const override { return LayoutShape::BoundaryPunctuation; }
 
   // Evaluation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<float>(this, context, complexFormat, angleUnit,computeOnComplex<float>);
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<double>(this, context, complexFormat, angleUnit, computeOnComplex<double>);
   }

--- a/poincare/include/poincare/decimal.h
+++ b/poincare/include/poincare/decimal.h
@@ -45,9 +45,11 @@ public:
   Expression setSign(Sign s, ReductionContext reductionContext) override;
 
   // Approximation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return Complex<float>::Builder(templatedApproximate<float>());
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return Complex<double>::Builder(templatedApproximate<double>());
   }

--- a/poincare/include/poincare/derivative.h
+++ b/poincare/include/poincare/derivative.h
@@ -34,7 +34,9 @@ private:
   LayoutShape rightLayoutShape() const override { return LayoutShape::BoundaryPunctuation; }
 
   // Evaluation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
   template<typename T> Evaluation<T> templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
   template<typename T> T approximateWithArgument(T x, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;

--- a/poincare/include/poincare/determinant.h
+++ b/poincare/include/poincare/determinant.h
@@ -28,7 +28,9 @@ private:
   LayoutShape leftLayoutShape() const override { return LayoutShape::MoreLetters; };
   LayoutShape rightLayoutShape() const override { return LayoutShape::BoundaryPunctuation; }
   /* Approximation */
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
  template<typename T> Evaluation<T> templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
 };

--- a/poincare/include/poincare/division.h
+++ b/poincare/include/poincare/division.h
@@ -28,12 +28,14 @@ public:
   Expression getUnit() const override { assert(false); return ExpressionNode::getUnit(); }
 
   // Approximation
+#if POINCARE_FLOAT_SUPPORT
   virtual Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::MapReduce<float>(
         this, context, complexFormat, angleUnit, compute<float>,
         computeOnComplexAndMatrix<float>, computeOnMatrixAndComplex<float>,
         computeOnMatrices<float>);
   }
+#endif
   virtual Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::MapReduce<double>(
         this, context, complexFormat, angleUnit, compute<double>,

--- a/poincare/include/poincare/division_quotient.h
+++ b/poincare/include/poincare/division_quotient.h
@@ -32,7 +32,9 @@ private:
   // Simplification
   Expression shallowReduce(ReductionContext reductionContext) override;
   // Evaluation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
   template<typename T> Evaluation<T> templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
 };

--- a/poincare/include/poincare/division_remainder.h
+++ b/poincare/include/poincare/division_remainder.h
@@ -34,7 +34,9 @@ private:
   // Simplification
   Expression shallowReduce(ReductionContext reductionContext) override;
   // Evaluation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
   template<typename T> Evaluation<T> templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
 };

--- a/poincare/include/poincare/empty_expression.h
+++ b/poincare/include/poincare/empty_expression.h
@@ -33,7 +33,9 @@ private:
   // Layout
   Layout createLayout(Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const override;
   // Evaluation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
   template<typename T> Evaluation<T> templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
 };

--- a/poincare/include/poincare/equal.h
+++ b/poincare/include/poincare/equal.h
@@ -28,7 +28,9 @@ private:
   Layout createLayout(Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const override;
   int serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const override;
   // Evalutation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
   template<typename T> Evaluation<T> templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
 };

--- a/poincare/include/poincare/expression_node.h
+++ b/poincare/include/poincare/expression_node.h
@@ -208,7 +208,9 @@ public:
   typedef float SinglePrecision;
   typedef double DoublePrecision;
   constexpr static int k_maxNumberOfSteps = 10000;
+#if POINCARE_FLOAT_SUPPORT
   virtual Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const = 0;
+#endif
   virtual Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const = 0;
 
   /* Simplification */

--- a/poincare/include/poincare/factor.h
+++ b/poincare/include/poincare/factor.h
@@ -31,7 +31,9 @@ private:
   LayoutShape rightLayoutShape() const override { return LayoutShape::BoundaryPunctuation; }
 
   /* Evaluation */
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
   template<typename T> Evaluation<T> templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
 };

--- a/poincare/include/poincare/factorial.h
+++ b/poincare/include/poincare/factorial.h
@@ -36,9 +36,11 @@ private:
 
   // Evaluation
   template<typename T> static Complex<T> computeOnComplex(const std::complex<T> c, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit);
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<float>(this, context, complexFormat, angleUnit,computeOnComplex<float>);
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<double>(this, context, complexFormat, angleUnit, computeOnComplex<double>);
   }

--- a/poincare/include/poincare/float.h
+++ b/poincare/include/poincare/float.h
@@ -46,7 +46,9 @@ public:
   /* Layout */
   Layout createLayout(Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const override;
   /* Evaluation */
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif  
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
 private:
   // Simplification

--- a/poincare/include/poincare/floor.h
+++ b/poincare/include/poincare/floor.h
@@ -31,9 +31,11 @@ private:
 
   // Evaluation
   template<typename T> static Complex<T> computeOnComplex(const std::complex<T> c, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit);
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<float>(this, context, complexFormat, angleUnit, computeOnComplex<float>);
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<double>(this, context, complexFormat, angleUnit, computeOnComplex<double>);
   }

--- a/poincare/include/poincare/frac_part.h
+++ b/poincare/include/poincare/frac_part.h
@@ -34,9 +34,11 @@ private:
 
   // Evaluation
   template<typename T> static Complex<T> computeOnComplex(const std::complex<T> c, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit);
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<float>(this, context, complexFormat, angleUnit, computeOnComplex<float>);
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<double>(this, context, complexFormat, angleUnit, computeOnComplex<double>);
   }

--- a/poincare/include/poincare/function.h
+++ b/poincare/include/poincare/function.h
@@ -46,7 +46,9 @@ private:
   LayoutShape rightLayoutShape() const override { return LayoutShape::BoundaryPunctuation; }
 
   // Evaluation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override;
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override;
   template<typename T> Evaluation<T> templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
 };

--- a/poincare/include/poincare/great_common_divisor.h
+++ b/poincare/include/poincare/great_common_divisor.h
@@ -29,7 +29,9 @@ private:
   LayoutShape leftLayoutShape() const override { return LayoutShape::MoreLetters; };
   LayoutShape rightLayoutShape() const override { return LayoutShape::BoundaryPunctuation; }
   // Evaluation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
   template<typename T> Evaluation<T> templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
 };

--- a/poincare/include/poincare/hyperbolic_arc_cosine.h
+++ b/poincare/include/poincare/hyperbolic_arc_cosine.h
@@ -27,9 +27,11 @@ private:
   int serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const override;
   //Evaluation
   template<typename T> static Complex<T> computeOnComplex(const std::complex<T> c, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit);
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<float>(this, context, complexFormat, angleUnit,computeOnComplex<float>);
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<double>(this, context, complexFormat, angleUnit, computeOnComplex<double>);
   }

--- a/poincare/include/poincare/hyperbolic_arc_sine.h
+++ b/poincare/include/poincare/hyperbolic_arc_sine.h
@@ -25,9 +25,11 @@ private:
   int serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const override;
   //Evaluation
   template<typename T> static Complex<T> computeOnComplex(const std::complex<T> c, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit);
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<float>(this, context, complexFormat, angleUnit,computeOnComplex<float>);
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<double>(this, context, complexFormat, angleUnit, computeOnComplex<double>);
   }

--- a/poincare/include/poincare/hyperbolic_arc_tangent.h
+++ b/poincare/include/poincare/hyperbolic_arc_tangent.h
@@ -25,9 +25,11 @@ private:
   int serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const override;
   //Evaluation
   template<typename T> static Complex<T> computeOnComplex(const std::complex<T> c, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit);
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<float>(this, context, complexFormat, angleUnit,computeOnComplex<float>);
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<double>(this, context, complexFormat, angleUnit, computeOnComplex<double>);
   }

--- a/poincare/include/poincare/hyperbolic_cosine.h
+++ b/poincare/include/poincare/hyperbolic_cosine.h
@@ -27,9 +27,11 @@ private:
   int serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const override;
   //Evaluation
   template<typename T> static Complex<T> computeOnComplex(const std::complex<T> c, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit);
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<float>(this, context, complexFormat, angleUnit,computeOnComplex<float>);
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<double>(this, context, complexFormat, angleUnit, computeOnComplex<double>);
   }

--- a/poincare/include/poincare/hyperbolic_sine.h
+++ b/poincare/include/poincare/hyperbolic_sine.h
@@ -25,9 +25,11 @@ private:
   int serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const override;
   //Evaluation
   template<typename T> static Complex<T> computeOnComplex(const std::complex<T> c, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit);
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<float>(this, context, complexFormat, angleUnit,computeOnComplex<float>);
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<double>(this, context, complexFormat, angleUnit, computeOnComplex<double>);
   }

--- a/poincare/include/poincare/hyperbolic_tangent.h
+++ b/poincare/include/poincare/hyperbolic_tangent.h
@@ -25,9 +25,11 @@ private:
   int serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const override;
   //Evaluation
   template<typename T> static Complex<T> computeOnComplex(const std::complex<T> c, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit);
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<float>(this, context, complexFormat, angleUnit,computeOnComplex<float>);
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<double>(this, context, complexFormat, angleUnit, computeOnComplex<double>);
   }

--- a/poincare/include/poincare/imaginary_part.h
+++ b/poincare/include/poincare/imaginary_part.h
@@ -34,9 +34,11 @@ private:
   template<typename T> static Complex<T> computeOnComplex(const std::complex<T> c, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) {
     return Complex<T>::Builder(std::imag(c));
   }
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<float>(this, context, complexFormat, angleUnit,computeOnComplex<float>);
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<double>(this, context, complexFormat, angleUnit, computeOnComplex<double>);
   }

--- a/poincare/include/poincare/infinity.h
+++ b/poincare/include/poincare/infinity.h
@@ -26,9 +26,11 @@ public:
   Expression setSign(Sign s, ReductionContext reductionContext) override;
 
   // Approximation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return templatedApproximate<float>();
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return templatedApproximate<double>();
   }

--- a/poincare/include/poincare/integral.h
+++ b/poincare/include/poincare/integral.h
@@ -31,7 +31,9 @@ private:
   LayoutShape leftLayoutShape() const override { return LayoutShape::BoundaryPunctuation; };
   LayoutShape rightLayoutShape() const override { return LayoutShape::MoreLetters; }
   // Evaluation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
  template<typename T> Evaluation<T> templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
   template<typename T>

--- a/poincare/include/poincare/inv_binom.h
+++ b/poincare/include/poincare/inv_binom.h
@@ -30,7 +30,9 @@ private:
   Expression shallowReduce(ReductionContext reductionContext) override;
 
   // Evaluation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
   template<typename T> Evaluation<T> templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
 };

--- a/poincare/include/poincare/inv_norm.h
+++ b/poincare/include/poincare/inv_norm.h
@@ -30,7 +30,9 @@ private:
   Expression shallowReduce(ReductionContext reductionContext) override;
 
   // Evaluation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
   template<typename T> Evaluation<T> templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
 };

--- a/poincare/include/poincare/least_common_multiple.h
+++ b/poincare/include/poincare/least_common_multiple.h
@@ -29,7 +29,9 @@ private:
   LayoutShape leftLayoutShape() const override { return LayoutShape::MoreLetters; };
   LayoutShape rightLayoutShape() const override { return LayoutShape::BoundaryPunctuation; }
   /* Evaluation */
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
   template<typename T> Evaluation<T> templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
 };

--- a/poincare/include/poincare/logarithm.h
+++ b/poincare/include/poincare/logarithm.h
@@ -39,7 +39,9 @@ public:
      * (warning: log takes the other side of the cut values on ]-inf-0i, 0-0i]). */
     return Complex<U>::Builder(std::log10(c));
   }
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
   template<typename U> Evaluation<U> templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
 };

--- a/poincare/include/poincare/matrix.h
+++ b/poincare/include/poincare/matrix.h
@@ -40,9 +40,11 @@ public:
   Expression shallowReduce(ReductionContext reductionContext) override;
 
   // Approximation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return templatedApproximate<float>(context, complexFormat, angleUnit);
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return templatedApproximate<double>(context, complexFormat, angleUnit);
   }

--- a/poincare/include/poincare/matrix_dimension.h
+++ b/poincare/include/poincare/matrix_dimension.h
@@ -29,7 +29,9 @@ private:
   LayoutShape leftLayoutShape() const override { return LayoutShape::MoreLetters; };
   LayoutShape rightLayoutShape() const override { return LayoutShape::BoundaryPunctuation; }
   // Evaluation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
  template<typename T> Evaluation<T> templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
 };

--- a/poincare/include/poincare/matrix_identity.h
+++ b/poincare/include/poincare/matrix_identity.h
@@ -27,7 +27,9 @@ private:
   LayoutShape leftLayoutShape() const override { return LayoutShape::MoreLetters; };
   LayoutShape rightLayoutShape() const override { return LayoutShape::BoundaryPunctuation; }
   // Evaluation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
   template<typename T> Evaluation<T> templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
 };

--- a/poincare/include/poincare/matrix_inverse.h
+++ b/poincare/include/poincare/matrix_inverse.h
@@ -28,7 +28,9 @@ private:
   LayoutShape leftLayoutShape() const override { return LayoutShape::MoreLetters; };
   LayoutShape rightLayoutShape() const override { return LayoutShape::BoundaryPunctuation; }
   // Evaluation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
   template<typename T> Evaluation<T> templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
 };

--- a/poincare/include/poincare/matrix_trace.h
+++ b/poincare/include/poincare/matrix_trace.h
@@ -28,7 +28,9 @@ private:
   LayoutShape leftLayoutShape() const override { return LayoutShape::MoreLetters; };
   LayoutShape rightLayoutShape() const override { return LayoutShape::BoundaryPunctuation; }
   // Evaluation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
  template<typename T> Evaluation<T> templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
 };

--- a/poincare/include/poincare/matrix_transpose.h
+++ b/poincare/include/poincare/matrix_transpose.h
@@ -28,7 +28,9 @@ private:
   LayoutShape leftLayoutShape() const override { return LayoutShape::MoreLetters; };
   LayoutShape rightLayoutShape() const override { return LayoutShape::BoundaryPunctuation; }
   // Evaluation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
   template<typename T> Evaluation<T> templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
 };

--- a/poincare/include/poincare/multiplication.h
+++ b/poincare/include/poincare/multiplication.h
@@ -54,9 +54,11 @@ private:
   template<typename T> static MatrixComplex<T> computeOnMatrixAndComplex(const MatrixComplex<T> m, const std::complex<T> c, Preferences::ComplexFormat complexFormat) {
     return ApproximationHelper::ElementWiseOnMatrixComplexAndComplex(m, c, complexFormat, compute<T>);
   }
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::MapReduce<float>(this, context, complexFormat, angleUnit, compute<float>, computeOnComplexAndMatrix<float>, computeOnMatrixAndComplex<float>, computeOnMatrices<float>);
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::MapReduce<double>(this, context, complexFormat, angleUnit, compute<double>, computeOnComplexAndMatrix<double>, computeOnMatrixAndComplex<double>, computeOnMatrices<double>);
   }

--- a/poincare/include/poincare/naperian_logarithm.h
+++ b/poincare/include/poincare/naperian_logarithm.h
@@ -35,9 +35,11 @@ private:
      * (warning: ln takes the other side of the cut values on ]-inf-0i, 0-0i]). */
     return Complex<T>::Builder(std::log(c));
   }
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<float>(this, context, complexFormat, angleUnit,computeOnComplex<float>);
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<double>(this, context, complexFormat, angleUnit, computeOnComplex<double>);
   }

--- a/poincare/include/poincare/norm_cdf.h
+++ b/poincare/include/poincare/norm_cdf.h
@@ -29,7 +29,9 @@ private:
   int serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const override;
 
   // Evaluation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
   template<typename T> Evaluation<T> templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
 };

--- a/poincare/include/poincare/norm_cdf2.h
+++ b/poincare/include/poincare/norm_cdf2.h
@@ -31,7 +31,9 @@ private:
   int serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const override;
 
   // Evaluation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
   template<typename T> Evaluation<T> templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
 };

--- a/poincare/include/poincare/norm_pdf.h
+++ b/poincare/include/poincare/norm_pdf.h
@@ -29,7 +29,9 @@ private:
   int serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const override;
 
   // Evaluation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
   template<typename T> Evaluation<T> templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
 };

--- a/poincare/include/poincare/nth_root.h
+++ b/poincare/include/poincare/nth_root.h
@@ -29,7 +29,9 @@ private:
   LayoutShape leftLayoutShape() const override { return LayoutShape::NthRoot; };
   LayoutShape rightLayoutShape() const override { return LayoutShape::Root; };
   // Evaluation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
  template<typename T> Evaluation<T> templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
 

--- a/poincare/include/poincare/opposite.h
+++ b/poincare/include/poincare/opposite.h
@@ -29,9 +29,11 @@ public:
   bool childAtIndexNeedsUserParentheses(const Expression & child, int childIndex) const override;
 
   // Approximation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<float>(this, context, complexFormat, angleUnit, compute<float>);
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<double>(this, context, complexFormat, angleUnit, compute<double>);
   }

--- a/poincare/include/poincare/parenthesis.h
+++ b/poincare/include/poincare/parenthesis.h
@@ -31,7 +31,9 @@ public:
   LayoutShape leftLayoutShape() const override { return LayoutShape::BoundaryPunctuation; };
 
   // Approximation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
 private:
  template<typename T> Evaluation<T> templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;

--- a/poincare/include/poincare/permute_coefficient.h
+++ b/poincare/include/poincare/permute_coefficient.h
@@ -33,7 +33,9 @@ private:
   LayoutShape leftLayoutShape() const override { return LayoutShape::MoreLetters; };
   LayoutShape rightLayoutShape() const override { return LayoutShape::BoundaryPunctuation; }
   // Evaluation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
   template<typename T> Evaluation<T> templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
 };

--- a/poincare/include/poincare/power.h
+++ b/poincare/include/poincare/power.h
@@ -59,9 +59,11 @@ private:
   template<typename T> static MatrixComplex<T> computeOnComplexAndMatrix(const std::complex<T> c, const MatrixComplex<T> n, Preferences::ComplexFormat complexFormat);
   template<typename T> static MatrixComplex<T> computeOnMatrixAndComplex(const MatrixComplex<T> m, const std::complex<T> d, Preferences::ComplexFormat complexFormat);
   template<typename T> static MatrixComplex<T> computeOnMatrices(const MatrixComplex<T> m, const MatrixComplex<T> n, Preferences::ComplexFormat complexFormat);
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return templatedApproximate<float>(context, complexFormat, angleUnit);
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return templatedApproximate<double>(context, complexFormat, angleUnit);
   }

--- a/poincare/include/poincare/prediction_interval.h
+++ b/poincare/include/poincare/prediction_interval.h
@@ -31,7 +31,9 @@ private:
   LayoutShape leftLayoutShape() const override { return LayoutShape::MoreLetters; };
   LayoutShape rightLayoutShape() const override { return LayoutShape::BoundaryPunctuation; }
   // Evaluation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
   template<typename T> Evaluation<T> templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
 };

--- a/poincare/include/poincare/product.h
+++ b/poincare/include/poincare/product.h
@@ -24,9 +24,11 @@ private:
   Evaluation<double> evaluateWithNextTerm(DoublePrecision p, Evaluation<double> a, Evaluation<double> b, Preferences::ComplexFormat complexFormat) const override {
     return templatedApproximateWithNextTerm<double>(a, b, complexFormat);
   }
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> evaluateWithNextTerm(SinglePrecision p, Evaluation<float> a, Evaluation<float> b, Preferences::ComplexFormat complexFormat) const override {
     return templatedApproximateWithNextTerm<float>(a, b, complexFormat);
   }
+#endif
   template<typename T> Evaluation<T> templatedApproximateWithNextTerm(Evaluation<T> a, Evaluation<T> b, Preferences::ComplexFormat complexFormat) const;
 };
 

--- a/poincare/include/poincare/randint.h
+++ b/poincare/include/poincare/randint.h
@@ -28,9 +28,11 @@ private:
   Layout createLayout(Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const override;
   int serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const override;
   // Evaluation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return templateApproximate<float>(context, complexFormat, angleUnit);
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return templateApproximate<double>(context, complexFormat, angleUnit);
   }

--- a/poincare/include/poincare/random.h
+++ b/poincare/include/poincare/random.h
@@ -32,9 +32,11 @@ private:
   Layout createLayout(Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const override;
   int serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const override;
   // Evaluation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return templateApproximate<float>();
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return templateApproximate<double>();
   }

--- a/poincare/include/poincare/rational.h
+++ b/poincare/include/poincare/rational.h
@@ -38,7 +38,9 @@ public:
   Layout createLayout(Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const override;
 
   // Approximation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return Complex<float>::Builder(templatedApproximate<float>()); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return Complex<double>::Builder(templatedApproximate<double>()); }
   template<typename T> T templatedApproximate() const;
 

--- a/poincare/include/poincare/real_part.h
+++ b/poincare/include/poincare/real_part.h
@@ -34,9 +34,11 @@ private:
   template<typename T> static Complex<T> computeOnComplex(const std::complex<T> c, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) {
     return Complex<T>::Builder(std::real(c));
   }
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<float>(this, context, complexFormat, angleUnit,computeOnComplex<float>);
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<double>(this, context, complexFormat, angleUnit, computeOnComplex<double>);
   }

--- a/poincare/include/poincare/round.h
+++ b/poincare/include/poincare/round.h
@@ -30,7 +30,9 @@ private:
   LayoutShape leftLayoutShape() const override { return LayoutShape::MoreLetters; };
   LayoutShape rightLayoutShape() const override { return LayoutShape::BoundaryPunctuation; }
   // Evaluation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
   template<typename T> Evaluation<T> templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
 };

--- a/poincare/include/poincare/sequence.h
+++ b/poincare/include/poincare/sequence.h
@@ -19,11 +19,15 @@ private:
   Expression shallowReduce(ReductionContext reductionContext) override;
   LayoutShape leftLayoutShape() const override { return LayoutShape::BoundaryPunctuation; };
   /* Approximation */
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
  template<typename T> Evaluation<T> templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
   virtual float emptySequenceValue() const = 0;
+#if POINCARE_FLOAT_SUPPORT
   virtual Evaluation<float> evaluateWithNextTerm(SinglePrecision p, Evaluation<float> a, Evaluation<float> b, Preferences::ComplexFormat complexFormat) const = 0;
+#endif
   virtual Evaluation<double> evaluateWithNextTerm(DoublePrecision p, Evaluation<double> a, Evaluation<double> b, Preferences::ComplexFormat complexFormat) const = 0;
 };
 

--- a/poincare/include/poincare/sign_function.h
+++ b/poincare/include/poincare/sign_function.h
@@ -34,9 +34,11 @@ private:
   LayoutShape rightLayoutShape() const override { return LayoutShape::BoundaryPunctuation; }
   // Evaluation
   template<typename T> static Complex<T> computeOnComplex(const std::complex<T> c, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit);
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<float>(this, context, complexFormat, angleUnit, computeOnComplex<float>);
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<double>(this, context, complexFormat, angleUnit, computeOnComplex<double>);
   }

--- a/poincare/include/poincare/sine.h
+++ b/poincare/include/poincare/sine.h
@@ -36,9 +36,11 @@ private:
   LayoutShape rightLayoutShape() const override { return LayoutShape::BoundaryPunctuation; }
 
   // Evaluation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<float>(this, context, complexFormat, angleUnit,computeOnComplex<float>);
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<double>(this, context, complexFormat, angleUnit, computeOnComplex<double>);
   }

--- a/poincare/include/poincare/square_root.h
+++ b/poincare/include/poincare/square_root.h
@@ -30,9 +30,11 @@ private:
   LayoutShape leftLayoutShape() const override { return LayoutShape::Root; };
   // Evaluation
   template<typename T> static Complex<T> computeOnComplex(const std::complex<T> c, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit);
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<float>(this, context, complexFormat, angleUnit,computeOnComplex<float>);
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<double>(this, context, complexFormat, angleUnit, computeOnComplex<double>);
   }

--- a/poincare/include/poincare/store.h
+++ b/poincare/include/poincare/store.h
@@ -23,7 +23,9 @@ private:
   // Simplification
   Expression shallowReduce(ReductionContext reductionContext) override;
   // Evalutation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
   template<typename T> Evaluation<T> templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
 };

--- a/poincare/include/poincare/subtraction.h
+++ b/poincare/include/poincare/subtraction.h
@@ -28,9 +28,11 @@ public:
 
   // Approximation
   template<typename T> static Complex<T> compute(const std::complex<T> c, const std::complex<T> d, Preferences::ComplexFormat complexFormat) { return Complex<T>::Builder(c - d); }
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::MapReduce<float>(this, context, complexFormat, angleUnit, compute<float>, computeOnComplexAndMatrix<float>, computeOnMatrixAndComplex<float>, computeOnMatrices<float>);
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::MapReduce<double>(this, context, complexFormat, angleUnit, compute<double>, computeOnComplexAndMatrix<double>, computeOnMatrixAndComplex<double>, computeOnMatrices<double>);
   }

--- a/poincare/include/poincare/sum.h
+++ b/poincare/include/poincare/sum.h
@@ -21,11 +21,13 @@ private:
   float emptySequenceValue() const override { return 0.0f; }
   Layout createSequenceLayout(Layout argumentLayout, Layout symbolLayout, Layout subscriptLayout, Layout superscriptLayout) const override;
   int serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const override;
-  Evaluation<double> evaluateWithNextTerm(DoublePrecision p, Evaluation<double> a, Evaluation<double> b, Preferences::ComplexFormat complexFormat) const override {
-    return templatedApproximateWithNextTerm<double>(a, b, complexFormat);
-  }
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> evaluateWithNextTerm(SinglePrecision p, Evaluation<float> a, Evaluation<float> b, Preferences::ComplexFormat complexFormat) const override {
     return templatedApproximateWithNextTerm<float>(a, b, complexFormat);
+  }
+#endif
+  Evaluation<double> evaluateWithNextTerm(DoublePrecision p, Evaluation<double> a, Evaluation<double> b, Preferences::ComplexFormat complexFormat) const override {
+    return templatedApproximateWithNextTerm<double>(a, b, complexFormat);
   }
   template<typename T> Evaluation<T> templatedApproximateWithNextTerm(Evaluation<T> a, Evaluation<T> b, Preferences::ComplexFormat complexFormat) const;
 };

--- a/poincare/include/poincare/symbol.h
+++ b/poincare/include/poincare/symbol.h
@@ -38,7 +38,9 @@ public:
   LayoutShape leftLayoutShape() const override;
 
   /* Approximation */
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
 
   bool isUnknown() const;

--- a/poincare/include/poincare/tangent.h
+++ b/poincare/include/poincare/tangent.h
@@ -34,9 +34,11 @@ private:
 
   // Evaluation
   template<typename T> static Complex<T> computeOnComplex(const std::complex<T> c, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit = Preferences::AngleUnit::Radian);
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<float>(this, context, complexFormat, angleUnit,computeOnComplex<float>);
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return ApproximationHelper::Map<double>(this, context, complexFormat, angleUnit, computeOnComplex<double>);
   }

--- a/poincare/include/poincare/trigonometry.h
+++ b/poincare/include/poincare/trigonometry.h
@@ -13,7 +13,11 @@ public:
     Sine = 1,
   };
   static double PiInAngleUnit(Preferences::AngleUnit angleUnit);
+#if POINCARE_FLOAT_SUPPORT
   static float characteristicXRange(const Expression & e, Context * context, Preferences::AngleUnit angleUnit);
+#else
+  static double characteristicXRange(const Expression & e, Context * context, Preferences::AngleUnit angleUnit);
+#endif
   static bool isDirectTrigonometryFunction(const Expression & e);
   static bool isInverseTrigonometryFunction(const Expression & e);
   static bool AreInverseFunctions(const Expression & directFunction, const Expression & inverseFunction);

--- a/poincare/include/poincare/undefined.h
+++ b/poincare/include/poincare/undefined.h
@@ -22,9 +22,11 @@ public:
   Expression setSign(Sign s, ReductionContext reductionContext) override;
 
   // Approximation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return templatedApproximate<float>();
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return templatedApproximate<double>();
   }

--- a/poincare/include/poincare/unit.h
+++ b/poincare/include/poincare/unit.h
@@ -121,7 +121,9 @@ public:
   int serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const override;
 
   /* Approximation */
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
 
   // Comparison

--- a/poincare/include/poincare/unit_convert.h
+++ b/poincare/include/poincare/unit_convert.h
@@ -24,7 +24,9 @@ private:
   // Simplification
   Expression shallowReduce(ReductionContext reductionContext) override;
   // Evalutation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<float>(context, complexFormat, angleUnit); }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override { return templatedApproximate<double>(context, complexFormat, angleUnit); }
   template<typename T> Evaluation<T> templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
 };

--- a/poincare/include/poincare/unreal.h
+++ b/poincare/include/poincare/unreal.h
@@ -20,9 +20,11 @@ public:
   Type type() const override { return Type::Unreal; }
 
   // Approximation
+#if POINCARE_FLOAT_SUPPORT
   Evaluation<float> approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return templatedApproximate<float>();
   }
+#endif
   Evaluation<double> approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const override {
     return templatedApproximate<double>();
   }

--- a/poincare/src/approximation_helper.cpp
+++ b/poincare/src/approximation_helper.cpp
@@ -127,17 +127,29 @@ template<typename T> MatrixComplex<T> ApproximationHelper::ElementWiseOnComplexM
   return matrix;
 }
 
+#if POINCARE_FLOAT_SUPPORT
 template int Poincare::ApproximationHelper::PositiveIntegerApproximationIfPossible<float>(Poincare::ExpressionNode const*, bool*, Poincare::Context*, Poincare::Preferences::ComplexFormat, Poincare::Preferences::AngleUnit);
+#endif
 template int Poincare::ApproximationHelper::PositiveIntegerApproximationIfPossible<double>(Poincare::ExpressionNode const*, bool*, Poincare::Context*, Poincare::Preferences::ComplexFormat, Poincare::Preferences::AngleUnit);
+#if POINCARE_FLOAT_SUPPORT
 template std::complex<float> Poincare::ApproximationHelper::NeglectRealOrImaginaryPartIfNeglectable<float>(std::complex<float>,std::complex<float>,std::complex<float>,bool);
+#endif
 template std::complex<double> Poincare::ApproximationHelper::NeglectRealOrImaginaryPartIfNeglectable<double>(std::complex<double>,std::complex<double>,std::complex<double>,bool);
+#if POINCARE_FLOAT_SUPPORT
 template Poincare::Evaluation<float> Poincare::ApproximationHelper::Map(const Poincare::ExpressionNode * expression, Poincare::Context * context, Poincare::Preferences::ComplexFormat, Poincare::Preferences::AngleUnit angleUnit, Poincare::ApproximationHelper::ComplexCompute<float> compute);
+#endif
 template Poincare::Evaluation<double> Poincare::ApproximationHelper::Map(const Poincare::ExpressionNode * expression, Poincare::Context * context, Poincare::Preferences::ComplexFormat, Poincare::Preferences::AngleUnit angleUnit, Poincare::ApproximationHelper::ComplexCompute<double> compute);
+#if POINCARE_FLOAT_SUPPORT
 template Poincare::Evaluation<float> Poincare::ApproximationHelper::MapReduce(const Poincare::ExpressionNode * expression, Poincare::Context * context, Poincare::Preferences::ComplexFormat, Poincare::Preferences::AngleUnit angleUnit, Poincare::ApproximationHelper::ComplexAndComplexReduction<float> computeOnComplexes, Poincare::ApproximationHelper::ComplexAndMatrixReduction<float> computeOnComplexAndMatrix, Poincare::ApproximationHelper::MatrixAndComplexReduction<float> computeOnMatrixAndComplex, Poincare::ApproximationHelper::MatrixAndMatrixReduction<float> computeOnMatrices);
+#endif
 template Poincare::Evaluation<double> Poincare::ApproximationHelper::MapReduce(const Poincare::ExpressionNode * expression, Poincare::Context * context, Poincare::Preferences::ComplexFormat, Poincare::Preferences::AngleUnit angleUnit, Poincare::ApproximationHelper::ComplexAndComplexReduction<double> computeOnComplexes, Poincare::ApproximationHelper::ComplexAndMatrixReduction<double> computeOnComplexAndMatrix, Poincare::ApproximationHelper::MatrixAndComplexReduction<double> computeOnMatrixAndComplex, Poincare::ApproximationHelper::MatrixAndMatrixReduction<double> computeOnMatrices);
+#if POINCARE_FLOAT_SUPPORT
 template Poincare::MatrixComplex<float> Poincare::ApproximationHelper::ElementWiseOnMatrixComplexAndComplex<float>(const Poincare::MatrixComplex<float>, const std::complex<float>, Poincare::Preferences::ComplexFormat, Poincare::Complex<float> (*)(std::complex<float>, std::complex<float>, Poincare::Preferences::ComplexFormat));
+#endif
 template Poincare::MatrixComplex<double> Poincare::ApproximationHelper::ElementWiseOnMatrixComplexAndComplex<double>(const Poincare::MatrixComplex<double>, std::complex<double> const, Poincare::Preferences::ComplexFormat, Poincare::Complex<double> (*)(std::complex<double>, std::complex<double>, Poincare::Preferences::ComplexFormat));
+#if POINCARE_FLOAT_SUPPORT
 template Poincare::MatrixComplex<float> Poincare::ApproximationHelper::ElementWiseOnComplexMatrices<float>(const Poincare::MatrixComplex<float>, const Poincare::MatrixComplex<float>, Poincare::Preferences::ComplexFormat, Poincare::Complex<float> (*)(std::complex<float>, std::complex<float>, Poincare::Preferences::ComplexFormat));
+#endif
 template Poincare::MatrixComplex<double> Poincare::ApproximationHelper::ElementWiseOnComplexMatrices<double>(const Poincare::MatrixComplex<double>, const Poincare::MatrixComplex<double>, Poincare::Preferences::ComplexFormat, Poincare::Complex<double> (*)(std::complex<double>, std::complex<double>, Poincare::Preferences::ComplexFormat));
 
 

--- a/poincare/src/complex_argument.cpp
+++ b/poincare/src/complex_argument.cpp
@@ -51,13 +51,22 @@ Expression ComplexArgument::shallowReduce(ExpressionNode::ReductionContext reduc
   }
   bool real = c.isReal(reductionContext.context());
   if (real) {
+#if POINCARE_FLOAT_SUPPORT
     float app = c.node()->approximate(float(), reductionContext.context(), reductionContext.complexFormat(), reductionContext.angleUnit()).toScalar();
     if (!std::isnan(app) && app >= Expression::Epsilon<float>()) {
+#else
+    double app = c.node()->approximate(double(), reductionContext.context(), reductionContext.complexFormat(), reductionContext.angleUnit()).toScalar();
+    if (!std::isnan(app) && app >= Expression::Epsilon<double>()) {
+#endif
       // arg(x) = 0 if x > 0
       Expression result = Rational::Builder(0);
       replaceWithInPlace(result);
       return result;
+#if POINCARE_FLOAT_SUPPORT
     } else if (!std::isnan(app) && app <= -Expression::Epsilon<float>()) {
+#else
+    } else if (!std::isnan(app) && app <= -Expression::Epsilon<double>()) {
+#endif
       // arg(x) = Pi if x < 0
       Expression result = Constant::Builder(UCodePointGreekSmallLetterPi);
       replaceWithInPlace(result);

--- a/poincare/src/expression.cpp
+++ b/poincare/src/expression.cpp
@@ -249,7 +249,11 @@ bool Expression::getLinearCoefficients(char * variables, int maxVariableSize, Ex
 bool Expression::isDefinedCosineOrSine(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const {
   ExpressionNode::Type t = type();
   if (t == ExpressionNode::Type::Cosine || t == ExpressionNode::Type::Sine) {
+#if POINCARE_FLOAT_SUPPORT
     float r = childAtIndex(0).approximateToScalar<float>(context, complexFormat, angleUnit);
+#else
+    double r = childAtIndex(0).approximateToScalar<double>(context, complexFormat, angleUnit);
+#endif
     if (!std::isnan(r)) {
       return true;
     }
@@ -272,12 +276,20 @@ bool Expression::hasDefinedComplexApproximation(Context * context, Preferences::
   /* We return true when both real and imaginary approximation are defined and
    * imaginary part is not null. */
   Expression imag = ImaginaryPart::Builder(*this);
+#if POINCARE_FLOAT_SUPPORT
   float b = imag.approximateToScalar<float>(context, complexFormat, angleUnit);
+#else
+  double b = imag.approximateToScalar<double>(context, complexFormat, angleUnit);
+#endif
   if (b == 0.0f || std::isinf(b) || std::isnan(b)) {
     return false;
   }
   Expression real = RealPart::Builder(*this);
+#if POINCARE_FLOAT_SUPPORT
   float a = real.approximateToScalar<float>(context, complexFormat, angleUnit);
+#else
+  double a = real.approximateToScalar<double>(context, complexFormat, angleUnit);
+#endif
   if (std::isinf(a) || std::isnan(a)) {
     return false;
   }
@@ -1140,22 +1152,34 @@ void Expression::bracketRoot(const char * symbol, double start, double step, dou
   result[1] = NAN;
 }
 
+#if POINCARE_FLOAT_SUPPORT
 template float Expression::Epsilon<float>();
+#endif
 template double Expression::Epsilon<double>();
 
+#if POINCARE_FLOAT_SUPPORT
 template Expression Expression::approximate<float>(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
+#endif
 template Expression Expression::approximate<double>(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
 
+#if POINCARE_FLOAT_SUPPORT
 template float Expression::approximateToScalar(Context * context, Preferences::ComplexFormat, Preferences::AngleUnit angleUnit) const;
+#endif
 template double Expression::approximateToScalar(Context * context, Preferences::ComplexFormat, Preferences::AngleUnit angleUnit) const;
 
+#if POINCARE_FLOAT_SUPPORT
 template float Expression::ApproximateToScalar<float>(const char * text, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit, ExpressionNode::SymbolicComputation symbolicComputation);
+#endif
 template double Expression::ApproximateToScalar<double>(const char * text, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit, ExpressionNode::SymbolicComputation symbolicComputation);
 
+#if POINCARE_FLOAT_SUPPORT
 template Evaluation<float> Expression::approximateToEvaluation(Context * context, Preferences::ComplexFormat, Preferences::AngleUnit angleUnit) const;
+#endif
 template Evaluation<double> Expression::approximateToEvaluation(Context * context, Preferences::ComplexFormat, Preferences::AngleUnit angleUnit) const;
 
+#if POINCARE_FLOAT_SUPPORT
 template float Expression::approximateWithValueForSymbol(const char * symbol, float x, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
+#endif
 template double Expression::approximateWithValueForSymbol(const char * symbol, double x, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
 
 }

--- a/poincare/src/float.cpp
+++ b/poincare/src/float.cpp
@@ -49,10 +49,14 @@ Float<T> Float<T>::Builder(T value) {
   return static_cast<Float &>(h);
 }
 
+#if POINCARE_FLOAT_SUPPORT
 template class FloatNode<float>;
+#endif
 template class FloatNode<double>;
 
+#if POINCARE_FLOAT_SUPPORT
 template Float<float> Float<float>::Builder(float value);
+#endif
 template Float<double> Float<double>::Builder(double value);
 
 }

--- a/poincare/src/function.cpp
+++ b/poincare/src/function.cpp
@@ -69,9 +69,11 @@ Expression FunctionNode::deepReplaceReplaceableSymbols(Context * context, bool *
   return Function(this).deepReplaceReplaceableSymbols(context, didReplace, replaceFunctionsOnly);
 }
 
+#if POINCARE_FLOAT_SUPPORT
 Evaluation<float> FunctionNode::approximate(SinglePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const {
   return templatedApproximate<float>(context, complexFormat, angleUnit);
 }
+#endif
 
 Evaluation<double> FunctionNode::approximate(DoublePrecision p, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const {
   return templatedApproximate<double>(context, complexFormat, angleUnit);

--- a/poincare/src/hyperbolic_arc_cosine.cpp
+++ b/poincare/src/hyperbolic_arc_cosine.cpp
@@ -26,7 +26,9 @@ Complex<T> HyperbolicArcCosineNode::computeOnComplex(const std::complex<T> c, Pr
   return Complex<T>::Builder(ApproximationHelper::NeglectRealOrImaginaryPartIfNeglectable(result, c));
 }
 
+#if POINCARE_FLOAT_SUPPORT
 template Complex<float> Poincare::HyperbolicArcCosineNode::computeOnComplex<float>(std::complex<float>, Preferences::ComplexFormat, Preferences::AngleUnit);
+#endif
 template Complex<double> Poincare::HyperbolicArcCosineNode::computeOnComplex<double>(std::complex<double>, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit);
 
 }

--- a/poincare/src/hyperbolic_arc_sine.cpp
+++ b/poincare/src/hyperbolic_arc_sine.cpp
@@ -30,7 +30,9 @@ Complex<T> HyperbolicArcSineNode::computeOnComplex(const std::complex<T> c, Pref
   return Complex<T>::Builder(ApproximationHelper::NeglectRealOrImaginaryPartIfNeglectable(result, c));
 }
 
+#if POINCARE_FLOAT_SUPPORT
 template Complex<float> Poincare::HyperbolicArcSineNode::computeOnComplex<float>(std::complex<float>, Preferences::ComplexFormat, Preferences::AngleUnit);
+#endif
 template Complex<double> Poincare::HyperbolicArcSineNode::computeOnComplex<double>(std::complex<double>, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit);
 
 }

--- a/poincare/src/hyperbolic_arc_tangent.cpp
+++ b/poincare/src/hyperbolic_arc_tangent.cpp
@@ -30,7 +30,9 @@ Complex<T> HyperbolicArcTangentNode::computeOnComplex(const std::complex<T> c, P
   return Complex<T>::Builder(ApproximationHelper::NeglectRealOrImaginaryPartIfNeglectable(result, c));
 }
 
+#if POINCARE_FLOAT_SUPPORT
 template Complex<float> Poincare::HyperbolicArcTangentNode::computeOnComplex<float>(std::complex<float>, Preferences::ComplexFormat, Preferences::AngleUnit);
+#endif
 template Complex<double> Poincare::HyperbolicArcTangentNode::computeOnComplex<double>(std::complex<double>, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit);
 
 }

--- a/poincare/src/hyperbolic_cosine.cpp
+++ b/poincare/src/hyperbolic_cosine.cpp
@@ -19,7 +19,9 @@ Complex<T> HyperbolicCosineNode::computeOnComplex(const std::complex<T> c, Prefe
   return Complex<T>::Builder(ApproximationHelper::NeglectRealOrImaginaryPartIfNeglectable(std::cosh(c), c));
 }
 
+#if POINCARE_FLOAT_SUPPORT
 template Complex<float> Poincare::HyperbolicCosineNode::computeOnComplex<float>(std::complex<float>, Preferences::ComplexFormat, Preferences::AngleUnit);
+#endif
 template Complex<double> Poincare::HyperbolicCosineNode::computeOnComplex<double>(std::complex<double>, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit);
 
 }

--- a/poincare/src/hyperbolic_sine.cpp
+++ b/poincare/src/hyperbolic_sine.cpp
@@ -19,7 +19,9 @@ Complex<T> HyperbolicSineNode::computeOnComplex(const std::complex<T> c, Prefere
   return Complex<T>::Builder(ApproximationHelper::NeglectRealOrImaginaryPartIfNeglectable(std::sinh(c), c));
 }
 
+#if POINCARE_FLOAT_SUPPORT
 template Complex<float> Poincare::HyperbolicSineNode::computeOnComplex<float>(std::complex<float>, Preferences::ComplexFormat, Preferences::AngleUnit);
+#endif
 template Complex<double> Poincare::HyperbolicSineNode::computeOnComplex<double>(std::complex<double>, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit);
 
 }

--- a/poincare/src/hyperbolic_tangent.cpp
+++ b/poincare/src/hyperbolic_tangent.cpp
@@ -19,7 +19,9 @@ Complex<T> HyperbolicTangentNode::computeOnComplex(const std::complex<T> c, Pref
   return Complex<T>::Builder(ApproximationHelper::NeglectRealOrImaginaryPartIfNeglectable(std::tanh(c), c));
 }
 
+#if POINCARE_FLOAT_SUPPORT
 template Complex<float> Poincare::HyperbolicTangentNode::computeOnComplex<float>(std::complex<float>, Preferences::ComplexFormat, Preferences::AngleUnit);
+#endif
 template Complex<double> Poincare::HyperbolicTangentNode::computeOnComplex<double>(std::complex<double>, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit);
 
 }

--- a/poincare/src/logarithm.cpp
+++ b/poincare/src/logarithm.cpp
@@ -274,8 +274,13 @@ Expression Logarithm::simpleShallowReduce(Context * context, Preferences::Comple
       }
       bool isNegative = true;
       Expression result;
+#if POINCARE_FLOAT_SUPPORT
       Evaluation<float> baseApproximation = b.node()->approximate(1.0f, context, complexFormat, angleUnit);
       std::complex<float> logDenominator = std::log10(static_cast<Complex<float>&>(baseApproximation).stdComplex());
+#else
+      Evaluation<double> baseApproximation = b.node()->approximate(1.0, context, complexFormat, angleUnit);
+      std::complex<double> logDenominator = std::log10(static_cast<Complex<double>&>(baseApproximation).stdComplex());
+#endif
       if (logDenominator.imag() != 0.0f || logDenominator.real() == 0.0f) {
         result = Undefined::Builder();
       }
@@ -381,9 +386,13 @@ Expression Logarithm::shallowBeautify() {
   return *this;
 }
 
+#if POINCARE_FLOAT_SUPPORT
 template Evaluation<float> LogarithmNode<1>::templatedApproximate<float>(Poincare::Context *, Poincare::Preferences::ComplexFormat, Poincare::Preferences::AngleUnit) const;
+#endif
 template Evaluation<double> LogarithmNode<1>::templatedApproximate<double>(Poincare::Context *, Poincare::Preferences::ComplexFormat, Poincare::Preferences::AngleUnit) const;
+#if POINCARE_FLOAT_SUPPORT
 template Evaluation<float> LogarithmNode<2>::templatedApproximate<float>(Poincare::Context *, Poincare::Preferences::ComplexFormat, Poincare::Preferences::AngleUnit) const;
+#endif
 template Evaluation<double> LogarithmNode<2>::templatedApproximate<double>(Poincare::Context *, Poincare::Preferences::ComplexFormat, Poincare::Preferences::AngleUnit) const;
 template int LogarithmNode<1>::serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const;
 template int LogarithmNode<2>::serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const;

--- a/poincare/src/matrix.cpp
+++ b/poincare/src/matrix.cpp
@@ -169,7 +169,11 @@ int Matrix::ArrayInverse(T * array, int numberOfRows, int numberOfColumns) {
   ArrayRowCanonize(operands, dim, 2*dim);
   // Check inversibility
   for (int i = 0; i < dim; i++) {
+#if POINCARE_FLOAT_SUPPORT
     if (std::abs(operands[i*2*dim+i] - (T)1.0) > Expression::Epsilon<float>()) {
+#else
+    if (std::abs(operands[i*2*dim+i] - (T)1.0) > Expression::Epsilon<double>()) {
+#endif
       return -2;
     }
   }
@@ -476,11 +480,17 @@ Expression Matrix::computeInverseOrDeterminant(bool computeDeterminant, Expressi
 }
 
 
+#if POINCARE_FLOAT_SUPPORT
 template int Matrix::ArrayInverse<float>(float *, int, int);
+#endif
 template int Matrix::ArrayInverse<double>(double *, int, int);
+#if POINCARE_FLOAT_SUPPORT
 template int Matrix::ArrayInverse<std::complex<float>>(std::complex<float> *, int, int);
+#endif
 template int Matrix::ArrayInverse<std::complex<double>>(std::complex<double> *, int, int);
+#if POINCARE_FLOAT_SUPPORT
 template void Matrix::ArrayRowCanonize<std::complex<float> >(std::complex<float>*, int, int, std::complex<float>*);
+#endif
 template void Matrix::ArrayRowCanonize<std::complex<double> >(std::complex<double>*, int, int, std::complex<double>*);
 
 }

--- a/poincare/src/matrix_complex.cpp
+++ b/poincare/src/matrix_complex.cpp
@@ -164,10 +164,14 @@ void MatrixComplex<T>::addChildAtIndexInPlace(Evaluation<T> t, int index, int cu
   Evaluation<T>::addChildAtIndexInPlace(t, index, currentNumberOfChildren);
 }
 
+#if POINCARE_FLOAT_SUPPORT
 template class MatrixComplexNode<float>;
+#endif
 template class MatrixComplexNode<double>;
 
+#if POINCARE_FLOAT_SUPPORT
 template class MatrixComplex<float>;
+#endif
 template class MatrixComplex<double>;
 
 }

--- a/poincare/src/power.cpp
+++ b/poincare/src/power.cpp
@@ -741,7 +741,11 @@ Expression Power::shallowReduce(ExpressionNode::ReductionContext reductionContex
      * - (a^b)^(-1) has to be reduced to avoid infinite loop discussed above;
      * - if a^b is unreal, a^(-b) also. */
     if (!cMinusOne && reductionContext.complexFormat() == Preferences::ComplexFormat::Real) {
+#if POINCARE_FLOAT_SUPPORT
       Expression approximation = powerBase.approximate<float>(reductionContext.context(), reductionContext.complexFormat(), reductionContext.angleUnit());
+#else
+      Expression approximation = powerBase.approximate<double>(reductionContext.context(), reductionContext.complexFormat(), reductionContext.angleUnit());
+#endif
       if (approximation.type() == ExpressionNode::Type::Unreal) {
         // The inner power is unreal, return "unreal"
         replaceWithInPlace(approximation);
@@ -1413,7 +1417,9 @@ bool Power::RationalExponentShouldNotBeReduced(const Rational & b, const Rationa
 }
 
 
+#if POINCARE_FLOAT_SUPPORT
 template Complex<float> PowerNode::compute<float>(std::complex<float>, std::complex<float>, Preferences::ComplexFormat);
+#endif
 template Complex<double> PowerNode::compute<double>(std::complex<double>, std::complex<double>, Preferences::ComplexFormat);
 
 }

--- a/poincare/src/sequence.cpp
+++ b/poincare/src/sequence.cpp
@@ -62,7 +62,9 @@ Expression Sequence::shallowReduce(Context * context) {
   return *this;
 }
 
+#if POINCARE_FLOAT_SUPPORT
 template Evaluation<float> SequenceNode::templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
+#endif
 template Evaluation<double> SequenceNode::templatedApproximate(Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit) const;
 
 }

--- a/poincare/src/sign_function.cpp
+++ b/poincare/src/sign_function.cpp
@@ -71,9 +71,15 @@ Expression SignFunction::shallowReduce(ExpressionNode::ReductionContext reductio
   if (s == ExpressionNode::Sign::Negative) {
     resultSign = Rational::Builder(-1);
   } else {
+#if POINCARE_FLOAT_SUPPORT
     Evaluation<float> childApproximated = child.node()->approximate(1.0f, reductionContext.context(), reductionContext.complexFormat(), reductionContext.angleUnit());
     assert(childApproximated.type() == EvaluationNode<float>::Type::Complex);
     Complex<float> c = static_cast<Complex<float>&>(childApproximated);
+#else
+    Evaluation<double> childApproximated = child.node()->approximate(1.0, reductionContext.context(), reductionContext.complexFormat(), reductionContext.angleUnit());
+    assert(childApproximated.type() == EvaluationNode<double>::Type::Complex);
+    Complex<double> c = static_cast<Complex<double>&>(childApproximated);
+#endif
     if (std::isnan(c.imag()) || std::isnan(c.real()) || c.imag() != 0) {
       // c's approximation has no sign (c is complex or NAN)
       if (reductionContext.target() == ExpressionNode::ReductionTarget::User && s == ExpressionNode::Sign::Positive) {

--- a/poincare/src/trigonometry.cpp
+++ b/poincare/src/trigonometry.cpp
@@ -53,7 +53,11 @@ double Trigonometry::PiInAngleUnit(Preferences::AngleUnit angleUnit) {
   return 200.0;
 }
 
+#if POINCARE_FLOAT_SUPPORT
 float Trigonometry::characteristicXRange(const Expression & e, Context * context, Preferences::AngleUnit angleUnit) {
+#else
+double Trigonometry::characteristicXRange(const Expression & e, Context * context, Preferences::AngleUnit angleUnit) {
+#endif
   assert(e.numberOfChildren() == 1);
 
   constexpr int bufferSize = CodePoint::MaxCodePointCharLength + 1;
@@ -73,7 +77,11 @@ float Trigonometry::characteristicXRange(const Expression & e, Context * context
   assert(d == 1);
   /* To compute a, the slope of the expression child(0), we compute the
    * derivative of child(0) for any x value. */
+#if POINCARE_FLOAT_SUPPORT
   Poincare::Derivative derivative = Poincare::Derivative::Builder(e.childAtIndex(0).clone(), Symbol::Builder(x, 1), Float<float>::Builder(1.0f));
+#else
+  Poincare::Derivative derivative = Poincare::Derivative::Builder(e.childAtIndex(0).clone(), Symbol::Builder(x, 1), Float<double>::Builder(1.0f));
+#endif
   double a = derivative.node()->approximate(double(), context, Preferences::ComplexFormat::Real, angleUnit).toScalar();
   double pi = PiInAngleUnit(angleUnit);
   return std::fabs(a) < Expression::Epsilon<double>() ? NAN : 2.0*pi/std::fabs(a);
@@ -412,9 +420,13 @@ std::complex<T> Trigonometry::ConvertRadianToAngleUnit(const std::complex<T> c, 
   return c;
 }
 
+#if POINCARE_FLOAT_SUPPORT
 template std::complex<float> Trigonometry::ConvertToRadian<float>(std::complex<float>, Preferences::AngleUnit);
+#endif
 template std::complex<double> Trigonometry::ConvertToRadian<double>(std::complex<double>, Preferences::AngleUnit);
+#if POINCARE_FLOAT_SUPPORT
 template std::complex<float> Trigonometry::ConvertRadianToAngleUnit<float>(std::complex<float>, Preferences::AngleUnit);
+#endif
 template std::complex<double> Trigonometry::ConvertRadianToAngleUnit<double>(std::complex<double>, Preferences::AngleUnit);
 
 }

--- a/poincare/src/trigonometry_cheat_table.cpp
+++ b/poincare/src/trigonometry_cheat_table.cpp
@@ -59,13 +59,22 @@ Expression TrigonometryCheatTable::simplify(const Expression e, ExpressionNode::
   }
 
   // Approximate e to quickly compare it to cheat table entries
+#if POINCARE_FLOAT_SUPPORT
   float eValue = e.node()->approximate(float(), reductionContext.context(), reductionContext.complexFormat(), reductionContext.angleUnit()).toScalar();
+#else
+  double eValue = e.node()->approximate(double(), reductionContext.context(), reductionContext.complexFormat(), reductionContext.angleUnit()).toScalar();
+#endif
   if (std::isnan(eValue) || std::isinf(eValue)) {
     return Expression();
   }
   for (int i = 0; i < k_numberOfEntries; i++) {
+#if POINCARE_FLOAT_SUPPORT
     float inputValue = floatForTypeAtIndex(inputType, i);
     if (std::isnan(inputValue) || std::fabs(inputValue - eValue) > Expression::Epsilon<float>()) {
+#else
+    double inputValue = floatForTypeAtIndex(inputType, i);
+    if (std::isnan(inputValue) || std::fabs(inputValue - eValue) > Expression::Epsilon<double>()) {
+#endif
       continue;
     }
     /* e's approximation matches a table entry, check that both expressions are

--- a/poincare/test/helper.cpp
+++ b/poincare/test/helper.cpp
@@ -140,7 +140,11 @@ void assert_expression_layouts_as(Poincare::Expression expression, Poincare::Lay
   quiz_assert(l.isIdenticalTo(layout));
 }
 
+#if POINCARE_FLOAT_SUPPORT
 template void assert_expression_approximates_to<float>(char const*, char const *, Poincare::Preferences::AngleUnit, Poincare::Preferences::ComplexFormat, int);
+#endif
 template void assert_expression_approximates_to<double>(char const*, char const *,  Poincare::Preferences::AngleUnit, Poincare::Preferences::ComplexFormat, int);
+#if POINCARE_FLOAT_SUPPORT
 template void assert_expression_simplifies_approximates_to<float>(char const*, char const *, Poincare::Preferences::AngleUnit, Poincare::Preferences::ComplexFormat, int);
+#endif
 template void assert_expression_simplifies_approximates_to<double>(char const*, char const *,  Poincare::Preferences::AngleUnit, Poincare::Preferences::ComplexFormat, int);


### PR DESCRIPTION
I've always been somewhat annoyed by that templated float / double code duplication. Leveraging the processor's HW SPFP support, limited to a handful of instructions, is good in theory; however, for accuracy reasons, the SW DPFP code needs to be there anyway... and from eyeballing at the objdump disassembly output over the years, I always thought that the duplication was costly.
critor wrote that the latest Epsilon 13.1 builds are more than 920 KB large, so I wondered how hard disabling the SPFP code would be, and how much space it would save :)

Answer after a couple hours: certainly 30+ KB. I didn't do a thorough job purging the float <-> double comparisons, I just made the <float> templates optional, and performed just enough changes for the N0110 build to be successful. The CI jobs tell me that the other builds fail. Of course, I haven't tested my changes, as usual.

I'm pushing this code just so that it's not completely lost, if/when someone wants to do the same thing :)

Before:
```
$ arm-none-eabi-size ./output/release/device/n0110/epsilon.elf
   text    data     bss     dec     hex filename
 632100  231671  260144 1123915  11264b ./output/release/device/n0110/epsilon.elf
```

After:
```
$ arm-none-eabi-size ./output/release/device/n0110/epsilon.elf
   text    data     bss     dec     hex filename
 599892  230539  260152 1090583  10a417 ./output/release/device/n0110/epsilon.elf
```