### PR TITLE
[Calculation] Allow inserting a past result at the *denominator* of a fraction

### DIFF
--- a/apps/calculation/expression_field.h
+++ b/apps/calculation/expression_field.h
@@ -7,7 +7,10 @@ namespace Calculation {
 
 class ExpressionField : public ::ExpressionField {
 public:
-  using ::ExpressionField::ExpressionField;
+  ExpressionField(Responder * parentResponder, InputEventHandlerDelegate * inputEventHandler, TextFieldDelegate * textFieldDelegate, LayoutFieldDelegate * layoutFieldDelegate) :
+  ::ExpressionField(parentResponder, inputEventHandler, textFieldDelegate, layoutFieldDelegate) {
+    setLayoutInsertionCursorEvent(Ion::Events::Up);
+  }
 protected:
   bool handleEvent(Ion::Events::Event event) override;
 };

--- a/escher/include/escher/expression_field.h
+++ b/escher/include/escher/expression_field.h
@@ -25,6 +25,7 @@ public:
   bool isEmpty() const;
   bool inputViewHeightDidChange();
   bool handleEventWithText(const char * text, bool indentation = false, bool forceCursorRightOfText = false);
+  void setLayoutInsertionCursorEvent(Ion::Events::Event event) { m_layoutField.setInsertionCursorEvent(event); }
 
   /* View */
   int numberOfSubviews() const override { return 1; }

--- a/escher/include/escher/layout_field.h
+++ b/escher/include/escher/layout_field.h
@@ -60,6 +60,7 @@ private:
   void scrollRightOfLayout(Poincare::Layout layoutR);
   void scrollToBaselinedRect(KDRect rect, KDCoordinate baseline);
   void insertLayoutAtCursor(Poincare::Layout layoutR, Poincare::Expression correspondingExpression, bool forceCursorRightOfLayout = false);
+  bool eventShouldUpdateInsertionCursor(Ion::Events::Event event) { return event == Ion::Events::Up; }
 
   class ContentView : public View {
   public:
@@ -83,14 +84,22 @@ private:
     void copySelection(Poincare::Context * context);
     bool selectionIsEmpty() const;
     void deleteSelection();
+    void invalidateInsertionCursor() { m_insertionCursor = Poincare::LayoutCursor(); }
+    void updateInsertionCursor() {
+      if (!m_insertionCursor.isDefined()) {
+        m_insertionCursor = m_cursor;
+      }
+    }
 
   private:
     int numberOfSubviews() const override { return 2; }
     View * subviewAtIndex(int index) override;
     void layoutSubviews(bool force = false) override;
     void layoutCursorSubview(bool force);
+    void useInsertionCursor();
     KDRect selectionRect() const;
     Poincare::LayoutCursor m_cursor;
+    Poincare::LayoutCursor m_insertionCursor;
     ExpressionView m_expressionView;
     TextCursorView m_cursorView;
     /* The selection starts on the left of m_selectionStart, and ends on the

--- a/escher/include/escher/layout_field.h
+++ b/escher/include/escher/layout_field.h
@@ -19,6 +19,7 @@ public:
     ScrollableView(parentResponder, &m_contentView, this),
     EditableField(inputEventHandlerDelegate),
     m_contentView(),
+    m_insertionCursorEvent(Ion::Events::None),
     m_delegate(delegate)
   {}
   void setDelegates(InputEventHandlerDelegate * inputEventHandlerDelegate, LayoutFieldDelegate * delegate) { m_inputEventHandlerDelegate = inputEventHandlerDelegate; m_delegate = delegate; }
@@ -33,6 +34,7 @@ public:
   Poincare::Layout layout() const { return m_contentView.expressionView()->layout(); }
   CodePoint XNTCodePoint(CodePoint defaultXNTCodePoint) override;
   void putCursorRightOfLayout();
+  void setInsertionCursorEvent(Ion::Events::Event event) { m_insertionCursorEvent = event; }
 
   // ScrollableView
   void setBackgroundColor(KDColor c) override  {
@@ -60,7 +62,7 @@ private:
   void scrollRightOfLayout(Poincare::Layout layoutR);
   void scrollToBaselinedRect(KDRect rect, KDCoordinate baseline);
   void insertLayoutAtCursor(Poincare::Layout layoutR, Poincare::Expression correspondingExpression, bool forceCursorRightOfLayout = false);
-  bool eventShouldUpdateInsertionCursor(Ion::Events::Event event) { return event == Ion::Events::Up; }
+  bool eventShouldUpdateInsertionCursor(Ion::Events::Event event) { return event == m_insertionCursorEvent; }
 
   class ContentView : public View {
   public:
@@ -109,6 +111,7 @@ private:
     bool m_isEditing;
   };
   ContentView m_contentView;
+  Ion::Events::Event m_insertionCursorEvent;
   LayoutFieldDelegate * m_delegate;
 };
 

--- a/escher/include/escher/layout_field.h
+++ b/escher/include/escher/layout_field.h
@@ -101,6 +101,14 @@ private:
     void useInsertionCursor();
     KDRect selectionRect() const;
     Poincare::LayoutCursor m_cursor;
+    /* The insertion cursor is a secondary cursor that determines where text
+     * should be inserted. Most of the time this cursor is useless (and is
+     * therefore disabled), but in an interface where the user can navigate out
+     * of the field, it's important to keep track of where inserted text should
+     * go even if the main cursor was moved.
+     * For instance, this is useful in the Calculation app when the user wants
+     * to type a division and scroll up the history to insert something at the
+     * denominator. */
     Poincare::LayoutCursor m_insertionCursor;
     ExpressionView m_expressionView;
     TextCursorView m_cursorView;

--- a/escher/src/layout_field.cpp
+++ b/escher/src/layout_field.cpp
@@ -12,6 +12,7 @@ static inline KDCoordinate minCoordinate(KDCoordinate x, KDCoordinate y) { retur
 
 LayoutField::ContentView::ContentView() :
   m_cursor(),
+  m_insertionCursor(),
   m_expressionView(0.0f, 0.5f, KDColorBlack, KDColorWhite, &m_selectionStart, &m_selectionEnd),
   m_cursorView(),
   m_selectionStart(),
@@ -31,10 +32,19 @@ bool LayoutField::ContentView::setEditing(bool isEditing) {
       m_expressionView.layout().invalidAllSizesPositionsAndBaselines();
       return true;
     }
+  } else {
+    // We're leaving the edition of the current layout
+    useInsertionCursor();
   }
   layoutSubviews();
   markRectAsDirty(bounds());
   return false;
+}
+
+void LayoutField::ContentView::useInsertionCursor() {
+  if (m_insertionCursor.isDefined()) {
+    m_cursor = m_insertionCursor;
+  }
 }
 
 void LayoutField::ContentView::clearLayout() {
@@ -319,6 +329,12 @@ bool LayoutField::handleEventWithText(const char * text, bool indentation, bool 
    * - the text added after a toolbox selection
    * - the result of a copy-paste. */
 
+  /* This routing can be called even if no actual underlying event has been
+   * dispatched on the LayoutField. For instance, when someone wants to insert
+   * text in the field from the outside. In this scenario, let's make sure the
+   * insertionCursor is invalidated. */
+  m_contentView.invalidateInsertionCursor();
+
   // Delete the selected layouts if needed
   deleteSelection();
 
@@ -382,6 +398,9 @@ bool LayoutField::handleEvent(Ion::Events::Event event) {
   KDSize previousSize = minimalSizeForOptimalDisplay();
   bool shouldRecomputeLayout = m_contentView.cursor()->showEmptyLayoutIfNeeded();
   bool moveEventChangedLayout = false;
+  if (!eventShouldUpdateInsertionCursor(event)) {
+    m_contentView.invalidateInsertionCursor();
+  }
   if (privateHandleMoveEvent(event, &moveEventChangedLayout)) {
     if (!isEditing()) {
       setEditing(true);
@@ -551,6 +570,9 @@ bool LayoutField::privateHandleMoveEvent(Ion::Events::Event event, bool * should
   LayoutCursor result;
   result = m_contentView.cursor()->cursorAtDirection(DirectionForMoveEvent(event), shouldRecomputeLayout);
   if (result.isDefined()) {
+    if (eventShouldUpdateInsertionCursor(event)) {
+      m_contentView.updateInsertionCursor();
+    }
     m_contentView.setCursor(result);
     return true;
   }


### PR DESCRIPTION
1. Go to the Calculation app
2. Type `123`
3. Now type `456/` and try retrieving the `123` above to make `456/123`.