### PR TITLE
[Python] Kandinsky line()

### DIFF
--- a/python/port/genhdr/qstrdefs.in.h
+++ b/python/port/genhdr/qstrdefs.in.h
@@ -72,6 +72,7 @@ Q(draw_string)
 Q(fill_rect)
 Q(get_pixel)
 Q(set_pixel)
+Q(line)
 
 // Matplotlib QSTRs
 Q(arrow)

--- a/python/port/mod/kandinsky/modkandinsky.cpp
+++ b/python/port/mod/kandinsky/modkandinsky.cpp
@@ -106,3 +106,13 @@ mp_obj_t modkandinsky_fill_rect(size_t n_args, const mp_obj_t * args) {
   micropython_port_interrupt_if_needed();
   return mp_const_none;
 }
+
+mp_obj_t modkandinsky_line(size_t n_args, const mp_obj_t * args){
+  KDPoint point1(mp_obj_get_int(args[0]), mp_obj_get_int(args[1]));
+  KDPoint point2(mp_obj_get_int(args[2]), mp_obj_get_int(args[3]));
+  KDColor color = ColorForTuple(args[4]);
+  MicroPython::ExecutionEnvironment::currentExecutionEnvironment()->displaySandbox();
+  KDIonContext::sharedContext()->drawLine(point1, point2, color);
+  micropython_port_interrupt_if_needed();
+  return mp_const_none;
+}

--- a/python/port/mod/kandinsky/modkandinsky.h
+++ b/python/port/mod/kandinsky/modkandinsky.h
@@ -5,3 +5,4 @@ mp_obj_t modkandinsky_get_pixel(mp_obj_t x, mp_obj_t y);
 mp_obj_t modkandinsky_set_pixel(mp_obj_t x, mp_obj_t y, mp_obj_t color);
 mp_obj_t modkandinsky_draw_string(size_t n_args, const mp_obj_t *args);
 mp_obj_t modkandinsky_fill_rect(size_t n_args, const mp_obj_t *args);
+mp_obj_t modkandinsky_line(size_t n_args, const mp_obj_t * args);

--- a/python/port/mod/kandinsky/modkandinsky_table.c
+++ b/python/port/mod/kandinsky/modkandinsky_table.c
@@ -5,6 +5,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(modkandinsky_get_pixel_obj, modkandinsky_get_pi
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(modkandinsky_set_pixel_obj, modkandinsky_set_pixel);
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(modkandinsky_draw_string_obj, 3, 5, modkandinsky_draw_string);
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(modkandinsky_fill_rect_obj, 5, 5, modkandinsky_fill_rect);
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(modkandinsky_line_obj, 5, 5, modkandinsky_line);
 
 STATIC const mp_rom_map_elem_t modkandinsky_module_globals_table[] = {
   { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_kandinsky) },
@@ -13,6 +14,7 @@ STATIC const mp_rom_map_elem_t modkandinsky_module_globals_table[] = {
   { MP_ROM_QSTR(MP_QSTR_set_pixel), (mp_obj_t)&modkandinsky_set_pixel_obj },
   { MP_ROM_QSTR(MP_QSTR_draw_string), (mp_obj_t)&modkandinsky_draw_string_obj },
   { MP_ROM_QSTR(MP_QSTR_fill_rect), (mp_obj_t)&modkandinsky_fill_rect_obj },
+  { MP_ROM_QSTR(MP_QSTR_line), (mp_obj_t)&modkandinsky_line_obj }
 };
 
 STATIC MP_DEFINE_CONST_DICT(modkandinsky_module_globals, modkandinsky_module_globals_table);


### PR DESCRIPTION
Rebase of https://github.com/numworks/epsilon/pull/1327
https://github.com/numworks/epsilon/pull/1327#issuecomment-610832377 is partially patched : the line which doesn't look like a line is due to https://github.com/numworks/epsilon/issues/1502. You can still compile by adding
```cpp
SFLAGS += -DEPSILON_SDL_SCREEN_ONLY=1
```
in ./Makefile to avoid the non straight line

- [ ] Add the function in toolbox