### PR TITLE
I18NWarn

### DIFF
--- a/apps/Makefile
+++ b/apps/Makefile
@@ -80,7 +80,7 @@ $(eval $(call rule_for, \
   I18N, \
   apps/i18n.cpp, \
   $(i18n_files), \
-  $$(PYTHON) apps/i18n.py --header $$(subst .cpp,.h,$$@) --implementation $$@ --locales $$(EPSILON_I18N) --files $$^, \
+  $$(PYTHON) apps/i18n.py --codepoints $(code_points) --header $$(subst .cpp,.h,$$@) --implementation $$@ --locales $$(EPSILON_I18N) --files $$^, \
   global \
 ))
 

--- a/kandinsky/Makefile
+++ b/kandinsky/Makefile
@@ -25,6 +25,8 @@ tests_src += $(addprefix kandinsky/test/,\
   rect.cpp\
 )
 
+code_points = kandinsky/fonts/code_points.h
+
 RASTERIZER_CFLAGS := -std=c99 $(shell pkg-config freetype2 --cflags)
 RASTERIZER_LDFLAGS := $(shell pkg-config freetype2 --libs)
 


### PR DESCRIPTION
This patch https://github.com/numworks/epsilon/issues/1173
## An example of logs :
```
I18N    apps/i18n.cpp
👍 (0x128077) is not a valid character
```
## How it works :
It just parse the code_points.h file, and check for each character if it is inside this file.

Note : this is a reopen of https://github.com/numworks/epsilon/pull/1359.