### PR TITLE
[build] rule_for now takes both "local" and "global" parameters

### DIFF
--- a/apps/Makefile
+++ b/apps/Makefile
@@ -80,7 +80,8 @@ $(eval $(call rule_for, \
   I18N, \
   apps/i18n.cpp, \
   $(i18n_files), \
-  $$(PYTHON) apps/i18n.py --header $$(subst .cpp,.h,$$@) --implementation $$@ --locales $$(EPSILON_I18N) --files $$^ \
+  $$(PYTHON) apps/i18n.py --header $$(subst .cpp,.h,$$@) --implementation $$@ --locales $$(EPSILON_I18N) --files $$^, \
+  global \
 ))
 
 $(BUILD_DIR)/apps/i18n.h: $(BUILD_DIR)/apps/i18n.cpp

--- a/build/helpers.mk
+++ b/build/helpers.mk
@@ -8,15 +8,20 @@ define rule_label
 @ echo "$(shell printf "%-8s" $(strip $(1)))$(@:$(BUILD_DIR)/%=%)"
 endef
 
+# rule_for can define both global and local rules
+#  - use local if the source can be an intermediate file
+#  - use global if the source can be in the main tree
 define rule_for
-ifeq ($(strip $(5)),with_local_version)
+ifneq ($(filter global,$(5)),)
+$(addprefix $$(BUILD_DIR)/,$(strip $(2))): $(strip $(3)) | $$$$(@D)/.
+	@ echo "$(shell printf "%-8s" $(strip $(1)))$$(@:$$(BUILD_DIR)/%=%)"
+	$(Q) $(4)
+endif
+ifneq ($(filter local,$(5)),)
 $(addprefix $$(BUILD_DIR)/,$(strip $(2))): $(addprefix $$(BUILD_DIR)/,$(strip $(3)))
 	@ echo "$(shell printf "%-8s" $(strip $(1)))$$(@:$$(BUILD_DIR)/%=%)"
 	$(Q) $(4)
 endif
-$(addprefix $$(BUILD_DIR)/,$(strip $(2))): $(strip $(3)) | $$$$(@D)/.
-	@ echo "$(shell printf "%-8s" $(strip $(1)))$$(@:$$(BUILD_DIR)/%=%)"
-	$(Q) $(4)
 endef
 
 # Helper functions to work with variants

--- a/build/rules.mk
+++ b/build/rules.mk
@@ -2,56 +2,62 @@
 
 $(eval $(call rule_for, \
   AS, %.o, %.s, \
-  $$(CC) $$(SFLAGS) -c $$< -o $$@ \
+  $$(CC) $$(SFLAGS) -c $$< -o $$@, \
+  global \
 ))
 
 $(eval $(call rule_for, \
   CC, %.o, %.c, \
   $$(CC) $$(CFLAGS) $$(SFLAGS) -c $$< -o $$@, \
-  with_local_version \
+  global local \
 ))
 
 $(eval $(call rule_for, \
   CPP, %, %.inc, \
-  $$(CPP) -P $$< $$@ \
+  $$(CPP) -P $$< $$@, \
+  global \
 ))
 
 $(eval $(call rule_for, \
   CXX, %.o, %.cpp, \
   $$(CXX) $$(CXXFLAGS) $$(SFLAGS) -c $$< -o $$@, \
-  with_local_version \
+  global local \
 ))
 
 $(eval $(call rule_for, \
   DFUSE, %.dfu, %.elf, \
   $$(PYTHON) build/device/elf2dfu.py $$< $$@, \
-  with_local_version \
+  local \
 ))
 
 $(eval $(call rule_for, \
   OBJCOPY, %.hex, %.elf, \
-  $$(OBJCOPY) -O ihex $$< $$@ \
+  $$(OBJCOPY) -O ihex $$< $$@, \
+  local \
 ))
 
 $(eval $(call rule_for, \
   OBJCOPY, %.bin, %.elf, \
   $$(OBJCOPY) -O binary $$< $$@, \
-  with_local_version \
+  local \
 ))
 
 $(eval $(call rule_for, \
   OCC, %.o, %.m, \
-  $$(CC) $$(CFLAGS) $$(SFLAGS) -c $$< -o $$@ \
+  $$(CC) $$(CFLAGS) $$(SFLAGS) -c $$< -o $$@, \
+  global \
 ))
 
 $(eval $(call rule_for, \
   OCC, %.o, %.mm, \
-  $$(CXX) $$(CXXFLAGS) $$(SFLAGS) -c $$< -o $$@ \
+  $$(CXX) $$(CXXFLAGS) $$(SFLAGS) -c $$< -o $$@, \
+  global \
 ))
 
 $(eval $(call rule_for, \
   WINDRES, %.o, %.rc, \
-  $$(WINDRES) $$< -O coff -o $$@ \
+  $$(WINDRES) $$< -O coff -o $$@, \
+  global \
 ))
 
 ifdef EXE
