### PR TITLE
[apps] GET_OPT uses generated i18n language codes to find language

### DIFF
--- a/apps/Makefile
+++ b/apps/Makefile
@@ -57,6 +57,9 @@ $(call object_for,apps/apps_container_storage.cpp apps/apps_container.cpp apps/m
 SFLAGS += -I$(BUILD_DIR)
 
 i18n_files += $(addprefix apps/language_,$(addsuffix .universal.i18n, $(EPSILON_I18N)))
+ifeq ($(EPSILON_GETOPT),1)
+i18n_files += $(addprefix apps/language_,$(addsuffix _iso6391.universal.i18n, $(EPSILON_I18N)))
+endif
 i18n_files += $(addprefix apps/,\
   shared.de.i18n\
   shared.en.i18n\
@@ -80,7 +83,7 @@ $(eval $(call rule_for, \
   I18N, \
   apps/i18n.cpp, \
   $(i18n_files), \
-  $$(PYTHON) apps/i18n.py --codepoints $(code_points) --header $$(subst .cpp,.h,$$@) --implementation $$@ --locales $$(EPSILON_I18N) --files $$^, \
+  $$(PYTHON) apps/i18n.py --codepoints $(code_points) --header $$(subst .cpp,.h,$$@) --implementation $$@ --locales $$(EPSILON_I18N) --files $$^ --generateISO6391locales $$(EPSILON_GETOPT), \
   global \
 ))
 

--- a/apps/i18n.py
+++ b/apps/i18n.py
@@ -19,8 +19,12 @@ parser.add_argument('--implementation', help='the .cpp file to generate')
 parser.add_argument('--locales', nargs='+', help='locale to actually generate')
 parser.add_argument('--codepoints', help='the code_points.h file')
 parser.add_argument('--files', nargs='+', help='an i18n file')
+parser.add_argument('--generateISO6391locales', type=int, nargs='+', help='whether to generate the ISO6391 codes for the languages (for instance "en" for english)')
 
 args = parser.parse_args()
+
+def generate_ISO6391():
+    return args.generateISO6391locales[0] == 1
 
 def has_glyph(glyph):
     return glyph in codepoints
@@ -143,6 +147,14 @@ def print_header(data, path, locales):
     for locale in locales:
         f.write("  Message::Language" + locale.upper() + ",\n")
     f.write("};\n\n")
+
+    if generate_ISO6391():
+        # Language ISO639-1 codes
+        f.write("constexpr const Message LanguageISO6391Names[NumberOfLanguages] = {\n");
+        for locale in locales:
+            f.write("  Message::LanguageISO6391" + locale.upper() + ",\n")
+        f.write("};\n\n")
+
     f.write("}\n\n")
     f.write("#endif\n")
     f.close()

--- a/apps/language_de_iso6391.universal.i18n
+++ b/apps/language_de_iso6391.universal.i18n
@@ -1,0 +1,1 @@
+LanguageISO6391DE = "de"

--- a/apps/language_en_iso6391.universal.i18n
+++ b/apps/language_en_iso6391.universal.i18n
@@ -1,0 +1,1 @@
+LanguageISO6391EN = "en"

--- a/apps/language_es_iso6391.universal.i18n
+++ b/apps/language_es_iso6391.universal.i18n
@@ -1,0 +1,1 @@
+LanguageISO6391ES = "es"

--- a/apps/language_fr_iso6391.universal.i18n
+++ b/apps/language_fr_iso6391.universal.i18n
@@ -1,0 +1,1 @@
+LanguageISO6391FR = "fr"

--- a/apps/language_pt_iso6391.universal.i18n
+++ b/apps/language_pt_iso6391.universal.i18n
@@ -1,0 +1,1 @@
+LanguageISO6391PT = "pt"

--- a/apps/main.cpp
+++ b/apps/main.cpp
@@ -31,11 +31,13 @@ void ion_main(int argc, const char * const argv[]) {
      * $ ./epsilon.elf --language fr
      */
     if (strcmp(argv[i], "--language") == 0 && argc > i+1) {
-      const char * languageIdentifiers[] = {"none", "en", "fr", "es", "de", "pt"};
       const char * requestedLanguageId = argv[i+1];
-      for (int i=0; i<sizeof(languageIdentifiers)/sizeof(languageIdentifiers[0]); i++) {
-        if (strcmp(requestedLanguageId, languageIdentifiers[i]) == 0) {
-          GlobalPreferences::sharedGlobalPreferences()->setLanguage((I18n::Language)i);
+      if (strcmp(requestedLanguageId, "none") == 0) {
+        continue;
+      }
+      for (int j = 0; j < I18n::NumberOfLanguages; j++) {
+        if (strcmp(requestedLanguageId, I18n::translate(I18n::LanguageISO6391Names[j])) == 0) {
+          GlobalPreferences::sharedGlobalPreferences()->setLanguage((I18n::Language)j);
           break;
         }
       }


### PR DESCRIPTION
Fixes #1493
- We removed Default from the Languages list in #1454, which invalidated our algorithm to parse the argument "--language" in apps/main.cpp, which resulted in the bug described in #1493
- This PR cleans said algorithm, so we do not need the dangerous `const char * languageIdentifiers[]` anymore

I added i18n files for the ISO639-1 codes for languages, but those i18n are only built when `EPSILON_GET_OPT=1`, so not for the device

Maybe we should remove the "none" case?

