### PR TITLE
[Escher/Metric] Decrease row height from 50 to 38

### DIFF
--- a/escher/include/escher/metric.h
+++ b/escher/include/escher/metric.h
@@ -26,7 +26,7 @@ public:
   constexpr static KDCoordinate PopUpTopMargin = 50;
   constexpr static KDCoordinate ExamPopUpTopMargin = 27;
   constexpr static KDCoordinate ExamPopUpBottomMargin = 55;
-  constexpr static KDCoordinate StoreRowHeight = 50;
+  constexpr static KDCoordinate StoreRowHeight = 38;
   constexpr static KDCoordinate ToolboxRowHeight = 40;
   constexpr static KDCoordinate StackTitleHeight = 20;
   constexpr static KDCoordinate FractionAndConjugateHorizontalOverflow = 2;


### PR DESCRIPTION
I decreased the row height from 50px to 38px so more items can now be showed in a list. This works well with the compact result display. This closes #1023 

Before:
![NWHO1](https://user-images.githubusercontent.com/29680628/78919064-fdad7180-7a56-11ea-982a-3d2a92d80336.png)![NWHO2](https://user-images.githubusercontent.com/29680628/78919065-fdad7180-7a56-11ea-9215-585e9a338f9b.png)

After: 
![NWSC1](https://user-images.githubusercontent.com/29680628/78919590-bbd0fb00-7a57-11ea-8584-66cc24890532.png)![NWSC2](https://user-images.githubusercontent.com/29680628/78919593-bbd0fb00-7a57-11ea-8f18-09f9568b2d35.png)