@@ -63,12 +69,14 @@ ifeq ($(OS),Windows_NT)
 # the linker to read its arguments from this file.
 $(eval $(call rule_for, \
   LD, %.$$(EXE), , \
-  echo $$^ > $$@.objs && $$(LD) @$$@.objs $$(LDFLAGS) -o $$@ && rm $$@.objs \
+  echo $$^ > $$@.objs && $$(LD) @$$@.objs $$(LDFLAGS) -o $$@ && rm $$@.objs, \
+  global \
 ))
 else
 $(eval $(call rule_for, \
   LD, %.$$(EXE), , \
-  $$(LD) $$^ $$(LDFLAGS) -o $$@ \
+  $$(LD) $$^ $$(LDFLAGS) -o $$@, \
+  global \
 ))
 endif
 endif

--- a/escher/Makefile
+++ b/escher/Makefile
@@ -94,7 +94,8 @@ $(eval $(call rule_for, \
   HOSTCC, \
   escher/image/inliner, \
   escher/image/inliner.c $(addprefix ion/src/external/lz4/, lz4.c lz4hc.c), \
-  $$(HOSTCC) -std=c99 `libpng-config --cflags` $$^ `libpng-config --ldflags` -o $$@ \
+  $$(HOSTCC) -std=c99 `libpng-config --cflags` $$^ `libpng-config --ldflags` -o $$@, \
+  global \
 ))
 
 INLINER := $(BUILD_DIR)/escher/image/inliner
@@ -104,7 +105,8 @@ $(eval $(call rule_for, \
   INLINER, \
   %.h %.cpp, \
   %.png $$(INLINER), \
-  $$(INLINER) $$< $$(basename $$@).h $$(basename $$@).cpp \
+  $$(INLINER) $$< $$(basename $$@).h $$(basename $$@).cpp, \
+  global \
 ))
 
 # Mark a .cpp file as depending on a .png one

--- a/kandinsky/Makefile
+++ b/kandinsky/Makefile
@@ -38,7 +38,8 @@ $(eval $(call rule_for, \
   HOSTCC, \
   kandinsky/fonts/rasterizer, \
   kandinsky/fonts/rasterizer.c $(addprefix ion/src/external/lz4/, lz4.c lz4hc.c), \
-  $$(HOSTCC) $$(RASTERIZER_CFLAGS) $$^ $$(RASTERIZER_LDFLAGS) -o $$@ \
+  $$(HOSTCC) $$(RASTERIZER_CFLAGS) $$^ $$(RASTERIZER_LDFLAGS) -o $$@, \
+  global \
 ))
 
 RASTERIZER := $(BUILD_DIR)/kandinsky/fonts/rasterizer
@@ -49,7 +50,8 @@ $(call rule_for, \
   RASTER, \
   kandinsky/fonts/$(1).cpp, \
   kandinsky/fonts/$(1).ttf $$(RASTERIZER), \
-  $$(RASTERIZER) $$< $(2) $(2) $(3) $(4) $(1) $$@ $(if $(HAS_LIBPNG),$$(basename $$@).png) \
+  $$(RASTERIZER) $$< $(2) $(2) $(3) $(4) $(1) $$@ $(if $(HAS_LIBPNG),$$(basename $$@).png), \
+  global \
 )
 endef
 

--- a/python/Makefile
+++ b/python/Makefile
@@ -183,7 +183,8 @@ $(eval $(call rule_for, \
   QSTRDAT, \
   python/port/genhdr/qstrdefs.generated.h, \
   python/port/genhdr/qstrdefs.in.h, \
-  $$(PYTHON) python/src/py/makeqstrdata.py $$< > $$@ \
+  $$(PYTHON) python/src/py/makeqstrdata.py $$< > $$@, \
+  global \
 ))
 
 $(call object_for,$(python_src)): $(BUILD_DIR)/python/port/genhdr/qstrdefs.generated.h


### PR DESCRIPTION
Previous the build would fail on macOS if you had an epsilon.elf file in
at the root of the project. Indeed, the %.elf -> %.bin rule would get
triggered, but this rule should only operate on generated (intermediate)
elf file.