### PR TITLE
Use std::min and std::max

### DIFF
--- a/apps/calculation/calculation.cpp
+++ b/apps/calculation/calculation.cpp
@@ -7,13 +7,12 @@
 #include <poincare/unreal.h>
 #include <string.h>
 #include <cmath>
+#include <algorithm>
 
 using namespace Poincare;
 using namespace Shared;
 
 namespace Calculation {
-
-static inline KDCoordinate maxCoordinate(KDCoordinate x, KDCoordinate y) { return x > y ? x : y; }
 
 bool Calculation::operator==(const Calculation& c) {
   return strcmp(inputText(), c.inputText()) == 0
@@ -158,7 +157,7 @@ KDCoordinate Calculation::height(Context * context, bool expanded, bool allExpre
     KDCoordinate exactOutputHeight = exactLayout.layoutSize().height();
     if (allExpressionsInline) {
       KDCoordinate exactOutputBaseline = exactLayout.baseline();
-      result = maxCoordinate(inputBaseline, exactOutputBaseline) + maxCoordinate(inputHeight - inputBaseline, exactOutputHeight-exactOutputBaseline);
+      result = std::max(inputBaseline, exactOutputBaseline) + std::max(inputHeight - inputBaseline, exactOutputHeight-exactOutputBaseline);
     } else {
       result = inputHeight+exactOutputHeight;
     }
@@ -185,7 +184,7 @@ KDCoordinate Calculation::height(Context * context, bool expanded, bool allExpre
     if (displayOutput(context) == DisplayOutput::ApproximateOnly || (!expanded && displayOutput(context) == DisplayOutput::ExactAndApproximateToggle)) {
       if (allExpressionsInline) {
         KDCoordinate approximateOutputBaseline = approximateLayout.baseline();
-        result = maxCoordinate(inputBaseline, approximateOutputBaseline) + maxCoordinate(inputHeight - inputBaseline, approximateOutputHeight-approximateOutputBaseline);
+        result = std::max(inputBaseline, approximateOutputBaseline) + std::max(inputHeight - inputBaseline, approximateOutputHeight-approximateOutputBaseline);
       } else {
         result = inputHeight+approximateOutputHeight;
       }
@@ -195,9 +194,9 @@ KDCoordinate Calculation::height(Context * context, bool expanded, bool allExpre
       KDCoordinate exactOutputBaseline = exactLayout.baseline();
       KDCoordinate approximateOutputBaseline = approximateLayout.baseline();
       if (allExpressionsInline) {
-        result = maxCoordinate(inputBaseline, maxCoordinate(exactOutputBaseline, approximateOutputBaseline)) + maxCoordinate(inputHeight - inputBaseline, maxCoordinate(exactOutputHeight - exactOutputBaseline, approximateOutputHeight-approximateOutputBaseline));
+        result = std::max(inputBaseline, std::max(exactOutputBaseline, approximateOutputBaseline)) + std::max(inputHeight - inputBaseline, std::max(exactOutputHeight - exactOutputBaseline, approximateOutputHeight-approximateOutputBaseline));
       } else {
-        KDCoordinate outputHeight = maxCoordinate(exactOutputBaseline, approximateOutputBaseline) + maxCoordinate(exactOutputHeight-exactOutputBaseline, approximateOutputHeight-approximateOutputBaseline);
+        KDCoordinate outputHeight = std::max(exactOutputBaseline, approximateOutputBaseline) + std::max(exactOutputHeight-exactOutputBaseline, approximateOutputHeight-approximateOutputBaseline);
         result = inputHeight + outputHeight;
       }
     }

--- a/apps/calculation/history_view_cell.cpp
+++ b/apps/calculation/history_view_cell.cpp
@@ -5,11 +5,9 @@
 #include <poincare/exception_checkpoint.h>
 #include <assert.h>
 #include <string.h>
+#include <algorithm>
 
 namespace Calculation {
-
-static inline KDCoordinate minCoordinate(KDCoordinate x, KDCoordinate y) { return x < y ? x : y; }
-static inline KDCoordinate maxCoordinate(KDCoordinate x, KDCoordinate y) { return x > y ? x : y; }
 
 /* HistoryViewCellDataSource */
 
@@ -182,14 +180,14 @@ void HistoryViewCell::layoutSubviews(bool force) {
   KDSize inputSize = m_inputView.minimalSizeForOptimalDisplay();
   m_inputView.setFrame(KDRect(
     0, 0,
-    minCoordinate(maxFrameWidth, inputSize.width()),
+    std::min(maxFrameWidth, inputSize.width()),
     inputSize.height()),
   force);
   KDSize outputSize = m_scrollableOutputView.minimalSizeForOptimalDisplay();
   m_scrollableOutputView.setFrame(KDRect(
-    maxCoordinate(0, maxFrameWidth - outputSize.width()),
+    std::max(0, maxFrameWidth - outputSize.width()),
     inputSize.height(),
-    minCoordinate(maxFrameWidth, outputSize.width()),
+    std::min(maxFrameWidth, outputSize.width()),
     outputSize.height()),
   force);
 }

--- a/apps/code/console_controller.cpp
+++ b/apps/code/console_controller.cpp
@@ -3,6 +3,7 @@
 #include "script.h"
 #include "variable_box_controller.h"
 #include <apps/i18n.h>
+#include <algorithm>
 #include <assert.h>
 #include <escher/metric.h>
 #include <apps/global_preferences.h>
@@ -14,8 +15,6 @@ extern "C" {
 }
 
 namespace Code {
-
-static inline int minInt(int x, int y) { return x < y ? x : y; }
 
 static const char * sStandardPromptText = ">>> ";
 
@@ -487,7 +486,7 @@ void ConsoleController::autoImportScript(Script script, bool force) {
 
     /* Copy the script name without the extension ".py". The '.' is overwritten
      * by the null terminating char. */
-    int copySizeWithNullTerminatingZero = minInt(k_maxImportCommandSize - currentChar, strlen(scriptName) - strlen(ScriptStore::k_scriptExtension));
+    int copySizeWithNullTerminatingZero = std::min(k_maxImportCommandSize - currentChar, strlen(scriptName) - strlen(ScriptStore::k_scriptExtension));
     assert(copySizeWithNullTerminatingZero >= 0);
     assert(copySizeWithNullTerminatingZero <= k_maxImportCommandSize - currentChar);
     strlcpy(command+currentChar, scriptName, copySizeWithNullTerminatingZero);

--- a/apps/code/console_edit_cell.cpp
+++ b/apps/code/console_edit_cell.cpp
@@ -4,10 +4,9 @@
 #include <apps/i18n.h>
 #include <apps/global_preferences.h>
 #include <assert.h>
+#include <algorithm>
 
 namespace Code {
-
-static inline int minInt(int x, int y) { return x < y ? x : y; }
 
 ConsoleEditCell::ConsoleEditCell(Responder * parentResponder, InputEventHandlerDelegate * inputEventHandlerDelegate, TextFieldDelegate * delegate) :
   HighlightCell(),
@@ -70,7 +69,7 @@ const char * ConsoleEditCell::shiftCurrentTextAndClear() {
   char * textFieldBuffer = const_cast<char *>(m_textField.text());
   char * newTextPosition = textFieldBuffer + 1;
   assert(previousBufferSize > 0);
-  size_t copyLength = minInt(previousBufferSize - 1, strlen(textFieldBuffer));
+  size_t copyLength = std::min(previousBufferSize - 1, strlen(textFieldBuffer));
   memmove(newTextPosition, textFieldBuffer, copyLength);
   newTextPosition[copyLength] = 0;
   textFieldBuffer[0] = 0;

--- a/apps/code/console_store.cpp
+++ b/apps/code/console_store.cpp
@@ -11,7 +11,7 @@ void ConsoleStore::startNewSession() {
 
   m_history[0] = makePrevious(m_history[0]);
 
-  for (int i = 0; i < k_historySize - 1; i++) {
+  for (size_t i = 0; i < k_historySize - 1; i++) {
     if (m_history[i] == 0) {
       if (m_history[i+1] == 0) {
         return ;
@@ -24,7 +24,7 @@ void ConsoleStore::startNewSession() {
 ConsoleLine ConsoleStore::lineAtIndex(int i) const {
   assert(i >= 0 && i < numberOfLines());
   int currentLineIndex = 0;
-  for (int j=0; j<k_historySize; j++) {
+  for (size_t j=0; j<k_historySize; j++) {
     if (m_history[j] == 0) {
       currentLineIndex++;
       j++;
@@ -42,7 +42,7 @@ int ConsoleStore::numberOfLines() const {
     return 0;
   }
   int result = 0;
-  for (int i = 0; i < k_historySize - 1; i++) {
+  for (size_t i = 0; i < k_historySize - 1; i++) {
     if (m_history[i] == 0) {
       result++;
       if (m_history[i+1] == 0) {
@@ -95,7 +95,7 @@ const char * ConsoleStore::push(const char marker, const char * text) {
   if (ConsoleLine::sizeOfConsoleLine(textLength) > k_historySize - 1) {
     textLength = k_historySize - 1 - 1 - 1; // Marker, null termination and null marker.
   }
-  int i = indexOfNullMarker();
+  size_t i = indexOfNullMarker();
   // If needed, make room for the text we want to push.
   while (i + ConsoleLine::sizeOfConsoleLine(textLength) > k_historySize - 1) {
     deleteFirstLine();
@@ -112,11 +112,11 @@ ConsoleLine::Type ConsoleStore::lineTypeForMarker(char marker) const {
   return static_cast<ConsoleLine::Type>(marker-1);
 }
 
-int ConsoleStore::indexOfNullMarker() const {
+size_t ConsoleStore::indexOfNullMarker() const {
   if (m_history[0] == 0) {
     return 0;
   }
-  for (int i=0; i<k_historySize; i++) {
+  for (size_t i=0; i<k_historySize; i++) {
     if (m_history[i] == 0 && m_history[i+1] == 0) {
       return (i+1);
     }
@@ -128,13 +128,13 @@ int ConsoleStore::indexOfNullMarker() const {
 void ConsoleStore::deleteLineAtIndex(int index) {
   assert(index >=0 && index < numberOfLines());
   int currentLineIndex = 0;
-  for (int i = 0; i < k_historySize - 1; i++) {
+  for (size_t i = 0; i < k_historySize - 1; i++) {
     if (m_history[i] == 0) {
       currentLineIndex++;
       continue;
     }
     if (currentLineIndex == index) {
-      int nextLineStart = i;
+      size_t nextLineStart = i;
       while (m_history[nextLineStart] != 0 && nextLineStart < k_historySize - 2) {
         nextLineStart++;
       }
@@ -157,7 +157,7 @@ void ConsoleStore::deleteFirstLine() {
     secondLineMarkerIndex++;
   }
   secondLineMarkerIndex++;
-  for (int i=0; i<k_historySize - secondLineMarkerIndex; i++) {
+  for (size_t i=0; i<k_historySize - secondLineMarkerIndex; i++) {
     m_history[i] = m_history[secondLineMarkerIndex+i];
   }
 }
@@ -173,7 +173,7 @@ void ConsoleStore::deleteLastLine() {
   }
   int currentLineIndex = 1;
   int lastLineMarkerIndex = 0;
-  for (int i=0; i<k_historySize; i++) {
+  for (size_t i=0; i<k_historySize; i++) {
     if (m_history[i] == 0) {
       currentLineIndex++;
       if (currentLineIndex == lineCount) {

--- a/apps/code/console_store.cpp
+++ b/apps/code/console_store.cpp
@@ -1,9 +1,8 @@
 #include "console_store.h"
 #include <string.h>
+#include <algorithm>
 
 namespace Code {
-
-static inline int minInt(int x, int y) { return x < y ? x : y; }
 
 void ConsoleStore::startNewSession() {
   if (k_historySize < 1) {
@@ -103,7 +102,7 @@ const char * ConsoleStore::push(const char marker, const char * text) {
     i = indexOfNullMarker();
   }
   m_history[i] = marker;
-  strlcpy(&m_history[i+1], text, minInt(k_historySize-(i+1),textLength+1));
+  strlcpy(&m_history[i+1], text, std::min(k_historySize-(i+1),textLength+1));
   m_history[i+1+textLength+1] = 0;
   return &m_history[i+1];
 }

--- a/apps/code/console_store.h
+++ b/apps/code/console_store.h
@@ -23,7 +23,7 @@ private:
   static constexpr char CurrentSessionResultMarker = 0x02;
   static constexpr char PreviousSessionCommandMarker = 0x03;
   static constexpr char PreviousSessionResultMarker = 0x04;
-  static constexpr int k_historySize = 1024;
+  static constexpr size_t k_historySize = 1024;
   static char makePrevious(char marker) {
     if (marker == CurrentSessionCommandMarker || marker == CurrentSessionResultMarker) {
       return marker + 0x02;
@@ -32,7 +32,7 @@ private:
   }
   const char * push(const char marker, const char * text);
   ConsoleLine::Type lineTypeForMarker(char marker) const;
-  int indexOfNullMarker() const;
+  size_t indexOfNullMarker() const;
   void deleteLineAtIndex(int index);
   void deleteFirstLine();
   /* When there is no room left to store a new ConsoleLine, we have to delete

--- a/apps/code/python_text_area.cpp
+++ b/apps/code/python_text_area.cpp
@@ -9,6 +9,7 @@ extern "C" {
 #include "py/lexer.h"
 }
 #include <stdlib.h>
+#include <algorithm>
 
 namespace Code {
 
@@ -20,8 +21,6 @@ constexpr KDColor OperatorColor = KDColor::RGB24(0xd73a49);
 constexpr KDColor StringColor = KDColor::RGB24(0x032f62);
 constexpr KDColor BackgroundColor = KDColorWhite;
 constexpr KDColor HighlightColor = Palette::Select;
-
-static inline const char * minPointer(const char * x, const char * y) { return x < y ? x : y; }
 
 static inline KDColor TokenColor(mp_token_kind_t tokenKind) {
   if (tokenKind == MP_TOKEN_STRING) {
@@ -84,7 +83,7 @@ void PythonTextArea::ContentView::drawLine(KDContext * ctx, int line, const char
       line,
       fromColumn,
       lineStart,
-      minPointer(text + byteLength, lineEnd) - lineStart,
+      std::min(text + byteLength, lineEnd) - lineStart,
       StringColor,
       BackgroundColor,
       selectionStart,
@@ -107,7 +106,7 @@ void PythonTextArea::ContentView::drawLine(KDContext * ctx, int line, const char
         line,
         fromColumn,
         spacesStart,
-        minPointer(text + byteLength, firstNonSpace) - spacesStart,
+        std::min(text + byteLength, firstNonSpace) - spacesStart,
         StringColor,
         BackgroundColor,
         selectionStart,
@@ -135,7 +134,7 @@ void PythonTextArea::ContentView::drawLine(KDContext * ctx, int line, const char
             line,
             UTF8Helper::GlyphOffsetAtCodePoint(text, tokenEnd),
             tokenEnd,
-            minPointer(text + byteLength, tokenFrom) - tokenEnd,
+            std::min(text + byteLength, tokenFrom) - tokenEnd,
             StringColor,
             BackgroundColor,
             selectionStart,

--- a/apps/graph/graph/graph_controller.cpp
+++ b/apps/graph/graph/graph_controller.cpp
@@ -129,8 +129,8 @@ float GraphController::interestingXHalfRange() const {
     }
     // Compute the combined range of the functions
     assert(f->plotType() == ContinuousFunction::PlotType::Cartesian); // So that tMin tMax represents xMin xMax
-    tMin = std::min(tMin, f->tMin());
-    tMax = std::max(tMax, f->tMax());
+    tMin = std::min<double>(tMin, f->tMin());
+    tMax = std::max<double>(tMax, f->tMax());
   }
   constexpr float rangeMultiplicator = 1.6f;
   if (characteristicRange > 0.0f ) {

--- a/apps/graph/graph/graph_controller.cpp
+++ b/apps/graph/graph/graph_controller.cpp
@@ -1,15 +1,11 @@
 #include "graph_controller.h"
 #include "../app.h"
+#include <algorithm>
 
 using namespace Poincare;
 using namespace Shared;
 
 namespace Graph {
-
-static inline float minFloat(float x, float y) { return x < y ? x : y; }
-static inline float maxFloat(float x, float y) { return x > y ? x : y; }
-static inline double minDouble(double x, double y) { return x < y ? x : y; }
-static inline double maxDouble(double x, double y) { return x > y ? x : y; }
 
 GraphController::GraphController(Responder * parentResponder, ::InputEventHandlerDelegate * inputEventHandlerDelegate, Shared::InteractiveCurveViewRange * curveViewRange, CurveViewCursor * cursor, int * indexFunctionSelectedByCursor, uint32_t * modelVersion, uint32_t * previousModelsVersions, uint32_t * rangeVersion, Poincare::Preferences::AngleUnit * angleUnitVersion, ButtonRowController * header) :
   FunctionGraphController(parentResponder, inputEventHandlerDelegate, header, curveViewRange, &m_view, cursor, indexFunctionSelectedByCursor, modelVersion, previousModelsVersions, rangeVersion, angleUnitVersion),
@@ -52,10 +48,10 @@ void GraphController::interestingFunctionRange(ExpiringPointer<ContinuousFunctio
     float x = xy.x1();
     float y = xy.x2();
     if (!std::isnan(x) && !std::isinf(x) && !std::isnan(y) && !std::isinf(y)) {
-      *xm = minFloat(*xm, x);
-      *xM = maxFloat(*xM, x);
-      *ym = minFloat(*ym, y);
-      *yM = maxFloat(*yM, y);
+      *xm = std::min(*xm, x);
+      *xM = std::max(*xM, x);
+      *ym = std::min(*ym, y);
+      *yM = std::max(*yM, y);
     }
   }
 }
@@ -102,8 +98,8 @@ void GraphController::interestingRanges(float * xm, float * xM, float * ym, floa
      * y-range for even functions (y = 1/x). */
     assert(!std::isnan(f->tMin()));
     assert(!std::isnan(f->tMax()));
-    const double tMin = maxFloat(f->tMin(), resultxMin);
-    const double tMax = minFloat(f->tMax(), resultxMax);
+    const double tMin = std::max(f->tMin(), resultxMin);
+    const double tMax = std::min(f->tMax(), resultxMax);
     const double step = (tMax - tMin) / (2.0 * (m_view.bounds().width() - 1.0));
     interestingFunctionRange(f, tMin, tMax, step, &resultxMin, &resultxMax, &resultyMin, &resultyMax);
   }
@@ -129,12 +125,12 @@ float GraphController::interestingXHalfRange() const {
     ExpiringPointer<ContinuousFunction> f = store->modelForRecord(store->activeRecordAtIndex(i));
     float fRange = f->expressionReduced(context).characteristicXRange(context, Poincare::Preferences::sharedPreferences()->angleUnit());
     if (!std::isnan(fRange) && !std::isinf(fRange)) {
-      characteristicRange = maxFloat(fRange, characteristicRange);
+      characteristicRange = std::max(fRange, characteristicRange);
     }
     // Compute the combined range of the functions
     assert(f->plotType() == ContinuousFunction::PlotType::Cartesian); // So that tMin tMax represents xMin xMax
-    tMin = minDouble(tMin, f->tMin());
-    tMax = maxDouble(tMax, f->tMax());
+    tMin = std::min(tMin, f->tMin());
+    tMax = std::max(tMax, f->tMax());
   }
   constexpr float rangeMultiplicator = 1.6f;
   if (characteristicRange > 0.0f ) {
@@ -145,7 +141,7 @@ float GraphController::interestingXHalfRange() const {
   if (tMin >= -defaultXHalfRange && tMax <= defaultXHalfRange) {
     /* If the combined Range of the functions is smaller than the default range,
      * use it. */
-    float f = rangeMultiplicator * (float)maxDouble(std::fabs(tMin), std::fabs(tMax));
+    float f = rangeMultiplicator * (float)std::max(std::fabs(tMin), std::fabs(tMax));
     return (std::isnan(f) || std::isinf(f)) ? defaultXHalfRange : f;
   }
   return defaultXHalfRange;
@@ -226,7 +222,7 @@ void GraphController::jumpToLeftRightCurve(double t, int direction, int function
       if (currentXDelta <= xDelta) {
         double potentialNextTMin = f->tMin();
         double potentialNextTMax = f->tMax();
-        double potentialNextT = maxDouble(potentialNextTMin, minDouble(potentialNextTMax, t));
+        double potentialNextT = std::max(potentialNextTMin, std::min(potentialNextTMax, t));
         Coordinate2D<double> xy = f->evaluateXYAtParameter(potentialNextT, App::app()->localContext());
         if (currentXDelta < xDelta || std::abs(xy.x2() - m_cursor->y()) < std::abs(nextY - m_cursor->y())) {
           nextCurveIndex = i;

--- a/apps/graph/graph/graph_controller_helper.cpp
+++ b/apps/graph/graph/graph_controller_helper.cpp
@@ -3,14 +3,12 @@
 #include "../app.h"
 #include "../../shared/poincare_helpers.h"
 #include <poincare/preferences.h>
+#include <algorithm>
 
 using namespace Shared;
 using namespace Poincare;
 
 namespace Graph {
-
-static inline double minDouble(double x, double y) { return x < y ? x : y; }
-static inline double maxDouble(double x, double y) { return x > y ? x : y; }
 
 bool GraphControllerHelper::privateMoveCursorHorizontally(Shared::CurveViewCursor * cursor, int direction, Shared::InteractiveCurveViewRange * range, int numberOfStepsInGradUnit, Ion::Storage::Record record, bool fast) {
   ExpiringPointer<ContinuousFunction> function = App::app()->functionStore()->modelForRecord(record);
@@ -34,7 +32,7 @@ bool GraphControllerHelper::privateMoveCursorHorizontally(Shared::CurveViewCurso
     step *= 5.0;
   }
   t += dir * step;
-  t = maxDouble(tMin, minDouble(tMax, t));
+  t = std::max(tMin, std::min(tMax, t));
   Coordinate2D<double> xy = function->evaluateXYAtParameter(t, App::app()->localContext());
   cursor->moveTo(t, xy.x1(), xy.x2());
   return true;

--- a/apps/graph/list/text_field_function_title_cell.cpp
+++ b/apps/graph/list/text_field_function_title_cell.cpp
@@ -1,11 +1,9 @@
 #include "text_field_function_title_cell.h"
 #include "list_controller.h"
 #include <assert.h>
+#include <algorithm>
 
 namespace Graph {
-
-static inline float minFloat(float x, float y) { return x < y ? x : y; }
-static inline float maxFloat(float x, float y) { return x > y ? x : y; }
 
 TextFieldFunctionTitleCell::TextFieldFunctionTitleCell(ListController * listController, Orientation orientation, const KDFont * font) :
   Shared::FunctionTitleCell(orientation),
@@ -56,9 +54,9 @@ void TextFieldFunctionTitleCell::layoutSubviews(bool force) {
   KDRect frame = subviewFrame();
   m_textField.setFrame(frame, force);
   KDCoordinate maxTextFieldX = frame.width() - m_textField.minimalSizeForOptimalDisplay().width();
-  float horizontalAlignment = maxFloat(
+  float horizontalAlignment = std::max(
       0.0f,
-      minFloat(
+      std::min(
         1.0f,
         ((float)(maxTextFieldX - k_textFieldRightMargin))/((float)maxTextFieldX)));
   m_textField.setAlignment(horizontalAlignment, verticalAlignment());

--- a/apps/probability/calculation_cell.cpp
+++ b/apps/probability/calculation_cell.cpp
@@ -2,11 +2,9 @@
 #include "responder_image_cell.h"
 #include <apps/i18n.h>
 #include <assert.h>
+#include <algorithm>
 
 namespace Probability {
-
-static inline KDCoordinate minCoordinate(KDCoordinate x, KDCoordinate y) { return x < y ? x : y; }
-static inline KDCoordinate maxCoordinate(KDCoordinate x, KDCoordinate y) { return x > y ? x : y; }
 
 CalculationCell::CalculationCell(Responder * parentResponder, InputEventHandlerDelegate * inputEventHandlerDelegate, TextFieldDelegate * textFieldDelegate) :
   m_text(KDFont::LargeFont, I18n::Message::Default, 0.5f, 0.5f),
@@ -78,7 +76,7 @@ KDCoordinate CalculationCell::calculationCellWidth() const {
   KDCoordinate glyphWidth = KDFont::LargeFont->glyphSize().width();
   KDCoordinate minTextFieldWidth = 4 * glyphWidth + TextCursorView::k_width;
   KDCoordinate maxTextFieldWidth = 14 * glyphWidth + TextCursorView::k_width;
-  return minCoordinate(maxTextFieldWidth, maxCoordinate(minTextFieldWidth, calculationCellWidth));
+  return std::min(maxTextFieldWidth, std::max(minTextFieldWidth, calculationCellWidth));
 }
 
 }

--- a/apps/probability/calculation_controller.cpp
+++ b/apps/probability/calculation_controller.cpp
@@ -15,14 +15,13 @@
 #include "images/focused_calcul4_icon.h"
 #include <poincare/preferences.h>
 #include <assert.h>
+#include <algorithm>
 #include <cmath>
 
 using namespace Poincare;
 using namespace Shared;
 
 namespace Probability {
-
-static inline int minInt(int x, int y) { return x < y ? x : y; }
 
 CalculationController::ContentView::ContentView(SelectableTableView * selectableTableView, Distribution * distribution, Calculation * calculation) :
   m_titleView(KDFont::SmallFont, I18n::Message::ComputeProbability, 0.5f, 0.5f, Palette::GreyDark, Palette::WallScreen),
@@ -293,7 +292,7 @@ void CalculationController::updateTitle() {
     }
     currentChar += UTF8Decoder::CodePointToChars(' ', m_titleBuffer + currentChar, k_titleBufferSize - currentChar);
   }
-  m_titleBuffer[minInt(currentChar, k_titleBufferSize) - 1] = 0;
+  m_titleBuffer[std::min(currentChar, k_titleBufferSize) - 1] = 0;
 }
 
 }

--- a/apps/probability/distribution/chi_squared_distribution.cpp
+++ b/apps/probability/distribution/chi_squared_distribution.cpp
@@ -78,7 +78,7 @@ double ChiSquaredDistribution::cumulativeDistributiveInverseForProbability(doubl
     2.0 * *probability * std::exp(std::lgamma(ceilKOver2)) / (exp(-kOver2Minus1) * std::pow(kOver2Minus1, kOver2Minus1)) :
     30.0; // Ad hoc value
   xmax = std::isnan(xmax) ? 1000000000.0 : xmax;
-  return cumulativeDistributiveInverseForProbabilityUsingIncreasingFunctionRoot(probability, FLT_EPSILON, std::max(xMax(), xmax));
+  return cumulativeDistributiveInverseForProbabilityUsingIncreasingFunctionRoot(probability, FLT_EPSILON, std::max<double>(xMax(), xmax));
 }
 
 }

--- a/apps/probability/distribution/chi_squared_distribution.cpp
+++ b/apps/probability/distribution/chi_squared_distribution.cpp
@@ -1,10 +1,9 @@
 #include "chi_squared_distribution.h"
 #include "regularized_gamma.h"
 #include <cmath>
+#include <algorithm>
 
 namespace Probability {
-
-static inline double maxDouble(double x, double y) { return x > y ? x : y; }
 
 float ChiSquaredDistribution::xMin() const {
   return -k_displayLeftMarginRatio * xMax();
@@ -79,7 +78,7 @@ double ChiSquaredDistribution::cumulativeDistributiveInverseForProbability(doubl
     2.0 * *probability * std::exp(std::lgamma(ceilKOver2)) / (exp(-kOver2Minus1) * std::pow(kOver2Minus1, kOver2Minus1)) :
     30.0; // Ad hoc value
   xmax = std::isnan(xmax) ? 1000000000.0 : xmax;
-  return cumulativeDistributiveInverseForProbabilityUsingIncreasingFunctionRoot(probability, FLT_EPSILON, maxDouble(xMax(), xmax));
+  return cumulativeDistributiveInverseForProbabilityUsingIncreasingFunctionRoot(probability, FLT_EPSILON, std::max(xMax(), xmax));
 }
 
 }

--- a/apps/probability/distribution/fisher_distribution.cpp
+++ b/apps/probability/distribution/fisher_distribution.cpp
@@ -3,10 +3,9 @@
 #include <poincare/regularized_incomplete_beta_function.h>
 #include <cmath>
 #include <float.h>
+#include <algorithm>
 
 namespace Probability {
-
-static inline double maxDouble(double x, double y) { return x > y ? x : y; }
 
 float FisherDistribution::xMin() const {
   return -k_displayLeftMarginRatio * xMax();
@@ -74,7 +73,7 @@ double FisherDistribution::cumulativeDistributiveInverseForProbability(double * 
   if (*probability < DBL_EPSILON) {
     return 0.0;
   }
-  return cumulativeDistributiveInverseForProbabilityUsingIncreasingFunctionRoot(probability, DBL_EPSILON, maxDouble(xMax(), 100.0));  // Ad-hoc value;
+  return cumulativeDistributiveInverseForProbabilityUsingIncreasingFunctionRoot(probability, DBL_EPSILON, std::max(xMax(), 100.0));  // Ad-hoc value;
 }
 
 float FisherDistribution::mode() const {

--- a/apps/probability/distribution/fisher_distribution.cpp
+++ b/apps/probability/distribution/fisher_distribution.cpp
@@ -73,7 +73,7 @@ double FisherDistribution::cumulativeDistributiveInverseForProbability(double * 
   if (*probability < DBL_EPSILON) {
     return 0.0;
   }
-  return cumulativeDistributiveInverseForProbabilityUsingIncreasingFunctionRoot(probability, DBL_EPSILON, std::max(xMax(), 100.0));  // Ad-hoc value;
+  return cumulativeDistributiveInverseForProbabilityUsingIncreasingFunctionRoot(probability, DBL_EPSILON, std::max<double>(xMax(), 100.0));  // Ad-hoc value;
 }
 
 float FisherDistribution::mode() const {

--- a/apps/regression/calculation_controller.cpp
+++ b/apps/regression/calculation_controller.cpp
@@ -4,15 +4,13 @@
 #include <poincare/code_point_layout.h>
 #include <poincare/vertical_offset_layout.h>
 #include <poincare/preferences.h>
-
+#include <algorithm>
 #include <assert.h>
 
 using namespace Poincare;
 using namespace Shared;
 
 namespace Regression {
-
-static inline int maxInt(int x, int y) { return x > y ? x : y; }
 
 CalculationController::CalculationController(Responder * parentResponder, ButtonRowController * header, Store * store) :
   TabTableController(parentResponder),
@@ -375,7 +373,7 @@ int CalculationController::maxNumberOfCoefficients() const {
   int numberOfDefinedSeries = m_store->numberOfNonEmptySeries();
   for (int i = 0; i < numberOfDefinedSeries; i++) {
     int currentNumberOfCoefs = m_store->modelForSeries(m_store->indexOfKthNonEmptySeries(i))->numberOfCoefficients();
-    maxNumberCoefficients = maxInt(maxNumberCoefficients, currentNumberOfCoefs);
+    maxNumberCoefficients = std::max(maxNumberCoefficients, currentNumberOfCoefs);
   }
   return maxNumberCoefficients;
 }

--- a/apps/regression/graph_controller.cpp
+++ b/apps/regression/graph_controller.cpp
@@ -4,13 +4,10 @@
 #include "../apps_container.h"
 #include <poincare/preferences.h>
 #include <cmath>
+#include <algorithm>
 
 using namespace Poincare;
 using namespace Shared;
-
-static inline float minFloat(float x, float y) { return x < y ? x : y; }
-static inline float maxFloat(float x, float y) { return x > y ? x : y; }
-static inline int maxInt(int x, int y) { return x > y ? x : y; }
 
 namespace Regression {
 
@@ -165,7 +162,7 @@ void GraphController::reloadBannerView() {
   }
   if (!coefficientsAreDefined) {
     // Force the "Data not suitable" message to be on the next line
-    int numberOfCharToCompleteLine = maxInt(Ion::Display::Width / BannerView::Font()->glyphSize().width() - strlen(I18n::translate(formula)), 0);
+    int numberOfCharToCompleteLine = std::max(Ion::Display::Width / BannerView::Font()->glyphSize().width() - strlen(I18n::translate(formula)), 0);
     numberOfChar = 0;
     // Padding
     Shared::TextHelpers::PadWithSpaces(buffer, bufferSize, &numberOfChar, numberOfCharToCompleteLine - 1);
@@ -390,8 +387,8 @@ InteractiveCurveViewRangeDelegate::Range GraphController::computeYRange(Interact
   for (int series = 0; series < Store::k_numberOfSeries; series++) {
     for (int k = 0; k < m_store->numberOfPairsOfSeries(series); k++) {
       if (m_store->xMin() <= m_store->get(series, 0, k) && m_store->get(series, 0, k) <= m_store->xMax()) {
-        minY = minFloat(minY, m_store->get(series, 1, k));
-        maxY = maxFloat(maxY, m_store->get(series, 1, k));
+        minY = std::min(minY, m_store->get(series, 1, k));
+        maxY = std::max(maxY, m_store->get(series, 1, k));
       }
     }
   }

--- a/apps/regression/graph_controller.cpp
+++ b/apps/regression/graph_controller.cpp
@@ -162,7 +162,7 @@ void GraphController::reloadBannerView() {
   }
   if (!coefficientsAreDefined) {
     // Force the "Data not suitable" message to be on the next line
-    int numberOfCharToCompleteLine = std::max(Ion::Display::Width / BannerView::Font()->glyphSize().width() - strlen(I18n::translate(formula)), 0);
+    int numberOfCharToCompleteLine = std::max<int>(Ion::Display::Width / BannerView::Font()->glyphSize().width() - strlen(I18n::translate(formula)), 0);
     numberOfChar = 0;
     // Padding
     Shared::TextHelpers::PadWithSpaces(buffer, bufferSize, &numberOfChar, numberOfCharToCompleteLine - 1);
@@ -387,8 +387,8 @@ InteractiveCurveViewRangeDelegate::Range GraphController::computeYRange(Interact
   for (int series = 0; series < Store::k_numberOfSeries; series++) {
     for (int k = 0; k < m_store->numberOfPairsOfSeries(series); k++) {
       if (m_store->xMin() <= m_store->get(series, 0, k) && m_store->get(series, 0, k) <= m_store->xMax()) {
-        minY = std::min(minY, m_store->get(series, 1, k));
-        maxY = std::max(maxY, m_store->get(series, 1, k));
+        minY = std::min<float>(minY, m_store->get(series, 1, k));
+        maxY = std::max<float>(maxY, m_store->get(series, 1, k));
       }
     }
   }

--- a/apps/regression/store.cpp
+++ b/apps/regression/store.cpp
@@ -197,7 +197,7 @@ void Store::resetMemoization() {
 float Store::maxValueOfColumn(int series, int i) const {
   float maxColumn = -FLT_MAX;
   for (int k = 0; k < numberOfPairsOfSeries(series); k++) {
-    maxColumn = std::max(maxColumn, m_data[series][i][k]);
+    maxColumn = std::max<float>(maxColumn, m_data[series][i][k]);
   }
   return maxColumn;
 }
@@ -205,7 +205,7 @@ float Store::maxValueOfColumn(int series, int i) const {
 float Store::minValueOfColumn(int series, int i) const {
   float minColumn = FLT_MAX;
   for (int k = 0; k < numberOfPairsOfSeries(series); k++) {
-    minColumn = std::min(minColumn, m_data[series][i][k]);
+    minColumn = std::min<float>(minColumn, m_data[series][i][k]);
   }
   return minColumn;
 }

--- a/apps/regression/store.cpp
+++ b/apps/regression/store.cpp
@@ -5,13 +5,11 @@
 #include <float.h>
 #include <cmath>
 #include <string.h>
+#include <algorithm>
 
 using namespace Shared;
 
 namespace Regression {
-
-static inline float maxFloat(float x, float y) { return x > y ? x : y; }
-static inline float minFloat(float x, float y) { return x < y ? x : y; }
 
 static_assert(Model::k_numberOfModels == 9, "Number of models changed, Regression::Store() needs to adapt");
 static_assert(Store::k_numberOfSeries == 3, "Number of series changed, Regression::Store() needs to adapt (m_seriesChecksum)");
@@ -146,8 +144,8 @@ void Store::setDefault() {
   float maxX = -FLT_MAX;
   for (int series = 0; series < k_numberOfSeries; series++) {
     if (!seriesIsEmpty(series)) {
-      minX = minFloat(minX, minValueOfColumn(series, 0));
-      maxX = maxFloat(maxX, maxValueOfColumn(series, 0));
+      minX = std::min(minX, minValueOfColumn(series, 0));
+      maxX = std::max(maxX, maxValueOfColumn(series, 0));
     }
   }
   float range = maxX - minX;
@@ -199,7 +197,7 @@ void Store::resetMemoization() {
 float Store::maxValueOfColumn(int series, int i) const {
   float maxColumn = -FLT_MAX;
   for (int k = 0; k < numberOfPairsOfSeries(series); k++) {
-    maxColumn = maxFloat(maxColumn, m_data[series][i][k]);
+    maxColumn = std::max(maxColumn, m_data[series][i][k]);
   }
   return maxColumn;
 }
@@ -207,7 +205,7 @@ float Store::maxValueOfColumn(int series, int i) const {
 float Store::minValueOfColumn(int series, int i) const {
   float minColumn = FLT_MAX;
   for (int k = 0; k < numberOfPairsOfSeries(series); k++) {
-    minColumn = minFloat(minColumn, m_data[series][i][k]);
+    minColumn = std::min(minColumn, m_data[series][i][k]);
   }
   return minColumn;
 }

--- a/apps/sequence/graph/curve_view_range.cpp
+++ b/apps/sequence/graph/curve_view_range.cpp
@@ -2,13 +2,12 @@
 #include <cmath>
 #include <ion.h>
 #include <poincare/preferences.h>
+#include <algorithm>
 
 using namespace Shared;
 using namespace Poincare;
 
 namespace Sequence {
-
-static inline float maxFloat(float x, float y) { return x > y ? x : y; }
 
 CurveViewRange::CurveViewRange(InteractiveCurveViewRangeDelegate * delegate) :
   InteractiveCurveViewRange(delegate)
@@ -37,7 +36,7 @@ void CurveViewRange::normalize() {
   float xMean = xCenter();
   float yMean = yCenter();
 
-  const float unit = maxFloat(xGridUnit(), yGridUnit());
+  const float unit = std::max(xGridUnit(), yGridUnit());
 
   // Compute the X
   const float newXHalfRange = NormalizedXHalfRange(unit);

--- a/apps/sequence/graph/graph_controller.cpp
+++ b/apps/sequence/graph/graph_controller.cpp
@@ -52,7 +52,7 @@ float GraphController::interestingXHalfRange() const {
     Sequence * s = functionStore()->modelForRecord(functionStore()->activeRecordAtIndex(i));
     int firstInterestingIndex = s->initialRank();
     nmin = std::min(nmin, firstInterestingIndex);
-    nmax = std::max(nmax, firstInterestingIndex + standardRange);
+    nmax = std::max(nmax, firstInterestingIndex + static_cast<int>(standardRange));
   }
   assert(nmax - nmin >= standardRange);
   return nmax - nmin;

--- a/apps/sequence/graph/graph_controller.cpp
+++ b/apps/sequence/graph/graph_controller.cpp
@@ -2,14 +2,12 @@
 #include <cmath>
 #include <limits.h>
 #include "../app.h"
+#include <algorithm>
 
 using namespace Shared;
 using namespace Poincare;
 
 namespace Sequence {
-
-static inline int minInt(int x, int y) { return (x < y ? x : y); }
-static inline int maxInt(int x, int y) { return (x > y ? x : y); }
 
 GraphController::GraphController(Responder * parentResponder, ::InputEventHandlerDelegate * inputEventHandlerDelegate, SequenceStore * sequenceStore, CurveViewRange * graphRange, CurveViewCursor * cursor, int * indexFunctionSelectedByCursor, uint32_t * modelVersion, uint32_t * previousModelsVersions, uint32_t * rangeVersion, Preferences::AngleUnit * angleUnitVersion, ButtonRowController * header) :
   FunctionGraphController(parentResponder, inputEventHandlerDelegate, header, graphRange, &m_view, cursor, indexFunctionSelectedByCursor, modelVersion, previousModelsVersions, rangeVersion, angleUnitVersion),
@@ -39,7 +37,7 @@ float GraphController::interestingXMin() const {
   int nbOfActiveModels = functionStore()->numberOfActiveFunctions();
   for (int i = 0; i < nbOfActiveModels; i++) {
     Sequence * s = functionStore()->modelForRecord(functionStore()->activeRecordAtIndex(i));
-    nmin = minInt(nmin, s->initialRank());
+    nmin = std::min(nmin, s->initialRank());
   }
   assert(nmin < INT_MAX);
   return nmin;
@@ -53,8 +51,8 @@ float GraphController::interestingXHalfRange() const {
   for (int i = 0; i < nbOfActiveModels; i++) {
     Sequence * s = functionStore()->modelForRecord(functionStore()->activeRecordAtIndex(i));
     int firstInterestingIndex = s->initialRank();
-    nmin = minInt(nmin, firstInterestingIndex);
-    nmax = maxInt(nmax, firstInterestingIndex + standardRange);
+    nmin = std::min(nmin, firstInterestingIndex);
+    nmax = std::max(nmax, firstInterestingIndex + standardRange);
   }
   assert(nmax - nmin >= standardRange);
   return nmax - nmin;

--- a/apps/sequence/list/list_controller.cpp
+++ b/apps/sequence/list/list_controller.cpp
@@ -1,11 +1,10 @@
 #include "list_controller.h"
 #include "../app.h"
 #include <assert.h>
+#include <algorithm>
 
 using namespace Shared;
 using namespace Poincare;
-
-static inline KDCoordinate maxCoordinate(KDCoordinate x, KDCoordinate y) { return x > y ? x : y; }
 
 namespace Sequence {
 
@@ -55,7 +54,7 @@ KDCoordinate ListController::expressionRowHeight(int j) {
     return defaultHeight;
   }
   KDCoordinate sequenceHeight = layout.layoutSize().height();
-  return maxCoordinate(defaultHeight, sequenceHeight + 2*k_expressionCellVerticalMargin);
+  return std::max(defaultHeight, sequenceHeight + 2*k_expressionCellVerticalMargin);
 }
 
 void ListController::willDisplayCellAtLocation(HighlightCell * cell, int i, int j) {

--- a/apps/sequence/list/list_controller.cpp
+++ b/apps/sequence/list/list_controller.cpp
@@ -54,7 +54,7 @@ KDCoordinate ListController::expressionRowHeight(int j) {
     return defaultHeight;
   }
   KDCoordinate sequenceHeight = layout.layoutSize().height();
-  return std::max(defaultHeight, sequenceHeight + 2*k_expressionCellVerticalMargin);
+  return std::max<KDCoordinate>(defaultHeight, sequenceHeight + 2*k_expressionCellVerticalMargin);
 }
 
 void ListController::willDisplayCellAtLocation(HighlightCell * cell, int i, int j) {

--- a/apps/settings/sub_menu/preferences_controller.cpp
+++ b/apps/settings/sub_menu/preferences_controller.cpp
@@ -7,12 +7,11 @@
 #include <poincare/code_point_layout.h>
 #include <poincare/fraction_layout.h>
 #include <poincare/vertical_offset_layout.h>
+#include <algorithm>
 
 using namespace Poincare;
 
 namespace Settings {
-
-static inline int maxInt(int x, int y) { return x > y ? x : y; }
 
 PreferencesController::PreferencesController(Responder * parentResponder) :
   GenericSubController(parentResponder)
@@ -145,7 +144,7 @@ void PreferencesController::setPreferenceWithValueIndex(I18n::Message message, i
       /* In Engineering mode, the number of significant digits cannot be lower
        * than 3, because we need to be able to display 100 for instance. */
       // TODO: Add warning about signifiant digits change ?
-      preferences->setNumberOfSignificantDigits(maxInt(preferences->numberOfSignificantDigits(), 3));
+      preferences->setNumberOfSignificantDigits(std::max(preferences->numberOfSignificantDigits(), 3));
     }
   } else if (message == I18n::Message::EditionMode) {
     preferences->setEditionMode((Preferences::EditionMode)valueIndex);

--- a/apps/settings/sub_menu/preferences_controller.cpp
+++ b/apps/settings/sub_menu/preferences_controller.cpp
@@ -144,7 +144,7 @@ void PreferencesController::setPreferenceWithValueIndex(I18n::Message message, i
       /* In Engineering mode, the number of significant digits cannot be lower
        * than 3, because we need to be able to display 100 for instance. */
       // TODO: Add warning about signifiant digits change ?
-      preferences->setNumberOfSignificantDigits(std::max(preferences->numberOfSignificantDigits(), 3));
+      preferences->setNumberOfSignificantDigits(std::max<int>(preferences->numberOfSignificantDigits(), 3));
     }
   } else if (message == I18n::Message::EditionMode) {
     preferences->setEditionMode((Preferences::EditionMode)valueIndex);

--- a/apps/settings/sub_menu/selectable_view_with_messages.cpp
+++ b/apps/settings/sub_menu/selectable_view_with_messages.cpp
@@ -51,7 +51,7 @@ void SelectableViewWithMessages::layoutSubviews(bool force) {
 
   // Layout the text
   KDCoordinate textHeight = KDFont::SmallFont->glyphSize().height();
-  KDCoordinate defOrigin = std::max(bounds().height() - Metric::CommonBottomMargin - m_numberOfMessages*textHeight, tableHeight);
+  KDCoordinate defOrigin = std::max<KDCoordinate>(bounds().height() - Metric::CommonBottomMargin - m_numberOfMessages*textHeight, tableHeight);
 
   for (int i = 0; i < m_numberOfMessages; i++) {
     m_messageLines[i].setFrame(KDRect(0, defOrigin, bounds().width(), textHeight), force);

--- a/apps/settings/sub_menu/selectable_view_with_messages.cpp
+++ b/apps/settings/sub_menu/selectable_view_with_messages.cpp
@@ -1,12 +1,11 @@
 #include "selectable_view_with_messages.h"
 #include <apps/i18n.h>
 #include <assert.h>
+#include <algorithm>
 
 using namespace Shared;
 
 namespace Settings {
-
-static inline KDCoordinate maxCoordinate(KDCoordinate x, KDCoordinate y) { return x > y ? x : y; }
 
 SelectableViewWithMessages::SelectableViewWithMessages(SelectableTableView * selectableTableView) :
   m_selectableTableView(selectableTableView),
@@ -52,7 +51,7 @@ void SelectableViewWithMessages::layoutSubviews(bool force) {
 
   // Layout the text
   KDCoordinate textHeight = KDFont::SmallFont->glyphSize().height();
-  KDCoordinate defOrigin = maxCoordinate(bounds().height() - Metric::CommonBottomMargin - m_numberOfMessages*textHeight, tableHeight);
+  KDCoordinate defOrigin = std::max(bounds().height() - Metric::CommonBottomMargin - m_numberOfMessages*textHeight, tableHeight);
 
   for (int i = 0; i < m_numberOfMessages; i++) {
     m_messageLines[i].setFrame(KDRect(0, defOrigin, bounds().width(), textHeight), force);

--- a/apps/shared/continuous_function.cpp
+++ b/apps/shared/continuous_function.cpp
@@ -14,13 +14,11 @@
 #include <apps/i18n.h>
 #include <float.h>
 #include <cmath>
+#include <algorithm>
 
 using namespace Poincare;
 
 namespace Shared {
-
-static inline double maxDouble(double x, double y) { return x > y ? x : y; }
-static inline double minDouble(double x, double y) { return x < y ? x : y; }
 
 void ContinuousFunction::DefaultName(char buffer[], size_t bufferSize) {
   constexpr int k_maxNumberOfDefaultLetterNames = 4;
@@ -312,14 +310,14 @@ Coordinate2D<double> ContinuousFunction::nextIntersectionFrom(double start, doub
   constexpr int bufferSize = CodePoint::MaxCodePointCharLength + 1;
   char unknownX[bufferSize];
   SerializationHelper::CodePoint(unknownX, bufferSize, UCodePointUnknown);
-  double domainMin = maxDouble(tMin(), eDomainMin);
-  double domainMax = minDouble(tMax(), eDomainMax);
+  double domainMin = std::max(tMin(), eDomainMin);
+  double domainMax = std::min(tMax(), eDomainMax);
   if (step > 0.0f) {
-    start = maxDouble(start, domainMin);
-    max = minDouble(max, domainMax);
+    start = std::max(start, domainMin);
+    max = std::min(max, domainMax);
   } else {
-    start = minDouble(start, domainMax);
-    max = maxDouble(max, domainMin);
+    start = std::min(start, domainMax);
+    max = std::max(max, domainMin);
   }
   return PoincareHelpers::NextIntersection(expressionReduced(context), unknownX, start, step, max, context, e);
 }
@@ -330,19 +328,19 @@ Coordinate2D<double> ContinuousFunction::nextPointOfInterestFrom(double start, d
   char unknownX[bufferSize];
   SerializationHelper::CodePoint(unknownX, bufferSize, UCodePointUnknown);
   if (step > 0.0f) {
-    start = maxDouble(start, tMin());
-    max = minDouble(max, tMax());
+    start = std::max(start, tMin());
+    max = std::min(max, tMax());
   } else {
-    start = minDouble(start, tMax());
-    max = maxDouble(max, tMin());
+    start = std::min(start, tMax());
+    max = std::max(max, tMin());
   }
   return compute(expressionReduced(context), unknownX, start, step, max, context);
 }
 
 Poincare::Expression ContinuousFunction::sumBetweenBounds(double start, double end, Poincare::Context * context) const {
   assert(plotType() == PlotType::Cartesian);
-  start = maxDouble(start, tMin());
-  end = minDouble(end, tMax());
+  start = std::max(start, tMin());
+  end = std::min(end, tMax());
   return Poincare::Integral::Builder(expressionReduced(context).clone(), Poincare::Symbol::Builder(UCodePointUnknown), Poincare::Float<double>::Builder(start), Poincare::Float<double>::Builder(end)); // Integral takes ownership of args
   /* TODO: when we approximate integral, we might want to simplify the integral
    * here. However, we might want to do it once for all x (to avoid lagging in

--- a/apps/shared/continuous_function.cpp
+++ b/apps/shared/continuous_function.cpp
@@ -310,8 +310,8 @@ Coordinate2D<double> ContinuousFunction::nextIntersectionFrom(double start, doub
   constexpr int bufferSize = CodePoint::MaxCodePointCharLength + 1;
   char unknownX[bufferSize];
   SerializationHelper::CodePoint(unknownX, bufferSize, UCodePointUnknown);
-  double domainMin = std::max(tMin(), eDomainMin);
-  double domainMax = std::min(tMax(), eDomainMax);
+  double domainMin = std::max<double>(tMin(), eDomainMin);
+  double domainMax = std::min<double>(tMax(), eDomainMax);
   if (step > 0.0f) {
     start = std::max(start, domainMin);
     max = std::min(max, domainMax);
@@ -328,19 +328,19 @@ Coordinate2D<double> ContinuousFunction::nextPointOfInterestFrom(double start, d
   char unknownX[bufferSize];
   SerializationHelper::CodePoint(unknownX, bufferSize, UCodePointUnknown);
   if (step > 0.0f) {
-    start = std::max(start, tMin());
-    max = std::min(max, tMax());
+    start = std::max<double>(start, tMin());
+    max = std::min<double>(max, tMax());
   } else {
-    start = std::min(start, tMax());
-    max = std::max(max, tMin());
+    start = std::min<double>(start, tMax());
+    max = std::max<double>(max, tMin());
   }
   return compute(expressionReduced(context), unknownX, start, step, max, context);
 }
 
 Poincare::Expression ContinuousFunction::sumBetweenBounds(double start, double end, Poincare::Context * context) const {
   assert(plotType() == PlotType::Cartesian);
-  start = std::max(start, tMin());
-  end = std::min(end, tMax());
+  start = std::max<double>(start, tMin());
+  end = std::min<double>(end, tMax());
   return Poincare::Integral::Builder(expressionReduced(context).clone(), Poincare::Symbol::Builder(UCodePointUnknown), Poincare::Float<double>::Builder(start), Poincare::Float<double>::Builder(end)); // Integral takes ownership of args
   /* TODO: when we approximate integral, we might want to simplify the integral
    * here. However, we might want to do it once for all x (to avoid lagging in

--- a/apps/shared/curve_view.cpp
+++ b/apps/shared/curve_view.cpp
@@ -179,7 +179,7 @@ void CurveView::computeLabels(Axis axis) {
     int labelMaxGlyphLength = labelMaxGlyphLengthSize();
     if (axis == Axis::Horizontal) {
       float pixelsPerLabel = std::max(0.0f, ((float)Ion::Display::Width)/((float)axisLabelsCount) - k_labelMargin);
-      labelMaxGlyphLength = std::min(labelMaxGlyphLengthSize(), pixelsPerLabel/k_font->glyphSize().width());
+      labelMaxGlyphLength = std::min<int>(labelMaxGlyphLengthSize(), pixelsPerLabel/k_font->glyphSize().width());
     }
 
     if (labelValue < step && labelValue > -step) {

--- a/apps/shared/curve_view.cpp
+++ b/apps/shared/curve_view.cpp
@@ -4,17 +4,13 @@
 #include <poincare/print_float.h>
 #include <assert.h>
 #include <string.h>
+#include <algorithm>
 #include <cmath>
 #include <float.h>
 
 using namespace Poincare;
 
 namespace Shared {
-
-static inline int minInt(int x, int y) { return x < y ? x : y; }
-
-static inline float minFloat(float x, float y) { return x < y ? x : y; }
-static inline float maxFloat(float x, float y) { return x > y ? x : y; }
 
 CurveView::CurveView(CurveViewRange * curveViewRange, CurveViewCursor * curveViewCursor, BannerView * bannerView,
     CursorView * cursorView, View * okView, bool displayBanner) :
@@ -182,8 +178,8 @@ void CurveView::computeLabels(Axis axis) {
      * them from overprinting one another.*/
     int labelMaxGlyphLength = labelMaxGlyphLengthSize();
     if (axis == Axis::Horizontal) {
-      float pixelsPerLabel = maxFloat(0.0f, ((float)Ion::Display::Width)/((float)axisLabelsCount) - k_labelMargin);
-      labelMaxGlyphLength = minInt(labelMaxGlyphLengthSize(), pixelsPerLabel/k_font->glyphSize().width());
+      float pixelsPerLabel = std::max(0.0f, ((float)Ion::Display::Width)/((float)axisLabelsCount) - k_labelMargin);
+      labelMaxGlyphLength = std::min(labelMaxGlyphLengthSize(), pixelsPerLabel/k_font->glyphSize().width());
     }
 
     if (labelValue < step && labelValue > -step) {
@@ -590,7 +586,7 @@ void CurveView::drawCurve(KDContext * ctx, KDRect rect, float tStart, float tEnd
     x = xy.x1();
     y = xy.x2();
     if (colorUnderCurve && !std::isnan(x) && colorLowerBound < x && x < colorUpperBound && !(std::isnan(y) || std::isinf(y))) {
-      drawHorizontalOrVerticalSegment(ctx, rect, Axis::Vertical, x, minFloat(0.0f, y), maxFloat(0.0f, y), color, 1);
+      drawHorizontalOrVerticalSegment(ctx, rect, Axis::Vertical, x, std::min(0.0f, y), std::max(0.0f, y), color, 1);
     }
     joinDots(ctx, rect, xyEvaluation, model, context, drawStraightLinesEarly, previousT, previousX, previousY, t, x, y, color, thick, k_maxNumberOfIterations);
   } while (true);
@@ -599,8 +595,8 @@ void CurveView::drawCurve(KDContext * ctx, KDRect rect, float tStart, float tEnd
 void CurveView::drawCartesianCurve(KDContext * ctx, KDRect rect, float xMin, float xMax, EvaluateXYForParameter xyEvaluation, void * model, void * context, KDColor color, bool thick, bool colorUnderCurve, float colorLowerBound, float colorUpperBound) const {
   float rectLeft = pixelToFloat(Axis::Horizontal, rect.left() - k_externRectMargin);
   float rectRight = pixelToFloat(Axis::Horizontal, rect.right() + k_externRectMargin);
-  float tStart = std::isnan(rectLeft) ? xMin : maxFloat(xMin, rectLeft);
-  float tEnd = std::isnan(rectRight) ? xMax : minFloat(xMax, rectRight);
+  float tStart = std::isnan(rectLeft) ? xMin : std::max(xMin, rectLeft);
+  float tEnd = std::isnan(rectRight) ? xMax : std::min(xMax, rectRight);
   assert(!std::isnan(tStart) && !std::isnan(tEnd));
   if (std::isinf(tStart) || std::isinf(tEnd) || tStart > tEnd) {
     return;
@@ -701,8 +697,8 @@ static void clipBarycentricCoordinatesBetweenBounds(float & start, float & end, 
       end = 0;
     }
   } else {
-    start = maxFloat(start, (bounds[(p1f > p2f) ? lower : upper] - p2f)/(p1f-p2f));
-    end   = minFloat( end , (bounds[(p1f > p2f) ? upper : lower] - p2f)/(p1f-p2f));
+    start = std::max(start, (bounds[(p1f > p2f) ? lower : upper] - p2f)/(p1f-p2f));
+    end   = std::min( end , (bounds[(p1f > p2f) ? upper : lower] - p2f)/(p1f-p2f));
   }
 }
 

--- a/apps/shared/editable_cell_table_view_controller.cpp
+++ b/apps/shared/editable_cell_table_view_controller.cpp
@@ -3,10 +3,9 @@
 #include "../constant.h"
 #include <assert.h>
 #include <cmath>
+#include <algorithm>
 
 using namespace Poincare;
-
-static inline int maxInt(int x, int y) { return x > y ? x : y; }
 
 namespace Shared {
 
@@ -60,7 +59,7 @@ bool EditableCellTableViewController::textFieldDidFinishEditing(TextField * text
 int EditableCellTableViewController::numberOfRows() const {
   int numberOfModelElements = 0;
   for (int i = 0; i < numberOfColumns(); i++) {
-    numberOfModelElements = maxInt(numberOfModelElements, numberOfElementsInColumn(i));
+    numberOfModelElements = std::max(numberOfModelElements, numberOfElementsInColumn(i));
   }
   return 1 + numberOfModelElements + (numberOfModelElements < maxNumberOfElements());
 }

--- a/apps/shared/expression_model.cpp
+++ b/apps/shared/expression_model.cpp
@@ -7,13 +7,12 @@
 #include <string.h>
 #include <cmath>
 #include <assert.h>
+#include <algorithm>
 
 using namespace Ion;
 using namespace Poincare;
 
 namespace Shared {
-
-static inline int maxInt(int x, int y) { return x > y ? x : y; }
 
 ExpressionModel::ExpressionModel() :
   m_expression(),
@@ -126,7 +125,7 @@ Ion::Storage::Record::ErrorStatus ExpressionModel::setExpressionContent(Ion::Sto
   size_t newDataSize = previousDataSize - previousExpressionSize + newExpressionSize;
   void * expAddress = expressionAddress(record);
   // Update size of record to maximal size between previous and new data
-  newData.size = maxInt(previousDataSize, newDataSize);
+  newData.size = std::max(previousDataSize, newDataSize);
   Ion::Storage::Record::ErrorStatus error = record->setValue(newData);
   if (error != Ion::Storage::Record::ErrorStatus::None) {
     assert(error == Ion::Storage::Record::ErrorStatus::NotEnoughSpaceAvailable);

--- a/apps/shared/expression_model_list_controller.cpp
+++ b/apps/shared/expression_model_list_controller.cpp
@@ -1,10 +1,9 @@
 #include "expression_model_list_controller.h"
 #include <apps/constant.h>
 #include <poincare/symbol.h>
+#include <algorithm>
 
 namespace Shared {
-
-static inline int minInt(int x, int y) { return x < y ? x : y; }
 
 /* Table Data Source */
 
@@ -121,7 +120,7 @@ int ExpressionModelListController::memoizedIndexFromCumulatedHeight(KDCoordinate
 
   KDCoordinate currentCumulatedHeight = memoizedCumulatedHeightFromIndex(currentSelectedRow);
   if (offsetY > currentCumulatedHeight) {
-    int iMax = minInt(k_memoizedCellsCount/2 + 1, rowsCount - currentSelectedRow);
+    int iMax = std::min(k_memoizedCellsCount/2 + 1, rowsCount - currentSelectedRow);
     for (int i = 0; i < iMax; i++) {
       currentCumulatedHeight+= memoizedRowHeight(currentSelectedRow + i);
       if (offsetY <= currentCumulatedHeight) {
@@ -129,7 +128,7 @@ int ExpressionModelListController::memoizedIndexFromCumulatedHeight(KDCoordinate
       }
     }
   } else {
-    int iMax = minInt(k_memoizedCellsCount/2, currentSelectedRow);
+    int iMax = std::min(k_memoizedCellsCount/2, currentSelectedRow);
     for (int i = 1; i <= iMax; i++) {
       currentCumulatedHeight-= memoizedRowHeight(currentSelectedRow-i);
       if (offsetY > currentCumulatedHeight) {

--- a/apps/shared/function_graph_controller.cpp
+++ b/apps/shared/function_graph_controller.cpp
@@ -5,15 +5,11 @@
 #include <assert.h>
 #include <cmath>
 #include <float.h>
+#include <algorithm>
 
 using namespace Poincare;
 
 namespace Shared {
-
-static inline float minFloat(float x, float y) { return x < y ? x : y; }
-static inline float maxFloat(float x, float y) { return x > y ? x : y; }
-static inline double minDouble(double x, double y) { return x < y ? x : y; }
-static inline double maxDouble(double x, double y) { return x > y ? x : y; }
 
 FunctionGraphController::FunctionGraphController(Responder * parentResponder, InputEventHandlerDelegate * inputEventHandlerDelegate, ButtonRowController * header, InteractiveCurveViewRange * interactiveRange, CurveView * curveView, CurveViewCursor * cursor, int * indexFunctionSelectedByCursor, uint32_t * modelVersion, uint32_t * previousModelsVersions, uint32_t * rangeVersion, Preferences::AngleUnit * angleUnitVersion) :
   InteractiveCurveViewController(parentResponder, inputEventHandlerDelegate, header, interactiveRange, curveView, cursor, modelVersion, previousModelsVersions, rangeVersion),
@@ -92,13 +88,13 @@ InteractiveCurveViewRangeDelegate::Range FunctionGraphController::computeYRange(
     if (std::isnan(tMin)) {
       tMin = xMin;
     } else if (f->shouldClipTRangeToXRange()) {
-      tMin = maxFloat(tMin, xMin);
+      tMin = std::max(tMin, xMin);
     }
     double tMax = f->tMax();
     if (std::isnan(tMax)) {
       tMax = xMax;
     } else if (f->shouldClipTRangeToXRange()) {
-      tMax = minFloat(tMax, xMax);
+      tMax = std::min(tMax, xMax);
     }
   /* In practice, a step smaller than a pixel's width is needed for sampling
    * the values of a function. Otherwise some relevant extremal values may be
@@ -113,8 +109,8 @@ InteractiveCurveViewRangeDelegate::Range FunctionGraphController::computeYRange(
       if (!std::isnan(x) && !std::isinf(x) && x >= xMin && x <= xMax) {
         float y = xy.x2();
         if (!std::isnan(y) && !std::isinf(y)) {
-          min = minFloat(min, y);
-          max = maxFloat(max, y);
+          min = std::min(min, y);
+          max = std::max(max, y);
         }
       }
     }
@@ -167,7 +163,7 @@ bool FunctionGraphController::moveCursorVertically(int direction) {
   double clippedT = m_cursor->t();
   if (!std::isnan(f->tMin())) {
     assert(!std::isnan(f->tMax()));
-    clippedT = minDouble(f->tMax(), maxDouble(f->tMin(), clippedT));
+    clippedT = std::min(f->tMax(), std::max(f->tMin(), clippedT));
   }
   Poincare::Coordinate2D<double> cursorPosition = f->evaluateXYAtParameter(clippedT, context);
   m_cursor->moveTo(clippedT, cursorPosition.x1(), cursorPosition.x2());

--- a/apps/shared/function_graph_controller.cpp
+++ b/apps/shared/function_graph_controller.cpp
@@ -88,13 +88,13 @@ InteractiveCurveViewRangeDelegate::Range FunctionGraphController::computeYRange(
     if (std::isnan(tMin)) {
       tMin = xMin;
     } else if (f->shouldClipTRangeToXRange()) {
-      tMin = std::max(tMin, xMin);
+      tMin = std::max<double>(tMin, xMin);
     }
     double tMax = f->tMax();
     if (std::isnan(tMax)) {
       tMax = xMax;
     } else if (f->shouldClipTRangeToXRange()) {
-      tMax = std::min(tMax, xMax);
+      tMax = std::min<double>(tMax, xMax);
     }
   /* In practice, a step smaller than a pixel's width is needed for sampling
    * the values of a function. Otherwise some relevant extremal values may be
@@ -163,7 +163,7 @@ bool FunctionGraphController::moveCursorVertically(int direction) {
   double clippedT = m_cursor->t();
   if (!std::isnan(f->tMin())) {
     assert(!std::isnan(f->tMax()));
-    clippedT = std::min(f->tMax(), std::max(f->tMin(), clippedT));
+    clippedT = std::min<double>(f->tMax(), std::max<double>(f->tMin(), clippedT));
   }
   Poincare::Coordinate2D<double> cursorPosition = f->evaluateXYAtParameter(clippedT, context);
   m_cursor->moveTo(clippedT, cursorPosition.x1(), cursorPosition.x2());

--- a/apps/shared/function_list_controller.cpp
+++ b/apps/shared/function_list_controller.cpp
@@ -1,10 +1,9 @@
 #include "function_list_controller.h"
 #include "function_app.h"
 #include "function_expression_cell.h"
+#include <algorithm>
 
 namespace Shared {
-
-static inline int maxInt(int x, int y) { return x > y ? x : y; }
 
 FunctionListController::FunctionListController(Responder * parentResponder, ButtonRowController * header, ButtonRowController * footer, I18n::Message text) :
   ExpressionModelListController(parentResponder, text),
@@ -243,7 +242,7 @@ void FunctionListController::computeTitlesColumnWidth(bool forceMax) {
     return;
   }
   KDCoordinate maxTitleWidth = maxFunctionNameWidth()+k_functionTitleSumOfMargins;
-  m_titlesColumnWidth = maxInt(maxTitleWidth, k_minTitleColumnWidth);
+  m_titlesColumnWidth = std::max(maxTitleWidth, k_minTitleColumnWidth);
 }
 
 TabViewController * FunctionListController::tabController() const {
@@ -262,7 +261,7 @@ KDCoordinate FunctionListController::maxFunctionNameWidth() {
     const char * functionName = record.fullName();
     const char * dotPosition = strchr(functionName, Ion::Storage::k_dotChar);
     assert(dotPosition != nullptr);
-    maxNameLength = maxInt(maxNameLength, dotPosition-functionName);
+    maxNameLength = std::max(maxNameLength, dotPosition-functionName);
   }
   return nameWidth(maxNameLength + Function::k_parenthesedArgumentCodePointLength);
 }

--- a/apps/shared/function_list_controller.cpp
+++ b/apps/shared/function_list_controller.cpp
@@ -261,7 +261,7 @@ KDCoordinate FunctionListController::maxFunctionNameWidth() {
     const char * functionName = record.fullName();
     const char * dotPosition = strchr(functionName, Ion::Storage::k_dotChar);
     assert(dotPosition != nullptr);
-    maxNameLength = std::max(maxNameLength, dotPosition-functionName);
+    maxNameLength = std::max(maxNameLength, static_cast<int>(dotPosition-functionName));
   }
   return nameWidth(maxNameLength + Function::k_parenthesedArgumentCodePointLength);
 }

--- a/apps/shared/function_title_cell.cpp
+++ b/apps/shared/function_title_cell.cpp
@@ -1,10 +1,8 @@
 #include "function_title_cell.h"
 #include <assert.h>
+#include <algorithm>
 
 namespace Shared {
-
-static inline float minFloat(float x, float y) { return x < y ? x : y; }
-static inline float maxFloat(float x, float y) { return x > y ? x : y; }
 
 void FunctionTitleCell::setOrientation(Orientation orientation) {
   m_orientation = orientation;
@@ -51,9 +49,9 @@ KDRect FunctionTitleCell::subviewFrame() const {
 
 float FunctionTitleCell::verticalAlignment() const {
   assert(m_orientation == Orientation::VerticalIndicator);
-  return maxFloat(
+  return std::max(
       0.0f,
-      minFloat(
+      std::min(
         1.0f,
         m_baseline < 0 ? 0.5f : verticalAlignmentGivenExpressionBaselineAndRowHeight(m_baseline, subviewFrame().height())));
 }

--- a/apps/shared/interactive_curve_view_range.cpp
+++ b/apps/shared/interactive_curve_view_range.cpp
@@ -5,12 +5,11 @@
 #include <stddef.h>
 #include <assert.h>
 #include <poincare/preferences.h>
+#include <algorithm>
 
 using namespace Poincare;
 
 namespace Shared {
-
-static inline float maxFloat(float x, float y) { return x > y ? x : y; }
 
 uint32_t InteractiveCurveViewRange::rangeChecksum() {
   float data[5] = {xMin(), xMax(), yMin(), yMax(), m_yAuto ? 1.0f : 0.0f};
@@ -94,7 +93,7 @@ void InteractiveCurveViewRange::normalize() {
    * 1cm = 2 current units. */
   m_yAuto = false;
 
-  const float unit = maxFloat(xGridUnit(), yGridUnit());
+  const float unit = std::max(xGridUnit(), yGridUnit());
 
   // Set x range
   float newXHalfRange = NormalizedXHalfRange(unit);
@@ -160,7 +159,7 @@ void InteractiveCurveViewRange::setDefault() {
   yRange = yMax() - yMin();
   float xyRatio = xRange/yRange;
 
-  const float unit = maxFloat(xGridUnit(), yGridUnit());
+  const float unit = std::max(xGridUnit(), yGridUnit());
   const float newXHalfRange = NormalizedXHalfRange(unit);
   const float newYHalfRange = NormalizedYHalfRange(unit);
   float normalizedXYRatio = newXHalfRange/newYHalfRange;

--- a/apps/shared/range_1D.cpp
+++ b/apps/shared/range_1D.cpp
@@ -2,11 +2,9 @@
 #include <assert.h>
 #include <ion.h>
 #include <poincare/ieee754.h>
+#include <algorithm>
 
 namespace Shared {
-
-static inline float minFloat(float x, float y) { return x < y ? x : y; }
-static inline float maxFloat(float x, float y) { return x > y ? x : y; }
 
 void Range1D::setMin(float min, float lowerMaxFloat, float upperMaxFloat) {
   min = clipped(min, false, lowerMaxFloat, upperMaxFloat);
@@ -43,7 +41,7 @@ float Range1D::defaultRangeLengthFor(float position) {
 float Range1D::clipped(float x, bool isMax, float lowerMaxFloat, float upperMaxFloat) {
   float maxF = isMax ? upperMaxFloat : lowerMaxFloat;
   float minF = isMax ? -lowerMaxFloat : -upperMaxFloat;
-  return maxFloat(minF, minFloat(x, maxF));
+  return std::max(minF, std::min(x, maxF));
 }
 
 }

--- a/apps/shared/scrollable_multiple_expressions_view.cpp
+++ b/apps/shared/scrollable_multiple_expressions_view.cpp
@@ -1,11 +1,10 @@
 #include "scrollable_multiple_expressions_view.h"
 #include <apps/i18n.h>
 #include <assert.h>
+#include <algorithm>
 using namespace Poincare;
 
 namespace Shared {
-
-static inline KDCoordinate maxCoordinate(KDCoordinate x, KDCoordinate y) { return x > y ? x : y; }
 
 AbstractScrollableMultipleExpressionsView::ContentCell::ContentCell() :
   m_rightExpressionView(),
@@ -75,7 +74,7 @@ KDSize AbstractScrollableMultipleExpressionsView::ContentCell::minimalSizeForOpt
     centeredExpressionSize = m_centeredExpressionView.minimalSizeForOptimalDisplay();
     width += centeredExpressionSize.width() + 2*Metric::CommonLargeMargin + m_approximateSign.minimalSizeForOptimalDisplay().width();
   }
-  KDCoordinate height = maxCoordinate(maxCoordinate(centeredBaseline, rightBaseline), leftViewBaseline) + maxCoordinate(maxCoordinate(centeredExpressionSize.height()-centeredBaseline, rightExpressionSize.height()-rightBaseline), leftSize.height()-leftViewBaseline);
+  KDCoordinate height = std::max(std::max(centeredBaseline, rightBaseline), leftViewBaseline) + std::max(std::max(centeredExpressionSize.height()-centeredBaseline, rightExpressionSize.height()-rightBaseline), leftSize.height()-leftViewBaseline);
   return KDSize(width, height);
 }
 
@@ -134,7 +133,7 @@ void AbstractScrollableMultipleExpressionsView::ContentCell::layoutSubviews(bool
   KDSize rightExpressionSize = m_rightExpressionView.minimalSizeForOptimalDisplay();
   KDCoordinate rightBaseline = m_rightExpressionView.layout().isUninitialized() ? 0 : m_rightExpressionView.layout().baseline();
   // Compute baseline
-  KDCoordinate baseline = maxCoordinate(maxCoordinate(leftViewBaseline, rightBaseline), centeredBaseline);
+  KDCoordinate baseline = std::max(std::max(leftViewBaseline, rightBaseline), centeredBaseline);
   // Layout left view
   KDCoordinate currentWidth = 0;
   if (leftExpressionView()) {

--- a/apps/shared/store_controller.cpp
+++ b/apps/shared/store_controller.cpp
@@ -4,10 +4,9 @@
 #include "../constant.h"
 #include <escher/metric.h>
 #include <assert.h>
+#include <algorithm>
 
 using namespace Poincare;
-
-static inline int minInt(int x, int y) { return x < y ? x : y; }
 
 namespace Shared {
 
@@ -245,7 +244,7 @@ bool StoreController::privateFillColumnWithFormula(Expression formula, Expressio
     if (numberOfValuesToCompute == -1) {
       numberOfValuesToCompute = m_store->numberOfPairsOfSeries(series);
     } else {
-      numberOfValuesToCompute = minInt(numberOfValuesToCompute, m_store->numberOfPairsOfSeries(series));
+      numberOfValuesToCompute = std::min(numberOfValuesToCompute, m_store->numberOfPairsOfSeries(series));
     }
     index++;
   }

--- a/apps/shared/values_controller.cpp
+++ b/apps/shared/values_controller.cpp
@@ -3,12 +3,12 @@
 #include <poincare/preferences.h>
 #include <assert.h>
 #include <limits.h>
+#include <algorithm>
 
 using namespace Poincare;
 
 namespace Shared {
 
-static inline int minInt(int x, int y) { return x < y ? x : y; }
 static inline int absInt(int x) { return x < 0 ? -x : x; }
 
 // Constructor and helpers
@@ -338,9 +338,9 @@ char * ValuesController::memoizedBufferForCell(int i, int j) {
     }
     // Compute the buffer of the new cells of the memoized table
     int maxI = numberOfValuesColumns() - m_firstMemoizedColumn;
-    for (int ii = 0; ii < minInt(nbOfMemoizedColumns, maxI); ii++) {
+    for (int ii = 0; ii < std::min(nbOfMemoizedColumns, maxI); ii++) {
       int maxJ = numberOfElementsInColumn(absoluteColumnForValuesColumn(ii+m_firstMemoizedColumn)) - m_firstMemoizedRow;
-      for (int jj = 0; jj < minInt(k_maxNumberOfDisplayableRows, maxJ); jj++) {
+      for (int jj = 0; jj < std::min(k_maxNumberOfDisplayableRows, maxJ); jj++) {
         // Escape if already filled
         if (ii >= -offsetI && ii < -offsetI + nbOfMemoizedColumns && jj >= -offsetJ && jj < -offsetJ + k_maxNumberOfDisplayableRows) {
           continue;

--- a/apps/solver/solutions_controller.cpp
+++ b/apps/solver/solutions_controller.cpp
@@ -10,13 +10,12 @@
 #include <poincare/symbol_abstract.h>
 #include <poincare/symbol.h>
 #include <poincare/vertical_offset_layout.h>
+#include <algorithm>
 
 using namespace Poincare;
 using namespace Shared;
 
 namespace Solver {
-
-static inline KDCoordinate maxCoordinate(KDCoordinate x, KDCoordinate y) { return x > y ? x : y; }
 
 constexpr KDColor SolutionsController::ContentView::k_backgroundColor;
 
@@ -260,7 +259,7 @@ KDCoordinate SolutionsController::rowHeight(int j) {
     Poincare::Layout approximateLayout = m_equationStore->exactSolutionLayoutAtIndex(j, false);
     KDCoordinate exactLayoutHeight = exactLayout.layoutSize().height();
     KDCoordinate approximateLayoutHeight = approximateLayout.layoutSize().height();
-    KDCoordinate layoutHeight = maxCoordinate(exactLayout.baseline(), approximateLayout.baseline()) + maxCoordinate(exactLayoutHeight-exactLayout.baseline(), approximateLayoutHeight-approximateLayout.baseline());
+    KDCoordinate layoutHeight = std::max(exactLayout.baseline(), approximateLayout.baseline()) + std::max(exactLayoutHeight-exactLayout.baseline(), approximateLayoutHeight-approximateLayout.baseline());
     return layoutHeight + 2 * Metric::CommonSmallMargin;
   }
   if (j == rowOfUserVariablesMessage) {

--- a/apps/statistics/histogram_controller.cpp
+++ b/apps/statistics/histogram_controller.cpp
@@ -4,6 +4,7 @@
 #include "app.h"
 #include <poincare/ieee754.h>
 #include <poincare/preferences.h>
+#include <algorithm>
 #include <cmath>
 #include <assert.h>
 #include <float.h>
@@ -12,9 +13,6 @@ using namespace Poincare;
 using namespace Shared;
 
 namespace Statistics {
-
-static inline float minFloat(float x, float y) { return x < y ? x : y; }
-static inline float maxFloat(float x, float y) { return x > y ? x : y; }
 
 HistogramController::HistogramController(Responder * parentResponder, InputEventHandlerDelegate * inputEventHandlerDelegate, ButtonRowController * header, Store * store, uint32_t * storeVersion, uint32_t * barVersion, uint32_t * rangeVersion, int * selectedBarIndex, int * selectedSeriesIndex) :
   MultipleDataViewController(parentResponder, store, selectedBarIndex, selectedSeriesIndex),
@@ -193,8 +191,8 @@ void HistogramController::preinitXRangeParameters() {
   float maxValue = -FLT_MAX;
   for (int i = 0; i < Store::k_numberOfSeries; i ++) {
     if (!m_store->seriesIsEmpty(i)) {
-      minValue = minFloat(minValue, m_store->minValue(i));
-      maxValue = maxFloat(maxValue, m_store->maxValue(i));
+      minValue = std::min(minValue, m_store->minValue(i));
+      maxValue = std::max(maxValue, m_store->maxValue(i));
     }
   }
   m_store->setXMin(minValue);

--- a/apps/statistics/histogram_controller.cpp
+++ b/apps/statistics/histogram_controller.cpp
@@ -191,8 +191,8 @@ void HistogramController::preinitXRangeParameters() {
   float maxValue = -FLT_MAX;
   for (int i = 0; i < Store::k_numberOfSeries; i ++) {
     if (!m_store->seriesIsEmpty(i)) {
-      minValue = std::min(minValue, m_store->minValue(i));
-      maxValue = std::max(maxValue, m_store->maxValue(i));
+      minValue = std::min<float>(minValue, m_store->minValue(i));
+      maxValue = std::max<float>(maxValue, m_store->maxValue(i));
     }
   }
   m_store->setXMin(minValue);

--- a/apps/variable_box_controller.cpp
+++ b/apps/variable_box_controller.cpp
@@ -8,13 +8,11 @@
 #include <poincare/matrix_layout.h>
 #include <poincare/preferences.h>
 #include <assert.h>
+#include <algorithm>
 
 using namespace Poincare;
 using namespace Shared;
 using namespace Ion;
-
-static inline KDCoordinate maxCoordinate(KDCoordinate x, KDCoordinate y) { return x > y ? x : y; }
-static inline KDCoordinate maxInt(int x, int y) { return x > y ? x : y; }
 
 VariableBoxController::VariableBoxController() :
   NestedMenuController(nullptr, I18n::Message::Variables),
@@ -129,7 +127,7 @@ KDCoordinate VariableBoxController::rowHeight(int index) {
   if (m_currentPage != Page::RootMenu) {
     Layout layoutR = expressionLayoutForRecord(recordAtIndex(index), index);
     if (!layoutR.isUninitialized()) {
-      return maxCoordinate(layoutR.layoutSize().height()+k_leafMargin, Metric::ToolboxRowHeight);
+      return std::max(layoutR.layoutSize().height()+k_leafMargin, Metric::ToolboxRowHeight);
     }
   }
   return NestedMenuController::rowHeight(index);
@@ -289,7 +287,7 @@ void VariableBoxController::destroyRecordAtRowIndex(int rowIndex) {
     // The deleted row is after the memoization
     return;
   }
-  for (int i = maxInt(0, rowIndex - m_firstMemoizedLayoutIndex); i < k_maxNumberOfDisplayedRows - 1; i++) {
+  for (int i = std::max(0, rowIndex - m_firstMemoizedLayoutIndex); i < k_maxNumberOfDisplayedRows - 1; i++) {
     m_layouts[i] = m_layouts[i+1];
   }
   m_layouts[k_maxNumberOfDisplayedRows - 1] = Layout();

--- a/apps/variable_box_controller.cpp
+++ b/apps/variable_box_controller.cpp
@@ -127,7 +127,7 @@ KDCoordinate VariableBoxController::rowHeight(int index) {
   if (m_currentPage != Page::RootMenu) {
     Layout layoutR = expressionLayoutForRecord(recordAtIndex(index), index);
     if (!layoutR.isUninitialized()) {
-      return std::max(layoutR.layoutSize().height()+k_leafMargin, Metric::ToolboxRowHeight);
+      return std::max<KDCoordinate>(layoutR.layoutSize().height()+k_leafMargin, Metric::ToolboxRowHeight);
     }
   }
   return NestedMenuController::rowHeight(index);

--- a/escher/src/clipboard.cpp
+++ b/escher/src/clipboard.cpp
@@ -1,15 +1,14 @@
 #include <escher/clipboard.h>
+#include <algorithm>
 
 static Clipboard s_clipboard;
-
-static inline int minInt(int x, int y) { return x < y ? x : y; }
 
 Clipboard * Clipboard::sharedClipboard() {
   return &s_clipboard;
 }
 
 void Clipboard::store(const char * storedText, int length) {
-  strlcpy(m_textBuffer, storedText, length == -1 ? TextField::maxBufferSize() : minInt(TextField::maxBufferSize(), length + 1));
+  strlcpy(m_textBuffer, storedText, length == -1 ? TextField::maxBufferSize() : std::min(TextField::maxBufferSize(), length + 1));
 }
 
 void Clipboard::reset() {

--- a/escher/src/expression_field.cpp
+++ b/escher/src/expression_field.cpp
@@ -1,9 +1,7 @@
 #include <escher/expression_field.h>
 #include <poincare/preferences.h>
 #include <assert.h>
-
-static inline KDCoordinate minCoordinate(KDCoordinate x, KDCoordinate y) { return x < y ? x : y; }
-static inline KDCoordinate maxCoordinate(KDCoordinate x, KDCoordinate y) { return x > y ? x : y; }
+#include <algorithm>
 
 ExpressionField::ExpressionField(Responder * parentResponder, InputEventHandlerDelegate * inputEventHandlerDelegate, TextFieldDelegate * textFieldDelegate, LayoutFieldDelegate * layoutFieldDelegate) :
   Responder(parentResponder),
@@ -117,6 +115,6 @@ bool ExpressionField::handleEventWithText(const char * text, bool indentation, b
 KDCoordinate ExpressionField::inputViewHeight() const {
   return k_separatorThickness
     + (editionIsInTextField() ? k_minimalHeight :
-        minCoordinate(k_maximalHeight,
-          maxCoordinate(k_minimalHeight, m_layoutField.minimalSizeForOptimalDisplay().height())));
+        std::min(k_maximalHeight,
+          std::max(k_minimalHeight, m_layoutField.minimalSizeForOptimalDisplay().height())));
 }

--- a/escher/src/expression_view.cpp
+++ b/escher/src/expression_view.cpp
@@ -64,7 +64,7 @@ KDSize ExpressionView::minimalSizeForOptimalDisplay() const {
 
 KDPoint ExpressionView::drawingOrigin() const {
   KDSize expressionSize = m_layout.layoutSize();
-  return KDPoint(m_horizontalMargin + m_horizontalAlignment*(m_frame.width() - 2*m_horizontalMargin - expressionSize.width()), std::max(0, m_verticalAlignment*(m_frame.height() - expressionSize.height())));
+  return KDPoint(m_horizontalMargin + m_horizontalAlignment*(m_frame.width() - 2*m_horizontalMargin - expressionSize.width()), std::max<KDCoordinate>(0, m_verticalAlignment*(m_frame.height() - expressionSize.height())));
 }
 
 KDPoint ExpressionView::absoluteDrawingOrigin() const {

--- a/escher/src/expression_view.cpp
+++ b/escher/src/expression_view.cpp
@@ -1,9 +1,8 @@
 #include <escher/expression_view.h>
 #include <escher/palette.h>
+#include <algorithm>
 
 using namespace Poincare;
-
-static inline KDCoordinate maxCoordinate(KDCoordinate x, KDCoordinate y) { return x > y ? x : y; }
 
 ExpressionView::ExpressionView(float horizontalAlignment, float verticalAlignment,
     KDColor textColor, KDColor backgroundColor, Poincare::Layout * selectionStart, Poincare::Layout * selectionEnd ) :
@@ -65,7 +64,7 @@ KDSize ExpressionView::minimalSizeForOptimalDisplay() const {
 
 KDPoint ExpressionView::drawingOrigin() const {
   KDSize expressionSize = m_layout.layoutSize();
-  return KDPoint(m_horizontalMargin + m_horizontalAlignment*(m_frame.width() - 2*m_horizontalMargin - expressionSize.width()), maxCoordinate(0, m_verticalAlignment*(m_frame.height() - expressionSize.height())));
+  return KDPoint(m_horizontalMargin + m_horizontalAlignment*(m_frame.width() - 2*m_horizontalMargin - expressionSize.width()), std::max(0, m_verticalAlignment*(m_frame.height() - expressionSize.height())));
 }
 
 KDPoint ExpressionView::absoluteDrawingOrigin() const {

--- a/escher/src/layout_field.cpp
+++ b/escher/src/layout_field.cpp
@@ -5,10 +5,9 @@
 #include <poincare/horizontal_layout.h>
 #include <assert.h>
 #include <string.h>
+#include <algorithm>
 
 using namespace Poincare;
-
-static inline KDCoordinate minCoordinate(KDCoordinate x, KDCoordinate y) { return x < y ? x : y; }
 
 LayoutField::ContentView::ContentView() :
   m_cursor(),
@@ -610,8 +609,8 @@ void LayoutField::scrollToBaselinedRect(KDRect rect, KDCoordinate baseline) {
   scrollToContentRect(rect, true);
   // Show the rect area around its baseline
   KDCoordinate underBaseline = rect.height() - baseline;
-  KDCoordinate minAroundBaseline = minCoordinate(baseline, underBaseline);
-  minAroundBaseline = minCoordinate(minAroundBaseline, bounds().height() / 2);
+  KDCoordinate minAroundBaseline = std::min(baseline, underBaseline);
+  minAroundBaseline = std::min(minAroundBaseline, bounds().height() / 2);
   KDRect balancedRect(rect.x(), rect.y() + baseline - minAroundBaseline, rect.width(), 2 * minAroundBaseline);
   scrollToContentRect(balancedRect, true);
 }

--- a/escher/src/layout_field.cpp
+++ b/escher/src/layout_field.cpp
@@ -610,7 +610,7 @@ void LayoutField::scrollToBaselinedRect(KDRect rect, KDCoordinate baseline) {
   // Show the rect area around its baseline
   KDCoordinate underBaseline = rect.height() - baseline;
   KDCoordinate minAroundBaseline = std::min(baseline, underBaseline);
-  minAroundBaseline = std::min(minAroundBaseline, bounds().height() / 2);
+  minAroundBaseline = std::min<KDCoordinate>(minAroundBaseline, bounds().height() / 2);
   KDRect balancedRect(rect.x(), rect.y() + baseline - minAroundBaseline, rect.width(), 2 * minAroundBaseline);
   scrollToContentRect(balancedRect, true);
 }

--- a/escher/src/scroll_view.cpp
+++ b/escher/src/scroll_view.cpp
@@ -4,9 +4,7 @@
 extern "C" {
 #include <assert.h>
 }
-
-static inline KDCoordinate minCoordinate(KDCoordinate x, KDCoordinate y) { return x < y ? x : y; }
-static inline KDCoordinate maxCoordinate(KDCoordinate x, KDCoordinate y) { return x > y ? x : y; }
+#include <algorithm>
 
 ScrollView::ScrollView(View * contentView, ScrollViewDataSource * dataSource) :
   View(),
@@ -76,8 +74,8 @@ void ScrollView::scrollToContentPoint(KDPoint p, bool allowOverscroll) {
 
   // Handle cases when the size of the view has decreased.
   setContentOffset(KDPoint(
-    minCoordinate(contentOffset().x(), maxCoordinate(minimalSizeForOptimalDisplay().width() - bounds().width(), 0)),
-    minCoordinate(contentOffset().y(), maxCoordinate(minimalSizeForOptimalDisplay().height() - bounds().height(), 0))));
+    std::min(contentOffset().x(), std::max(minimalSizeForOptimalDisplay().width() - bounds().width(), 0)),
+    std::min(contentOffset().y(), std::max(minimalSizeForOptimalDisplay().height() - bounds().height(), 0))));
 }
 
 void ScrollView::scrollToContentRect(KDRect rect, bool allowOverscroll) {

--- a/escher/src/scroll_view.cpp
+++ b/escher/src/scroll_view.cpp
@@ -74,8 +74,8 @@ void ScrollView::scrollToContentPoint(KDPoint p, bool allowOverscroll) {
 
   // Handle cases when the size of the view has decreased.
   setContentOffset(KDPoint(
-    std::min(contentOffset().x(), std::max(minimalSizeForOptimalDisplay().width() - bounds().width(), 0)),
-    std::min(contentOffset().y(), std::max(minimalSizeForOptimalDisplay().height() - bounds().height(), 0))));
+    std::min(contentOffset().x(), std::max<KDCoordinate>(minimalSizeForOptimalDisplay().width() - bounds().width(), KDCoordinate{0})),
+    std::min(contentOffset().y(), std::max<KDCoordinate>(minimalSizeForOptimalDisplay().height() - bounds().height(), 0))));
 }
 
 void ScrollView::scrollToContentRect(KDRect rect, bool allowOverscroll) {

--- a/escher/src/scrollable_view.cpp
+++ b/escher/src/scrollable_view.cpp
@@ -1,9 +1,7 @@
 #include <escher/scrollable_view.h>
 #include <escher/metric.h>
 #include <assert.h>
-
-static inline KDCoordinate minCoordinate(KDCoordinate x, KDCoordinate y) { return x < y ? x : y; }
-static inline KDCoordinate maxCoordinate(KDCoordinate x, KDCoordinate y) { return x > y ? x : y; }
+#include <algorithm>
 
 ScrollableView::ScrollableView(Responder * parentResponder, View * view, ScrollViewDataSource * dataSource) :
   Responder(parentResponder),
@@ -17,25 +15,25 @@ bool ScrollableView::handleEvent(Ion::Events::Event event) {
   if (event == Ion::Events::Left) {
     KDCoordinate movementToEdge = contentOffset().x();
     if (movementToEdge > 0) {
-      translation = KDPoint(-minCoordinate(Metric::ScrollStep, movementToEdge), 0);
+      translation = KDPoint(-std::min(Metric::ScrollStep, movementToEdge), 0);
     }
   }
   if (event == Ion::Events::Right) {
     KDCoordinate movementToEdge = minimalSizeForOptimalDisplay().width() - bounds().width() - contentOffset().x();
     if (movementToEdge > 0) {
-      translation = KDPoint(minCoordinate(Metric::ScrollStep, movementToEdge), 0);
+      translation = KDPoint(std::min(Metric::ScrollStep, movementToEdge), 0);
     }
   }
   if (event == Ion::Events::Up) {
     KDCoordinate movementToEdge = contentOffset().y();
     if (movementToEdge > 0) {
-      translation = KDPoint(0, -minCoordinate(Metric::ScrollStep, movementToEdge));
+      translation = KDPoint(0, -std::min(Metric::ScrollStep, movementToEdge));
     }
   }
   if (event == Ion::Events::Down) {
     KDCoordinate movementToEdge = minimalSizeForOptimalDisplay().height() - bounds().height() - contentOffset().y();
     if (movementToEdge > 0) {
-      translation = KDPoint(0, minCoordinate(Metric::ScrollStep, movementToEdge));
+      translation = KDPoint(0, std::min(Metric::ScrollStep, movementToEdge));
     }
   }
   if (translation != KDPointZero) {
@@ -51,7 +49,7 @@ void ScrollableView::reloadScroll(bool forceReLayout) {
 
 KDSize ScrollableView::contentSize() const {
   KDSize viewSize = ScrollView::contentSize();
-  KDCoordinate viewWidth = maxCoordinate(viewSize.width(), maxContentWidthDisplayableWithoutScrolling());
-  KDCoordinate viewHeight = maxCoordinate(viewSize.height(), maxContentHeightDisplayableWithoutScrolling());
+  KDCoordinate viewWidth = std::max(viewSize.width(), maxContentWidthDisplayableWithoutScrolling());
+  KDCoordinate viewHeight = std::max(viewSize.height(), maxContentHeightDisplayableWithoutScrolling());
   return KDSize(viewWidth, viewHeight);
 }

--- a/escher/src/table_cell.cpp
+++ b/escher/src/table_cell.cpp
@@ -93,21 +93,21 @@ void TableCell::layoutSubviews(bool force) {
     KDCoordinate y = k_separatorThickness;
     if (label) {
       y += k_verticalMargin;
-      KDCoordinate labelHeight = std::min(labelSize.height(), height - y - k_separatorThickness - k_verticalMargin);
+      KDCoordinate labelHeight = std::min<KDCoordinate>(labelSize.height(), height - y - k_separatorThickness - k_verticalMargin);
       label->setFrame(KDRect(horizontalMargin, y, width-2*horizontalMargin, labelHeight), force);
       y += labelHeight + k_verticalMargin;
     }
     horizontalMargin = k_separatorThickness + k_horizontalMargin;
-    y = std::max(y, height - k_separatorThickness - withMargin(accessorySize.height(), Metric::TableCellVerticalMargin) - withMargin(subAccessorySize.height(), 0));
+    y = std::max<KDCoordinate>(y, height - k_separatorThickness - withMargin(accessorySize.height(), Metric::TableCellVerticalMargin) - withMargin(subAccessorySize.height(), 0));
     if (subAccessory) {
-      KDCoordinate subAccessoryHeight = std::min(subAccessorySize.height(), height - y - k_separatorThickness - Metric::TableCellVerticalMargin);
+      KDCoordinate subAccessoryHeight = std::min<KDCoordinate>(subAccessorySize.height(), height - y - k_separatorThickness - Metric::TableCellVerticalMargin);
       accessory->setFrame(KDRect(horizontalMargin, y, width - 2*horizontalMargin, subAccessoryHeight), force);
       y += subAccessoryHeight;
     }
     horizontalMargin = k_separatorThickness + accessoryMargin();
-    y = std::max(y, height - k_separatorThickness - withMargin(accessorySize.height(), Metric::TableCellVerticalMargin));
+    y = std::max<KDCoordinate>(y, height - k_separatorThickness - withMargin(accessorySize.height(), Metric::TableCellVerticalMargin));
     if (accessory) {
-      KDCoordinate accessoryHeight = std::min(accessorySize.height(), height - y - k_separatorThickness - Metric::TableCellVerticalMargin);
+      KDCoordinate accessoryHeight = std::min<KDCoordinate>(accessorySize.height(), height - y - k_separatorThickness - Metric::TableCellVerticalMargin);
       accessory->setFrame(KDRect(horizontalMargin, y, width - 2*horizontalMargin, accessoryHeight), force);
     }
   } else {
@@ -139,25 +139,25 @@ void TableCell::layoutSubviews(bool force) {
     KDCoordinate accessoryX = std::max(k_separatorThickness + accessoryMargin(), width - k_separatorThickness - withMargin(accessorySize.width(), accessoryMargin()));
     if (label) {
       x = labelX;
-      KDCoordinate labelWidth = std::min(labelSize.width(), width - x - k_separatorThickness - labelMargin());
+      KDCoordinate labelWidth = std::min<KDCoordinate>(labelSize.width(), width - x - k_separatorThickness - labelMargin());
       if (m_layout == Layout::HorizontalRightOverlap) {
-        labelWidth = std::min(labelWidth, subAccessoryX - x - labelMargin());
+        labelWidth = std::min<KDCoordinate>(labelWidth, subAccessoryX - x - labelMargin());
       }
       label->setFrame(KDRect(x, verticalMargin, labelWidth, height-2*verticalMargin), force);
       x += labelWidth + labelMargin();
     }
     if (subAccessory) {
       x = std::max(x, subAccessoryX);
-      KDCoordinate subAccessoryWidth = std::min(subAccessorySize.width(), width - x - k_separatorThickness - k_horizontalMargin);
+      KDCoordinate subAccessoryWidth = std::min<KDCoordinate>(subAccessorySize.width(), width - x - k_separatorThickness - k_horizontalMargin);
       if (m_layout == Layout::HorizontalRightOverlap) {
-        subAccessoryWidth = std::min(subAccessoryWidth, accessoryX - x);
+        subAccessoryWidth = std::min<KDCoordinate>(subAccessoryWidth, accessoryX - x);
       }
       subAccessory->setFrame(KDRect(x, verticalMargin, subAccessoryWidth, height-2*verticalMargin), force);
       x += subAccessoryWidth;
     }
     if (accessory) {
       x = std::max(x, accessoryX);
-      KDCoordinate accessoryWidth = std::min(accessorySize.width(), width - x - k_separatorThickness - accessoryMargin());
+      KDCoordinate accessoryWidth = std::min<KDCoordinate>(accessorySize.width(), width - x - k_separatorThickness - accessoryMargin());
       accessory->setFrame(KDRect(x, verticalMargin, accessoryWidth, height-2*verticalMargin), force);
     }
   }

--- a/escher/src/table_cell.cpp
+++ b/escher/src/table_cell.cpp
@@ -1,9 +1,7 @@
 #include <escher/table_cell.h>
 #include <escher/palette.h>
 #include <escher/metric.h>
-
-static inline KDCoordinate minCoordinate(KDCoordinate x, KDCoordinate y) { return x < y ? x : y; }
-static inline KDCoordinate maxCoordinate(KDCoordinate x, KDCoordinate y) { return x > y ? x : y; }
+#include <algorithm>
 
 TableCell::TableCell(Layout layout) :
   Bordered(),
@@ -95,21 +93,21 @@ void TableCell::layoutSubviews(bool force) {
     KDCoordinate y = k_separatorThickness;
     if (label) {
       y += k_verticalMargin;
-      KDCoordinate labelHeight = minCoordinate(labelSize.height(), height - y - k_separatorThickness - k_verticalMargin);
+      KDCoordinate labelHeight = std::min(labelSize.height(), height - y - k_separatorThickness - k_verticalMargin);
       label->setFrame(KDRect(horizontalMargin, y, width-2*horizontalMargin, labelHeight), force);
       y += labelHeight + k_verticalMargin;
     }
     horizontalMargin = k_separatorThickness + k_horizontalMargin;
-    y = maxCoordinate(y, height - k_separatorThickness - withMargin(accessorySize.height(), Metric::TableCellVerticalMargin) - withMargin(subAccessorySize.height(), 0));
+    y = std::max(y, height - k_separatorThickness - withMargin(accessorySize.height(), Metric::TableCellVerticalMargin) - withMargin(subAccessorySize.height(), 0));
     if (subAccessory) {
-      KDCoordinate subAccessoryHeight = minCoordinate(subAccessorySize.height(), height - y - k_separatorThickness - Metric::TableCellVerticalMargin);
+      KDCoordinate subAccessoryHeight = std::min(subAccessorySize.height(), height - y - k_separatorThickness - Metric::TableCellVerticalMargin);
       accessory->setFrame(KDRect(horizontalMargin, y, width - 2*horizontalMargin, subAccessoryHeight), force);
       y += subAccessoryHeight;
     }
     horizontalMargin = k_separatorThickness + accessoryMargin();
-    y = maxCoordinate(y, height - k_separatorThickness - withMargin(accessorySize.height(), Metric::TableCellVerticalMargin));
+    y = std::max(y, height - k_separatorThickness - withMargin(accessorySize.height(), Metric::TableCellVerticalMargin));
     if (accessory) {
-      KDCoordinate accessoryHeight = minCoordinate(accessorySize.height(), height - y - k_separatorThickness - Metric::TableCellVerticalMargin);
+      KDCoordinate accessoryHeight = std::min(accessorySize.height(), height - y - k_separatorThickness - Metric::TableCellVerticalMargin);
       accessory->setFrame(KDRect(horizontalMargin, y, width - 2*horizontalMargin, accessoryHeight), force);
     }
   } else {
@@ -137,29 +135,29 @@ void TableCell::layoutSubviews(bool force) {
     KDCoordinate verticalMargin = k_separatorThickness;
     KDCoordinate x = 0;
     KDCoordinate labelX = k_separatorThickness + labelMargin();
-    KDCoordinate subAccessoryX = maxCoordinate(k_separatorThickness + k_horizontalMargin, width - k_separatorThickness - withMargin(accessorySize.width(), accessoryMargin()) - withMargin(subAccessorySize.width(), 0));
-    KDCoordinate accessoryX = maxCoordinate(k_separatorThickness + accessoryMargin(), width - k_separatorThickness - withMargin(accessorySize.width(), accessoryMargin()));
+    KDCoordinate subAccessoryX = std::max(k_separatorThickness + k_horizontalMargin, width - k_separatorThickness - withMargin(accessorySize.width(), accessoryMargin()) - withMargin(subAccessorySize.width(), 0));
+    KDCoordinate accessoryX = std::max(k_separatorThickness + accessoryMargin(), width - k_separatorThickness - withMargin(accessorySize.width(), accessoryMargin()));
     if (label) {
       x = labelX;
-      KDCoordinate labelWidth = minCoordinate(labelSize.width(), width - x - k_separatorThickness - labelMargin());
+      KDCoordinate labelWidth = std::min(labelSize.width(), width - x - k_separatorThickness - labelMargin());
       if (m_layout == Layout::HorizontalRightOverlap) {
-        labelWidth = minCoordinate(labelWidth, subAccessoryX - x - labelMargin());
+        labelWidth = std::min(labelWidth, subAccessoryX - x - labelMargin());
       }
       label->setFrame(KDRect(x, verticalMargin, labelWidth, height-2*verticalMargin), force);
       x += labelWidth + labelMargin();
     }
     if (subAccessory) {
-      x = maxCoordinate(x, subAccessoryX);
-      KDCoordinate subAccessoryWidth = minCoordinate(subAccessorySize.width(), width - x - k_separatorThickness - k_horizontalMargin);
+      x = std::max(x, subAccessoryX);
+      KDCoordinate subAccessoryWidth = std::min(subAccessorySize.width(), width - x - k_separatorThickness - k_horizontalMargin);
       if (m_layout == Layout::HorizontalRightOverlap) {
-        subAccessoryWidth = minCoordinate(subAccessoryWidth, accessoryX - x);
+        subAccessoryWidth = std::min(subAccessoryWidth, accessoryX - x);
       }
       subAccessory->setFrame(KDRect(x, verticalMargin, subAccessoryWidth, height-2*verticalMargin), force);
       x += subAccessoryWidth;
     }
     if (accessory) {
-      x = maxCoordinate(x, accessoryX);
-      KDCoordinate accessoryWidth = minCoordinate(accessorySize.width(), width - x - k_separatorThickness - accessoryMargin());
+      x = std::max(x, accessoryX);
+      KDCoordinate accessoryWidth = std::min(accessorySize.width(), width - x - k_separatorThickness - accessoryMargin());
       accessory->setFrame(KDRect(x, verticalMargin, accessoryWidth, height-2*verticalMargin), force);
     }
   }

--- a/escher/src/table_view.cpp
+++ b/escher/src/table_view.cpp
@@ -4,8 +4,7 @@
 extern "C" {
 #include <assert.h>
 }
-
-#define MIN(x,y) ((x)<(y) ? (x) : (y))
+#include <algorithm>
 
 TableView::TableView(TableViewDataSource * dataSource, ScrollViewDataSource * scrollDataSource) :
   ScrollView(&m_contentView, scrollDataSource),
@@ -200,7 +199,7 @@ int TableView::ContentView::numberOfFullyDisplayableColumns() const {
 int TableView::ContentView::numberOfDisplayableRows() const {
   int rowOffset = rowsScrollingOffset();
   int displayedHeightWithOffset = m_dataSource->indexFromCumulatedHeight(m_tableView->bounds().height() + m_tableView->contentOffset().y());
-  return MIN(
+  return std::min(
     m_dataSource->numberOfRows(),
     displayedHeightWithOffset + 1
   )  - rowOffset;
@@ -209,7 +208,7 @@ int TableView::ContentView::numberOfDisplayableRows() const {
 int TableView::ContentView::numberOfDisplayableColumns() const {
   int columnOffset = columnsScrollingOffset();
   int displayedWidthWithOffset = m_dataSource->indexFromCumulatedWidth(m_tableView->bounds().width() + m_tableView->contentOffset().x());
-  return MIN(
+  return std::min(
     m_dataSource->numberOfColumns(),
     displayedWidthWithOffset + 1
   )  - columnOffset;

--- a/escher/src/text_area.cpp
+++ b/escher/src/text_area.cpp
@@ -8,10 +8,7 @@
 #include <stddef.h>
 #include <assert.h>
 #include <limits.h>
-
-static inline const char * maxPointer(const char * x, const char * y) { return x > y ? x : y; }
-static inline const char * minPointer(const char * x, const char * y) { return x < y ? x : y; }
-static inline size_t minSizeT(size_t x, size_t y) { return x < y ? x : y; }
+#include <algorithm>
 
 /* TextArea */
 
@@ -214,7 +211,7 @@ const char * TextArea::Text::pointerAtPosition(Position p) {
   for (Line l : *this) {
     if (p.line() == y) {
       const char * result = UTF8Helper::CodePointAtGlyphOffset(l.text(), p.column());
-      return minPointer(result, l.text() + l.charLength());
+      return std::min(result, l.text() + l.charLength());
     }
     y++;
   }
@@ -420,13 +417,13 @@ void TextArea::ContentView::drawStringAt(KDContext * ctx, int line, int column, 
     m_font,
     textColor,
     backgroundColor,
-    drawSelection ? (selectionStart >= text ? minSizeT(length, selectionStart - text) : 0) : length
+    drawSelection ? (selectionStart >= text ? std::min(length, selectionStart - text) : 0) : length
   );
   if (!drawSelection) {
     return;
   }
-  const char * highlightedDrawStart = maxPointer(selectionStart, text);
-  size_t highlightedDrawLength = minSizeT(selectionEnd - highlightedDrawStart, length - (highlightedDrawStart - text));
+  const char * highlightedDrawStart = std::max(selectionStart, text);
+  size_t highlightedDrawLength = std::min(selectionEnd - highlightedDrawStart, length - (highlightedDrawStart - text));
 
   nextPoint = ctx->drawString(
     highlightedDrawStart,

--- a/escher/src/text_area.cpp
+++ b/escher/src/text_area.cpp
@@ -417,7 +417,7 @@ void TextArea::ContentView::drawStringAt(KDContext * ctx, int line, int column, 
     m_font,
     textColor,
     backgroundColor,
-    drawSelection ? (selectionStart >= text ? std::min(length, selectionStart - text) : 0) : length
+    drawSelection ? (selectionStart >= text ? std::min<KDCoordinate>(length, selectionStart - text) : 0) : length
   );
   if (!drawSelection) {
     return;

--- a/escher/src/text_field.cpp
+++ b/escher/src/text_field.cpp
@@ -5,8 +5,8 @@
 #include <ion/unicode/utf8_helper.h>
 #include <poincare/serialization_helper.h>
 #include <assert.h>
+#include <algorithm>
 
-static inline int minInt(int x, int y) { return x < y ? x : y; }
 static char s_draftTextBuffer[TextField::maxBufferSize()];
 
 /* TextField::ContentView */
@@ -84,7 +84,7 @@ void TextField::ContentView::setText(const char * text) {
     buffer[0] = 0;
     return;
   }
-  int textLength = minInt(textRealLength, maxBufferSize - 1);
+  int textLength = std::min(textRealLength, maxBufferSize - 1);
   // Copy the text
   strlcpy(buffer, text, maxBufferSize);
   // Update the draft text length

--- a/escher/src/text_input.cpp
+++ b/escher/src/text_input.cpp
@@ -2,11 +2,9 @@
 #include <ion/unicode/utf8_decoder.h>
 #include <ion/unicode/utf8_helper.h>
 #include <assert.h>
+#include <algorithm>
 
 /* TextInput::ContentView */
-
-static inline const char * minCharPointer(const char * x, const char * y) { return x < y ? x : y; }
-static inline const char * maxCharPointer(const char * x, const char * y) { return x > y ? x : y; }
 
 void TextInput::ContentView::setFont(const KDFont * font) {
   m_font = font;
@@ -16,7 +14,7 @@ void TextInput::ContentView::setFont(const KDFont * font) {
 void TextInput::ContentView::setCursorLocation(const char * location) {
   assert(location != nullptr);
   assert(location >= editedText());
-  const char * adjustedLocation = minCharPointer(location, editedText() + editedTextLength());
+  const char * adjustedLocation = std::min(location, editedText() + editedTextLength());
   m_cursorLocation = adjustedLocation;
   layoutSubviews();
 }
@@ -131,7 +129,7 @@ bool TextInput::removePreviousGlyph() {
 
 bool TextInput::setCursorLocation(const char * location) {
   assert(location != nullptr);
-  const char * adjustedLocation = maxCharPointer(location, text());
+  const char * adjustedLocation = std::max(location, text());
   willSetCursorLocation(&adjustedLocation);
   contentView()->setCursorLocation(adjustedLocation);
   scrollToCursor();

--- a/escher/src/warning_controller.cpp
+++ b/escher/src/warning_controller.cpp
@@ -1,7 +1,6 @@
 #include <escher/warning_controller.h>
 #include <escher/container.h>
-
-static inline KDCoordinate maxCoordinate(KDCoordinate x, KDCoordinate y) { return x > y ? x : y; }
+#include <algorithm>
 
 WarningController::ContentView::ContentView() :
   SolidColorView(KDColorBlack),
@@ -46,7 +45,7 @@ KDSize WarningController::ContentView::minimalSizeForOptimalDisplay() const  {
   }
   assert(numberOfSubviews() == 2);
   KDSize textSize2 = m_textView2.minimalSizeForOptimalDisplay();
-  return KDSize(maxCoordinate(textSize1.width(), textSize2.width()) + k_horizontalMargin,
+  return KDSize(std::max(textSize1.width(), textSize2.width()) + k_horizontalMargin,
       textSize1.height() + textSize2.height() + 2*k_topAndBottomMargin + k_middleMargin);
 }
 

--- a/ion/src/device/shared/drivers/internal_flash.cpp
+++ b/ion/src/device/shared/drivers/internal_flash.cpp
@@ -2,6 +2,7 @@
 #include <drivers/cache.h>
 #include <drivers/config/internal_flash.h>
 #include <assert.h>
+#include <algorithm>
 
 namespace Ion {
 namespace Device {
@@ -96,11 +97,6 @@ static inline ptrdiff_t byte_offset(void * p1, void * p2) {
   return reinterpret_cast<uint8_t *>(p2) - reinterpret_cast<uint8_t *>(p1);
 }
 
-template <typename T>
-static inline T min(T i, T j) {
-  return (i<j) ? i : j;
-}
-
 static void flash_memcpy(uint8_t * destination, uint8_t * source, size_t length) {
   /* RM0402 3.5.4
    * It is not allowed to program data to the Flash memory that would cross the
@@ -156,7 +152,7 @@ static void flash_memcpy(uint8_t * destination, uint8_t * source, size_t length)
     // Here's where source data shall start being copied in the header
     uint8_t * headerDataStart = headerStart + headerDelta;
     // And here's where it should end
-    uint8_t * headerDataEnd = min<uint8_t *>(
+    uint8_t * headerDataEnd = std::min(
       headerStart + sizeof(MemoryAccessType), // Either at the end of the header
       headerDataStart + length // or whenever src runs out of data
     );

--- a/ion/src/device/shared/usb/stack/endpoint0.cpp
+++ b/ion/src/device/shared/usb/stack/endpoint0.cpp
@@ -4,8 +4,7 @@
 #include "device.h"
 #include "interface.h"
 #include "request_recipient.h"
-
-#define MIN(a, b) ((a) < (b) ? (a) : (b))
+#include <algorithm>
 
 namespace Ion {
 namespace Device {
@@ -98,7 +97,7 @@ void Endpoint0::readAndDispatchSetupPacket() {
   };
 
   m_request = SetupPacket(m_largeBuffer);
-  uint16_t maxBufferLength = MIN(m_request.wLength(), MaxTransferSize);
+  uint16_t maxBufferLength = std::min(m_request.wLength(), MaxTransferSize);
 
   // Forward the request to the request recipient
   uint8_t type = static_cast<uint8_t>(m_request.recipientType());
@@ -261,7 +260,7 @@ void Endpoint0::clearForOutTransactions(uint16_t wLength) {
 
 int Endpoint0::receiveSomeData() {
   // If it is the first chunk of data to be received, m_transferBufferLength is 0.
-  uint16_t packetSize = MIN(k_maxPacketSize, m_request.wLength() - m_transferBufferLength);
+  uint16_t packetSize = std::min(k_maxPacketSize, m_request.wLength() - m_transferBufferLength);
   uint16_t sizeOfPacketRead = readPacket(m_largeBuffer + m_transferBufferLength, packetSize);
   if (sizeOfPacketRead != packetSize) {
     stallTransaction();
@@ -273,7 +272,7 @@ int Endpoint0::receiveSomeData() {
 
 uint16_t Endpoint0::readPacket(void * buffer, uint16_t length) {
   uint32_t * buffer32 = (uint32_t *) buffer;
-  uint16_t buffer32Length = MIN(length, m_receivedPacketSize);
+  uint16_t buffer32Length = std::min(length, m_receivedPacketSize);
 
   int i;
   // The RX FIFO is read 4 bytes by 4 bytes

--- a/ion/src/device/shared/usb/stack/endpoint0.h
+++ b/ion/src/device/shared/usb/stack/endpoint0.h
@@ -23,7 +23,7 @@ public:
   };
 
   constexpr static int k_maxPacketSize = 64;
-  constexpr static int MaxTransferSize = 2048;
+  constexpr static uint16_t MaxTransferSize = 2048;
 
   constexpr Endpoint0(RequestRecipient * device, RequestRecipient * interface) :
     m_forceNAK(false),

--- a/ion/src/shared/unicode/utf8_helper.cpp
+++ b/ion/src/shared/unicode/utf8_helper.cpp
@@ -173,7 +173,8 @@ size_t CopyUntilCodePoint(char * dst, size_t dstSize, const char * src, CodePoin
     codePointPointer = decoder.stringPosition();
     codePoint = decoder.nextCodePoint();
   }
-  size_t copySize = std::min(dstSize - 1, codePointPointer - src);
+  assert(codePointPointer >= src);
+  size_t copySize = std::min(dstSize - 1, static_cast<size_t>(codePointPointer - src));
   assert(UTF8Helper::CodePointIs(src + copySize, 0) || UTF8Helper::CodePointIs(src + copySize, c));
   memmove(dst, src, copySize);
   assert(copySize < dstSize);

--- a/ion/src/shared/unicode/utf8_helper.cpp
+++ b/ion/src/shared/unicode/utf8_helper.cpp
@@ -2,10 +2,9 @@
 #include <ion/unicode/utf8_decoder.h>
 #include <string.h>
 #include <assert.h>
+#include <algorithm>
 
 namespace UTF8Helper {
-
-static inline size_t minSizeT(size_t x, size_t y) { return x < y ? x : y; }
 
 int CountOccurrences(const char * s, CodePoint c) {
   assert(c != UCodePointNull);
@@ -174,7 +173,7 @@ size_t CopyUntilCodePoint(char * dst, size_t dstSize, const char * src, CodePoin
     codePointPointer = decoder.stringPosition();
     codePoint = decoder.nextCodePoint();
   }
-  size_t copySize = minSizeT(dstSize - 1, codePointPointer - src);
+  size_t copySize = std::min(dstSize - 1, codePointPointer - src);
   assert(UTF8Helper::CodePointIs(src + copySize, 0) || UTF8Helper::CodePointIs(src + copySize, c));
   memmove(dst, src, copySize);
   assert(copySize < dstSize);

--- a/kandinsky/src/rect.cpp
+++ b/kandinsky/src/rect.cpp
@@ -1,7 +1,5 @@
 #include <kandinsky/rect.h>
-
-static inline KDCoordinate minCoordinate(KDCoordinate x, KDCoordinate y) { return x < y ? x : y; }
-static inline KDCoordinate maxCoordinate(KDCoordinate x, KDCoordinate y) { return x > y ? x : y; }
+#include <algorithm>
 
 KDRect::KDRect(KDPoint p, KDSize s) :
   m_x(p.x()), m_y(p.y()),
@@ -38,10 +36,10 @@ KDRect KDRect::intersectedWith(const KDRect & other) const {
     return KDRectZero;
   }
 
-  KDCoordinate intersectionLeft = maxCoordinate(left(), other.left());
-  KDCoordinate intersectionRight = minCoordinate(right(), other.right());
-  KDCoordinate intersectionTop = maxCoordinate(top(), other.top());
-  KDCoordinate intersectionBottom = minCoordinate(bottom(), other.bottom());
+  KDCoordinate intersectionLeft = std::max(left(), other.left());
+  KDCoordinate intersectionRight = std::min(right(), other.right());
+  KDCoordinate intersectionTop = std::max(top(), other.top());
+  KDCoordinate intersectionBottom = std::min(bottom(), other.bottom());
 
   return KDRect(
       intersectionLeft,
@@ -57,8 +55,8 @@ void computeUnionBound(KDCoordinate size1, KDCoordinate size2,
 {
   if (size1 != 0) {
     if (size2 != 0) {
-      *outputMin = minCoordinate(min1, min2);
-      *outputMax = maxCoordinate(max1, max2);
+      *outputMin = std::min(min1, min2);
+      *outputMax = std::max(max1, max2);
     } else {
       *outputMin = min1;
       *outputMax = max1;

--- a/libaxx/include/algorithm
+++ b/libaxx/include/algorithm
@@ -1,0 +1,18 @@
+#ifndef LIBAXX_ALGORITHM
+#define LIBAXX_ALGORITHM
+
+namespace std {
+
+template<class T>
+inline const T & min(const T & a, const T & b ) {
+  return (b < a) ? b : a;
+}
+
+template<class T>
+inline const T & max(const T & a, const T & b ) {
+  return (b > a) ? b : a;
+}
+
+}
+
+#endif

--- a/poincare/src/binomial_coefficient_layout.cpp
+++ b/poincare/src/binomial_coefficient_layout.cpp
@@ -4,10 +4,9 @@
 #include <poincare/right_parenthesis_layout.h>
 #include <poincare/layout_helper.h>
 #include <assert.h>
+#include <algorithm>
 
 namespace Poincare {
-
-static inline KDCoordinate maxCoordinate(KDCoordinate x, KDCoordinate y) { return x > y ? x : y; }
 
 void BinomialCoefficientLayoutNode::moveCursorLeft(LayoutCursor * cursor, bool * shouldRecomputeLayout, bool forSelection) {
   if (cursor->position() == LayoutCursor::Position::Left
@@ -79,7 +78,7 @@ int BinomialCoefficientLayoutNode::serialize(char * buffer, int bufferSize, Pref
 
 KDSize BinomialCoefficientLayoutNode::computeSize() {
   KDSize coefficientsSize = KDSize(
-      maxCoordinate(nLayout()->layoutSize().width(), kLayout()->layoutSize().width()),
+      std::max(nLayout()->layoutSize().width(), kLayout()->layoutSize().width()),
       knHeight());
   KDCoordinate width = coefficientsSize.width() + 2*ParenthesisLayoutNode::ParenthesisWidth();
   return KDSize(width, coefficientsSize.height());
@@ -90,7 +89,7 @@ KDCoordinate BinomialCoefficientLayoutNode::computeBaseline() {
 }
 
 KDPoint BinomialCoefficientLayoutNode::positionOfChild(LayoutNode * child) {
-  KDCoordinate horizontalCenter = ParenthesisLayoutNode::ParenthesisWidth() + maxCoordinate(nLayout()->layoutSize().width(), kLayout()->layoutSize().width())/2;
+  KDCoordinate horizontalCenter = ParenthesisLayoutNode::ParenthesisWidth() + std::max(nLayout()->layoutSize().width(), kLayout()->layoutSize().width())/2;
   if (child == nLayout()) {
     return KDPoint(horizontalCenter - nLayout()->layoutSize().width()/2, 0);
   }
@@ -101,7 +100,7 @@ KDPoint BinomialCoefficientLayoutNode::positionOfChild(LayoutNode * child) {
 void BinomialCoefficientLayoutNode::render(KDContext * ctx, KDPoint p, KDColor expressionColor, KDColor backgroundColor, Layout * selectionStart, Layout * selectionEnd, KDColor selectionColor) {
   // Render the parentheses.
   KDCoordinate childHeight = knHeight();
-  KDCoordinate rightParenthesisPointX = maxCoordinate(nLayout()->layoutSize().width(), kLayout()->layoutSize().width()) + LeftParenthesisLayoutNode::ParenthesisWidth();
+  KDCoordinate rightParenthesisPointX = std::max(nLayout()->layoutSize().width(), kLayout()->layoutSize().width()) + LeftParenthesisLayoutNode::ParenthesisWidth();
   LeftParenthesisLayoutNode::RenderWithChildHeight(childHeight, ctx, p, expressionColor, backgroundColor);
   RightParenthesisLayoutNode::RenderWithChildHeight(childHeight, ctx, p.translatedBy(KDPoint(rightParenthesisPointX, 0)), expressionColor, backgroundColor);
 }

--- a/poincare/src/bracket_layout.cpp
+++ b/poincare/src/bracket_layout.cpp
@@ -137,10 +137,10 @@ KDCoordinate BracketLayoutNode::computeChildHeight() {
     }
     KDCoordinate siblingHeight = sibling->layoutSize().height();
     KDCoordinate siblingBaseline = sibling->baseline();
-    maxUnderBaseline = std::max(maxUnderBaseline, siblingHeight - siblingBaseline);
+    maxUnderBaseline = std::max<KDCoordinate>(maxUnderBaseline, siblingHeight - siblingBaseline);
     maxAboveBaseline = std::max(maxAboveBaseline, siblingBaseline);
   }
-  return std::max(result, maxUnderBaseline + maxAboveBaseline);
+  return std::max<KDCoordinate>(result, maxUnderBaseline + maxAboveBaseline);
 }
 
 KDPoint BracketLayoutNode::positionOfChild(LayoutNode * child) {

--- a/poincare/src/bracket_layout.cpp
+++ b/poincare/src/bracket_layout.cpp
@@ -2,10 +2,9 @@
 #include <escher/metric.h>
 #include <assert.h>
 #include <stdlib.h>
+#include <algorithm>
 
 namespace Poincare {
-
-static inline KDCoordinate maxCoordinate(KDCoordinate x, KDCoordinate y) { return x > y ? x : y; }
 
 void BracketLayoutNode::moveCursorLeft(LayoutCursor * cursor, bool * shouldRecomputeLayout, bool forSelection) {
   assert(cursor->layoutNode() == this);
@@ -84,7 +83,7 @@ KDCoordinate BracketLayoutNode::computeBaseline() {
     {
       currentNumberOfOpenBrackets++;
     }
-    result = maxCoordinate(result, sibling->baseline());
+    result = std::max(result, sibling->baseline());
   }
   return result + (layoutSize().height() - childHeight()) / 2;
 }
@@ -138,10 +137,10 @@ KDCoordinate BracketLayoutNode::computeChildHeight() {
     }
     KDCoordinate siblingHeight = sibling->layoutSize().height();
     KDCoordinate siblingBaseline = sibling->baseline();
-    maxUnderBaseline = maxCoordinate(maxUnderBaseline, siblingHeight - siblingBaseline);
-    maxAboveBaseline = maxCoordinate(maxAboveBaseline, siblingBaseline);
+    maxUnderBaseline = std::max(maxUnderBaseline, siblingHeight - siblingBaseline);
+    maxAboveBaseline = std::max(maxAboveBaseline, siblingBaseline);
   }
-  return maxCoordinate(result, maxUnderBaseline + maxAboveBaseline);
+  return std::max(result, maxUnderBaseline + maxAboveBaseline);
 }
 
 KDPoint BracketLayoutNode::positionOfChild(LayoutNode * child) {

--- a/poincare/src/condensed_sum_layout.cpp
+++ b/poincare/src/condensed_sum_layout.cpp
@@ -14,7 +14,7 @@ KDSize CondensedSumLayoutNode::computeSize() {
   KDSize subscriptSize = subscriptLayout()->layoutSize();
   KDSize superscriptSize = superscriptLayout()->layoutSize();
   KDCoordinate sizeWidth = baseSize.width() + std::max(subscriptSize.width(), superscriptSize.width());
-  KDCoordinate sizeHeight = std::max(baseSize.height()/2, subscriptSize.height()) + std::max(baseSize.height()/2, superscriptSize.height());
+  KDCoordinate sizeHeight = std::max<KDCoordinate>(baseSize.height()/2, subscriptSize.height()) + std::max<KDCoordinate>(baseSize.height()/2, superscriptSize.height());
   return KDSize(sizeWidth, sizeHeight);
 }
 
@@ -28,7 +28,7 @@ KDPoint CondensedSumLayoutNode::positionOfChild(LayoutNode * child) {
   }
   if (child == subscriptLayout()) {
     x = baseSize.width();
-    y = std::max(baseSize.height()/2, superscriptSize.height());
+    y = std::max<KDCoordinate>(baseSize.height()/2, superscriptSize.height());
   }
   if (child == superscriptLayout()) {
     x = baseSize.width();

--- a/poincare/src/condensed_sum_layout.cpp
+++ b/poincare/src/condensed_sum_layout.cpp
@@ -1,21 +1,20 @@
 #include <poincare/condensed_sum_layout.h>
 #include <string.h>
 #include <assert.h>
+#include <algorithm>
 
 namespace Poincare {
 
-static inline KDCoordinate maxCoordinate(KDCoordinate x, KDCoordinate y) { return x > y ? x : y; }
-
 KDCoordinate CondensedSumLayoutNode::computeBaseline() {
-  return baseLayout()->baseline() + maxCoordinate(0, superscriptLayout()->layoutSize().height() - baseLayout()->layoutSize().height()/2);
+  return baseLayout()->baseline() + std::max(0, superscriptLayout()->layoutSize().height() - baseLayout()->layoutSize().height()/2);
 }
 
 KDSize CondensedSumLayoutNode::computeSize() {
   KDSize baseSize = baseLayout()->layoutSize();
   KDSize subscriptSize = subscriptLayout()->layoutSize();
   KDSize superscriptSize = superscriptLayout()->layoutSize();
-  KDCoordinate sizeWidth = baseSize.width() + maxCoordinate(subscriptSize.width(), superscriptSize.width());
-  KDCoordinate sizeHeight = maxCoordinate(baseSize.height()/2, subscriptSize.height()) + maxCoordinate(baseSize.height()/2, superscriptSize.height());
+  KDCoordinate sizeWidth = baseSize.width() + std::max(subscriptSize.width(), superscriptSize.width());
+  KDCoordinate sizeHeight = std::max(baseSize.height()/2, subscriptSize.height()) + std::max(baseSize.height()/2, superscriptSize.height());
   return KDSize(sizeWidth, sizeHeight);
 }
 
@@ -25,11 +24,11 @@ KDPoint CondensedSumLayoutNode::positionOfChild(LayoutNode * child) {
   KDSize baseSize = baseLayout()->layoutSize();
   KDSize superscriptSize = superscriptLayout()->layoutSize();
   if (child == baseLayout()) {
-    y = maxCoordinate(0, superscriptSize.height() - baseSize.height()/2);
+    y = std::max(0, superscriptSize.height() - baseSize.height()/2);
   }
   if (child == subscriptLayout()) {
     x = baseSize.width();
-    y = maxCoordinate(baseSize.height()/2, superscriptSize.height());
+    y = std::max(baseSize.height()/2, superscriptSize.height());
   }
   if (child == superscriptLayout()) {
     x = baseSize.width();

--- a/poincare/src/decimal.cpp
+++ b/poincare/src/decimal.cpp
@@ -11,11 +11,9 @@
 #include <assert.h>
 #include <cmath>
 #include <utility>
+#include <algorithm>
 
 namespace Poincare {
-
-static inline int maxInt(int x, int y) { return x > y ? x : y; }
-static inline int minInt(int x, int y) { return x < y ? x : y; }
 
 void removeZeroAtTheEnd(Integer * i, int minimalNumbersOfDigits = -1) {
   /* Remove the zeroes at the end of an integer, respecting the minimum number
@@ -204,7 +202,7 @@ int DecimalNode::convertToText(char * buffer, int bufferSize, Preferences::Print
   // Stop here if m is undef
   if (strcmp(tempBuffer, Undefined::Name()) == 0) {
     currentChar += strlcpy(buffer+currentChar, tempBuffer, bufferSize-currentChar);
-    return minInt(currentChar, bufferSize-1);
+    return std::min(currentChar, bufferSize-1);
   }
 
   /* We force scientific mode if the number of digits before the dot is superior
@@ -216,7 +214,7 @@ int DecimalNode::convertToText(char * buffer, int bufferSize, Preferences::Print
     if (exponent < 0) {
       numberOfRequiredDigits = mantissaLength-exponent;
     } else {
-      numberOfRequiredDigits = maxInt(mantissaLength, exponent);
+      numberOfRequiredDigits = std::max(mantissaLength, exponent);
     }
   }
 
@@ -269,7 +267,7 @@ int DecimalNode::convertToText(char * buffer, int bufferSize, Preferences::Print
   assert(UTF8Decoder::CharSizeOfCodePoint('.') == 1);
   assert(UTF8Decoder::CharSizeOfCodePoint('0') == 1);
   int deltaCharMantissa = exponent < 0 ? -exponent+1 : 0;
-  strlcpy(buffer+currentChar+deltaCharMantissa, tempBuffer, maxInt(0, bufferSize-deltaCharMantissa-currentChar));
+  strlcpy(buffer+currentChar+deltaCharMantissa, tempBuffer, std::max(0, bufferSize-deltaCharMantissa-currentChar));
   if (exponent < 0) {
     for (int i = 0; i <= -exponent; i++) {
       buffer[currentChar++] = i == 1 ? '.' : '0';

--- a/poincare/src/fraction_layout.cpp
+++ b/poincare/src/fraction_layout.cpp
@@ -5,10 +5,9 @@
 #include <poincare/serialization_helper.h>
 #include <escher/metric.h>
 #include <assert.h>
+#include <algorithm>
 
 namespace Poincare {
-
-static inline KDCoordinate maxCoordinate(KDCoordinate x, KDCoordinate y) { return x > y ? x : y; }
 
 void FractionLayoutNode::moveCursorLeft(LayoutCursor * cursor, bool * shouldRecomputeLayout, bool forSelection) {
    if (cursor->position() == LayoutCursor::Position::Left
@@ -170,7 +169,7 @@ void FractionLayoutNode::didCollapseSiblings(LayoutCursor * cursor) {
 }
 
 KDSize FractionLayoutNode::computeSize() {
-  KDCoordinate width = maxCoordinate(numeratorLayout()->layoutSize().width(), denominatorLayout()->layoutSize().width())
+  KDCoordinate width = std::max(numeratorLayout()->layoutSize().width(), denominatorLayout()->layoutSize().width())
     + 2*Metric::FractionAndConjugateHorizontalOverflow+2*Metric::FractionAndConjugateHorizontalMargin;
   KDCoordinate height = numeratorLayout()->layoutSize().height()
     + k_fractionLineMargin + k_fractionLineHeight + k_fractionLineMargin

--- a/poincare/src/grid_layout.cpp
+++ b/poincare/src/grid_layout.cpp
@@ -233,7 +233,7 @@ KDCoordinate GridLayoutNode::rowHeight(int i) const {
   int j = 0;
   for (LayoutNode * l : const_cast<GridLayoutNode *>(this)->childrenFromIndex(i*m_numberOfColumns)) {
     KDCoordinate b = l->baseline();
-    underBaseline = std::max(underBaseline, l->layoutSize().height() - b);
+    underBaseline = std::max<KDCoordinate>(underBaseline, l->layoutSize().height() - b);
     aboveBaseline = std::max(aboveBaseline, b);
     j++;
     if (j >= m_numberOfColumns) {

--- a/poincare/src/grid_layout.cpp
+++ b/poincare/src/grid_layout.cpp
@@ -1,10 +1,9 @@
 #include <poincare/grid_layout.h>
 #include <poincare/empty_layout.h>
 #include <poincare/layout_helper.h>
+#include <algorithm>
 
 namespace Poincare {
-
-static inline KDCoordinate maxCoordinate(KDCoordinate x, KDCoordinate y) { return x > y ? x : y; }
 
 // LayoutNode
 
@@ -219,7 +218,7 @@ KDCoordinate GridLayoutNode::rowBaseline(int i) {
   KDCoordinate rowBaseline = 0;
   int j = 0;
   for (LayoutNode * l : childrenFromIndex(i*m_numberOfColumns)) {
-    rowBaseline = maxCoordinate(rowBaseline, l->baseline());
+    rowBaseline = std::max(rowBaseline, l->baseline());
     j++;
     if (j >= m_numberOfColumns) {
       break;
@@ -234,8 +233,8 @@ KDCoordinate GridLayoutNode::rowHeight(int i) const {
   int j = 0;
   for (LayoutNode * l : const_cast<GridLayoutNode *>(this)->childrenFromIndex(i*m_numberOfColumns)) {
     KDCoordinate b = l->baseline();
-    underBaseline = maxCoordinate(underBaseline, l->layoutSize().height() - b);
-    aboveBaseline = maxCoordinate(aboveBaseline, b);
+    underBaseline = std::max(underBaseline, l->layoutSize().height() - b);
+    aboveBaseline = std::max(aboveBaseline, b);
     j++;
     if (j >= m_numberOfColumns) {
       break;
@@ -259,7 +258,7 @@ KDCoordinate GridLayoutNode::columnWidth(int j) const {
   int lastIndex = (m_numberOfRows-1)*m_numberOfColumns + j;
   for (LayoutNode * l : const_cast<GridLayoutNode *>(this)->childrenFromIndex(j)) {
     if (childIndex%m_numberOfColumns == j) {
-      columnWidth = maxCoordinate(columnWidth, l->layoutSize().width());
+      columnWidth = std::max(columnWidth, l->layoutSize().width());
       if (childIndex >= lastIndex) {
         break;
       }

--- a/poincare/src/horizontal_layout.cpp
+++ b/poincare/src/horizontal_layout.cpp
@@ -258,7 +258,7 @@ KDSize HorizontalLayoutNode::computeSize() {
   for (LayoutNode * l : children()) {
     KDSize childSize = l->layoutSize();
     totalWidth += childSize.width();
-    maxUnderBaseline = std::max(maxUnderBaseline, childSize.height() - l->baseline());
+    maxUnderBaseline = std::max<KDCoordinate>(maxUnderBaseline, childSize.height() - l->baseline());
     maxAboveBaseline = std::max(maxAboveBaseline, l->baseline());
   }
   return KDSize(totalWidth, maxUnderBaseline + maxAboveBaseline);
@@ -310,7 +310,7 @@ KDRect HorizontalLayoutNode::relativeSelectionRect(const Layout * selectionStart
   for (int i = firstSelectedNodeIndex; i <= secondSelectedNodeIndex; i++) {
     Layout childi = thisLayout.childAtIndex(i);
     KDSize childSize = childi.layoutSize();
-    maxUnderBaseline = std::max(maxUnderBaseline, childSize.height() - childi.baseline());
+    maxUnderBaseline = std::max<KDCoordinate>(maxUnderBaseline, childSize.height() - childi.baseline());
     maxAboveBaseline = std::max(maxAboveBaseline, childi.baseline());
   }
   return KDRect(KDPoint(selectionXStart, const_cast<HorizontalLayoutNode *>(this)->baseline() - maxAboveBaseline), KDSize(drawWidth, maxUnderBaseline + maxAboveBaseline));

--- a/poincare/src/horizontal_layout.cpp
+++ b/poincare/src/horizontal_layout.cpp
@@ -3,10 +3,9 @@
 #include <poincare/layout_helper.h>
 #include <poincare/nth_root_layout.h>
 #include <poincare/serialization_helper.h>
+#include <algorithm>
 
 namespace Poincare {
-
-static inline KDCoordinate maxCoordinate(KDCoordinate c1, KDCoordinate c2) { return c1 > c2 ? c1 : c2; }
 
 // LayoutNode
 
@@ -259,8 +258,8 @@ KDSize HorizontalLayoutNode::computeSize() {
   for (LayoutNode * l : children()) {
     KDSize childSize = l->layoutSize();
     totalWidth += childSize.width();
-    maxUnderBaseline = maxCoordinate(maxUnderBaseline, childSize.height() - l->baseline());
-    maxAboveBaseline = maxCoordinate(maxAboveBaseline, l->baseline());
+    maxUnderBaseline = std::max(maxUnderBaseline, childSize.height() - l->baseline());
+    maxAboveBaseline = std::max(maxAboveBaseline, l->baseline());
   }
   return KDSize(totalWidth, maxUnderBaseline + maxAboveBaseline);
 }
@@ -268,7 +267,7 @@ KDSize HorizontalLayoutNode::computeSize() {
 KDCoordinate HorizontalLayoutNode::computeBaseline() {
   KDCoordinate result = 0;
   for (LayoutNode * l : children()) {
-    result = maxCoordinate(result, l->baseline());
+    result = std::max(result, l->baseline());
   }
   return result;
 }
@@ -311,8 +310,8 @@ KDRect HorizontalLayoutNode::relativeSelectionRect(const Layout * selectionStart
   for (int i = firstSelectedNodeIndex; i <= secondSelectedNodeIndex; i++) {
     Layout childi = thisLayout.childAtIndex(i);
     KDSize childSize = childi.layoutSize();
-    maxUnderBaseline = maxCoordinate(maxUnderBaseline, childSize.height() - childi.baseline());
-    maxAboveBaseline = maxCoordinate(maxAboveBaseline, childi.baseline());
+    maxUnderBaseline = std::max(maxUnderBaseline, childSize.height() - childi.baseline());
+    maxAboveBaseline = std::max(maxAboveBaseline, childi.baseline());
   }
   return KDRect(KDPoint(selectionXStart, const_cast<HorizontalLayoutNode *>(this)->baseline() - maxAboveBaseline), KDSize(drawWidth, maxUnderBaseline + maxAboveBaseline));
 }

--- a/poincare/src/integer.cpp
+++ b/poincare/src/integer.cpp
@@ -575,7 +575,7 @@ Integer Integer::usum(const Integer & a, const Integer & b, bool subtract, bool 
       carry = (aDigit > result) || (bDigit > result); // There's been an overflow
     }
   }
-  size = std::min(size, k_maxNumberOfDigits+oneDigitOverflow);
+  size = std::min<int>(size, k_maxNumberOfDigits+oneDigitOverflow);
   while (size>0 && s_workingBuffer[size-1] == 0) {
     size--;
   }

--- a/poincare/src/integral_layout.cpp
+++ b/poincare/src/integral_layout.cpp
@@ -4,10 +4,9 @@
 #include <poincare/serialization_helper.h>
 #include <string.h>
 #include <assert.h>
+#include <algorithm>
 
 namespace Poincare {
-
-static inline KDCoordinate maxCoordinate(KDCoordinate x, KDCoordinate y) { return x > y ? x : y; }
 
 const uint8_t topSymbolPixel[IntegralLayoutNode::k_symbolHeight][IntegralLayoutNode::k_symbolWidth] = {
   {0x00, 0x00, 0xFF, 0xFF},
@@ -215,14 +214,14 @@ KDSize IntegralLayoutNode::computeSize() {
   KDSize differentialSize = differentialLayout()->layoutSize();
   KDSize lowerBoundSize = lowerBoundLayout()->layoutSize();
   KDSize upperBoundSize = upperBoundLayout()->layoutSize();
-  KDCoordinate width = k_symbolWidth+k_lineThickness+k_boundWidthMargin+maxCoordinate(lowerBoundSize.width(), upperBoundSize.width())+k_integrandWidthMargin+integrandSize.width()+2*k_differentialWidthMargin+dSize.width()+differentialSize.width();
+  KDCoordinate width = k_symbolWidth+k_lineThickness+k_boundWidthMargin+std::max(lowerBoundSize.width(), upperBoundSize.width())+k_integrandWidthMargin+integrandSize.width()+2*k_differentialWidthMargin+dSize.width()+differentialSize.width();
   KDCoordinate baseline = computeBaseline();
-  KDCoordinate height = baseline + k_integrandHeigthMargin+maxCoordinate(integrandSize.height()-integrandLayout()->baseline(), differentialSize.height()-differentialLayout()->baseline())+lowerBoundSize.height();
+  KDCoordinate height = baseline + k_integrandHeigthMargin+std::max(integrandSize.height()-integrandLayout()->baseline(), differentialSize.height()-differentialLayout()->baseline())+lowerBoundSize.height();
   return KDSize(width, height);
 }
 
 KDCoordinate IntegralLayoutNode::computeBaseline() {
-  return upperBoundLayout()->layoutSize().height() + k_integrandHeigthMargin + maxCoordinate(integrandLayout()->baseline(), differentialLayout()->baseline());
+  return upperBoundLayout()->layoutSize().height() + k_integrandHeigthMargin + std::max(integrandLayout()->baseline(), differentialLayout()->baseline());
 }
 
 KDPoint IntegralLayoutNode::positionOfChild(LayoutNode * child) {
@@ -237,7 +236,7 @@ KDPoint IntegralLayoutNode::positionOfChild(LayoutNode * child) {
     x = k_symbolWidth+k_lineThickness+k_boundWidthMargin;;
     y = 0;
   } else if (child == integrandLayout()) {
-    x = k_symbolWidth +k_lineThickness+ k_boundWidthMargin+maxCoordinate(lowerBoundSize.width(), upperBoundSize.width())+k_integrandWidthMargin;
+    x = k_symbolWidth +k_lineThickness+ k_boundWidthMargin+std::max(lowerBoundSize.width(), upperBoundSize.width())+k_integrandWidthMargin;
     y = computeBaseline()-integrandLayout()->baseline();
   } else if (child == differentialLayout()) {
     x = computeSize().width() - k_differentialWidthMargin - differentialLayout()->layoutSize().width();
@@ -252,7 +251,7 @@ void IntegralLayoutNode::render(KDContext * ctx, KDPoint p, KDColor expressionCo
   KDSize integrandSize = integrandLayout()->layoutSize();
   KDSize differentialSize = differentialLayout()->layoutSize();
   KDSize upperBoundSize = upperBoundLayout()->layoutSize();
-  KDCoordinate centralArgumentHeight =  maxCoordinate(integrandLayout()->baseline(), differentialLayout()->baseline()) + maxCoordinate(integrandSize.height()-integrandLayout()->baseline(), differentialSize.height()-differentialLayout()->baseline());
+  KDCoordinate centralArgumentHeight =  std::max(integrandLayout()->baseline(), differentialLayout()->baseline()) + std::max(integrandSize.height()-integrandLayout()->baseline(), differentialSize.height()-differentialLayout()->baseline());
 
   KDColor workingBuffer[k_symbolWidth*k_symbolHeight];
 

--- a/poincare/src/layout_cursor.cpp
+++ b/poincare/src/layout_cursor.cpp
@@ -10,13 +10,12 @@
 #include <poincare/right_parenthesis_layout.h>
 #include <poincare/vertical_offset_layout.h>
 #include <ion/unicode/utf8_decoder.h>
+#include <algorithm>
 #include <stdio.h>
 
 namespace Poincare {
 
 /* Getters and setters */
-
-static inline KDCoordinate maxCoordinate(KDCoordinate x, KDCoordinate y) { return x > y ? x : y; }
 
 KDCoordinate LayoutCursor::cursorHeightWithoutSelection() {
   KDCoordinate height = layoutHeight();
@@ -35,7 +34,7 @@ KDCoordinate LayoutCursor::baselineWithoutSelection() {
   if (m_layout.hasChild(equivalentLayout)) {
     return equivalentLayout.baseline();
   } else if (m_layout.hasSibling(equivalentLayout)) {
-    return maxCoordinate(layoutBaseline, equivalentLayout.baseline());
+    return std::max(layoutBaseline, equivalentLayout.baseline());
   }
   return layoutBaseline;
 }
@@ -233,8 +232,8 @@ KDCoordinate LayoutCursor::layoutHeight() {
     KDCoordinate equivalentLayoutHeight = equivalentLayout.layoutSize().height();
     KDCoordinate pointedLayoutBaseline = m_layout.baseline();
     KDCoordinate equivalentLayoutBaseline = equivalentLayout.baseline();
-    return maxCoordinate(pointedLayoutBaseline, equivalentLayoutBaseline)
-      + maxCoordinate(pointedLayoutHeight - pointedLayoutBaseline, equivalentLayoutHeight - equivalentLayoutBaseline);
+    return std::max(pointedLayoutBaseline, equivalentLayoutBaseline)
+      + std::max(pointedLayoutHeight - pointedLayoutBaseline, equivalentLayoutHeight - equivalentLayoutBaseline);
   }
   return pointedLayoutHeight;
 }

--- a/poincare/src/layout_cursor.cpp
+++ b/poincare/src/layout_cursor.cpp
@@ -11,7 +11,6 @@
 #include <poincare/vertical_offset_layout.h>
 #include <ion/unicode/utf8_decoder.h>
 #include <algorithm>
-#include <stdio.h>
 
 namespace Poincare {
 

--- a/poincare/src/matrix.cpp
+++ b/poincare/src/matrix.cpp
@@ -15,10 +15,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <utility>
+#include <algorithm>
 
 namespace Poincare {
-
-static inline int minInt(int x, int y) { return x < y ? x : y; }
 
 bool MatrixNode::hasMatrixChild(Context * context) const {
   for (ExpressionNode * c : children()) {
@@ -93,7 +92,7 @@ int MatrixNode::serialize(char * buffer, int bufferSize, Preferences::PrintFloat
     }
   }
   currentChar += SerializationHelper::CodePoint(buffer + currentChar, bufferSize - currentChar, ']');
-  return minInt(currentChar, bufferSize-1);
+  return std::min(currentChar, bufferSize-1);
 }
 
 template<typename T>

--- a/poincare/src/matrix_layout.cpp
+++ b/poincare/src/matrix_layout.cpp
@@ -4,10 +4,9 @@
 #include <poincare/layout_helper.h>
 #include <poincare/serialization_helper.h>
 #include <poincare/square_bracket_layout.h>
+#include <algorithm>
 
 namespace Poincare {
-
-static inline int minInt(int x, int y) { return x < y ? x : y; }
 
 // MatrixLayoutNode
 
@@ -164,7 +163,7 @@ int MatrixLayoutNode::serialize(char * buffer, int bufferSize, Preferences::Prin
 
   // Write the final closing bracket
   numberOfChar += SerializationHelper::CodePoint(buffer + numberOfChar, bufferSize - numberOfChar, ']');
-  return minInt(numberOfChar, bufferSize-1);
+  return std::min(numberOfChar, bufferSize-1);
 }
 
 // Protected

--- a/poincare/src/multiplication.cpp
+++ b/poincare/src/multiplication.cpp
@@ -19,6 +19,7 @@
 #include <assert.h>
 #include <cmath>
 #include <utility>
+#include <algorithm>
 
 namespace Poincare {
 
@@ -89,8 +90,6 @@ Expression MultiplicationNode::setSign(Sign s, ReductionContext reductionContext
   assert(s == ExpressionNode::Sign::Positive);
   return Multiplication(this).setSign(s, reductionContext);
 }
-
-static inline int maxInt(int x, int y) { return x > y ? x : y; }
 
 /* Operative symbol between two expressions depends on the layout shape on the
  * left and the right of the operator:
@@ -181,7 +180,7 @@ CodePoint MultiplicationNode::operatorSymbol() const {
   for (int i = 0; i < numberOfChildren() - 1; i++) {
     /* The operator symbol must be the same for all operands of the multiplication.
      * If one operator has to be '×', they will all be '×'. Idem for '·'. */
-    sign = maxInt(sign, operatorSymbolBetween(childAtIndex(i)->rightLayoutShape(), childAtIndex(i+1)->leftLayoutShape()));
+    sign = std::max(sign, operatorSymbolBetween(childAtIndex(i)->rightLayoutShape(), childAtIndex(i+1)->leftLayoutShape()));
   }
   switch (sign) {
     case 0:

--- a/poincare/src/nth_root_layout.cpp
+++ b/poincare/src/nth_root_layout.cpp
@@ -179,7 +179,7 @@ KDSize NthRootLayoutNode::computeSize() {
 }
 
 KDCoordinate NthRootLayoutNode::computeBaseline() {
-  return std::max(
+  return std::max<KDCoordinate>(
       radicandLayout()->baseline() + k_radixLineThickness + k_heightMargin,
       adjustedIndexSize().height());
 }

--- a/poincare/src/nth_root_layout.cpp
+++ b/poincare/src/nth_root_layout.cpp
@@ -4,10 +4,9 @@
 #include <poincare/layout_helper.h>
 #include <poincare/serialization_helper.h>
 #include <assert.h>
+#include <algorithm>
 
 namespace Poincare {
-
-static inline KDCoordinate maxCoordinate(KDCoordinate x, KDCoordinate y) { return x > y ? x : y; }
 
 const uint8_t radixPixel[NthRootLayoutNode::k_leftRadixHeight][NthRootLayoutNode::k_leftRadixWidth] = {
 {0x51, 0xCC, 0xFF, 0xFF, 0xFF},
@@ -180,7 +179,7 @@ KDSize NthRootLayoutNode::computeSize() {
 }
 
 KDCoordinate NthRootLayoutNode::computeBaseline() {
-  return maxCoordinate(
+  return std::max(
       radicandLayout()->baseline() + k_radixLineThickness + k_heightMargin,
       adjustedIndexSize().height());
 }
@@ -204,7 +203,7 @@ KDPoint NthRootLayoutNode::positionOfChild(LayoutNode * child) {
 KDSize NthRootLayoutNode::adjustedIndexSize() {
   return indexLayout() == nullptr ?
     KDSize(k_leftRadixWidth, 0) :
-    KDSize(maxCoordinate(k_leftRadixWidth, indexLayout()->layoutSize().width()), indexLayout()->layoutSize().height());
+    KDSize(std::max(k_leftRadixWidth, indexLayout()->layoutSize().width()), indexLayout()->layoutSize().height());
 }
 
 void NthRootLayoutNode::render(KDContext * ctx, KDPoint p, KDColor expressionColor, KDColor backgroundColor, Layout * selectionStart, Layout * selectionEnd, KDColor selectionColor) {

--- a/poincare/src/parsing/parser.cpp
+++ b/poincare/src/parsing/parser.cpp
@@ -1,10 +1,9 @@
 #include "parser.h"
 #include <ion/unicode/utf8_decoder.h>
 #include <utility>
+#include <algorithm>
 
 namespace Poincare {
-
-static inline Token::Type maxToken(Token::Type x, Token::Type y) { return ((int)x > (int) y ? x : y); }
 
 constexpr const Expression::FunctionHelper * Parser::s_reservedFunctions[];
 
@@ -185,7 +184,7 @@ void Parser::parseEmpty(Expression & leftHandSide, Token::Type stoppingType) {
 
 void Parser::parseMinus(Expression & leftHandSide, Token::Type stoppingType) {
   if (leftHandSide.isUninitialized()) {
-    Expression rightHandSide = parseUntil(maxToken(stoppingType, Token::Minus));
+    Expression rightHandSide = parseUntil(std::max(stoppingType, Token::Minus));
     if (m_status != Status::Progress) {
       return;
     }

--- a/poincare/src/print_float.cpp
+++ b/poincare/src/print_float.cpp
@@ -15,10 +15,9 @@ extern "C" {
 #include <limits.h>
 }
 #include <cmath>
+#include <algorithm>
 
 namespace Poincare {
-
-static inline int minInt(int x, int y) { return x < y ? x : y; }
 
 PrintFloat::Long::Long(int64_t i) :
   m_negative(i < 0)
@@ -79,7 +78,7 @@ int PrintFloat::Long::serialize(char * buffer, int bufferSize) const {
        * terminating char. */
       return wantedNumberOfChars;
     }
-    numberOfChars+= PrintInt::Right(m_digits[1], buffer + numberOfChars, minInt(k_maxNumberOfCharsForDigit, bufferSize - numberOfChars - 1));
+    numberOfChars+= PrintInt::Right(m_digits[1], buffer + numberOfChars, std::min(k_maxNumberOfCharsForDigit, bufferSize - numberOfChars - 1));
   } else {
     numberOfChars+= PrintInt::Left(m_digits[1], buffer + numberOfChars, bufferSize - numberOfChars - 1);
   }
@@ -167,7 +166,7 @@ PrintFloat::TextLengths PrintFloat::ConvertFloatToTextPrivate(T f, char * buffer
   assert(numberOfSignificantDigits > 0);
   assert(bufferSize > 0);
   assert(glyphLength > 0 && glyphLength <= k_maxFloatGlyphLength);
-  int availableCharLength = minInt(bufferSize-1, glyphLength);
+  int availableCharLength = std::min(bufferSize-1, glyphLength);
   TextLengths exceptionResult = {.CharLength = bufferSize, .GlyphLength = glyphLength+1};
   //TODO: accelerate for f between 0 and 10 ?
   if (std::isinf(f)) {

--- a/poincare/src/product_layout.cpp
+++ b/poincare/src/product_layout.cpp
@@ -1,10 +1,9 @@
 #include <poincare/product_layout.h>
 #include <poincare/code_point_layout.h>
 #include <poincare/horizontal_layout.h>
+#include <algorithm>
 
 namespace Poincare {
-
-static inline KDCoordinate maxCoordinate(KDCoordinate x, KDCoordinate y) { return x > y ? x : y; }
 
 int ProductLayoutNode::serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const {
   return SequenceLayoutNode::writeDerivedClassInBuffer("product", buffer, bufferSize, floatDisplayMode, numberOfSignificantDigits);
@@ -16,14 +15,14 @@ void ProductLayoutNode::render(KDContext * ctx, KDPoint p, KDColor expressionCol
   KDSize lowerBoundNEqualsSize = lowerBoundSizeWithVariableEquals();
 
   // Render the Product symbol.
-  ctx->fillRect(KDRect(p.x() + maxCoordinate(maxCoordinate(0, (upperBoundSize.width()-k_symbolWidth)/2), (lowerBoundNEqualsSize.width()-k_symbolWidth)/2),
-    p.y() + maxCoordinate(upperBoundSize.height()+k_boundHeightMargin, argumentLayout()->baseline()-(k_symbolHeight+1)/2),
+  ctx->fillRect(KDRect(p.x() + std::max(std::max(0, (upperBoundSize.width()-k_symbolWidth)/2), (lowerBoundNEqualsSize.width()-k_symbolWidth)/2),
+    p.y() + std::max(upperBoundSize.height()+k_boundHeightMargin, argumentLayout()->baseline()-(k_symbolHeight+1)/2),
     k_lineThickness, k_symbolHeight), expressionColor);
-  ctx->fillRect(KDRect(p.x() + maxCoordinate(maxCoordinate(0, (upperBoundSize.width()-k_symbolWidth)/2), (lowerBoundNEqualsSize.width()-k_symbolWidth)/2),
-    p.y() + maxCoordinate(upperBoundSize.height()+k_boundHeightMargin, argumentLayout()->baseline()-(k_symbolHeight+1)/2),
+  ctx->fillRect(KDRect(p.x() + std::max(std::max(0, (upperBoundSize.width()-k_symbolWidth)/2), (lowerBoundNEqualsSize.width()-k_symbolWidth)/2),
+    p.y() + std::max(upperBoundSize.height()+k_boundHeightMargin, argumentLayout()->baseline()-(k_symbolHeight+1)/2),
     k_symbolWidth, k_lineThickness), expressionColor);
-  ctx->fillRect(KDRect(p.x() + maxCoordinate(maxCoordinate(0, (upperBoundSize.width()-k_symbolWidth)/2), (lowerBoundNEqualsSize.width()-k_symbolWidth)/2)+k_symbolWidth,
-    p.y() + maxCoordinate(upperBoundSize.height()+k_boundHeightMargin, argumentLayout()->baseline()-(k_symbolHeight+1)/2),
+  ctx->fillRect(KDRect(p.x() + std::max(std::max(0, (upperBoundSize.width()-k_symbolWidth)/2), (lowerBoundNEqualsSize.width()-k_symbolWidth)/2)+k_symbolWidth,
+    p.y() + std::max(upperBoundSize.height()+k_boundHeightMargin, argumentLayout()->baseline()-(k_symbolHeight+1)/2),
     k_lineThickness, k_symbolHeight), expressionColor);
 
   // Render the "n=" and the parentheses.

--- a/poincare/src/sequence_layout.cpp
+++ b/poincare/src/sequence_layout.cpp
@@ -4,10 +4,9 @@
 #include <poincare/left_parenthesis_layout.h>
 #include <poincare/right_parenthesis_layout.h>
 #include <assert.h>
+#include <algorithm>
 
 namespace Poincare {
-
-static inline KDCoordinate maxCoordinate(KDCoordinate x, KDCoordinate y) { return x > y ? x : y; }
 
 void SequenceLayoutNode::moveCursorLeft(LayoutCursor * cursor, bool * shouldRecomputeLayout, bool forSelection) {
   if (cursor->layoutNode() == upperBoundLayout())
@@ -160,7 +159,7 @@ KDSize SequenceLayoutNode::lowerBoundSizeWithVariableEquals() {
   KDSize equalSize = k_font->stringSize(k_equal);
   return KDSize(
       variableSize.width() + equalSize.width() + lowerBoundSize.width(),
-      subscriptBaseline() + maxCoordinate(maxCoordinate(variableSize.height() - variableLayout()->baseline(), lowerBoundSize.height() - lowerBoundLayout()->baseline()), equalSize.height()/2));
+      subscriptBaseline() + std::max(std::max(variableSize.height() - variableLayout()->baseline(), lowerBoundSize.height() - lowerBoundLayout()->baseline()), equalSize.height()/2));
 }
 
 KDSize SequenceLayoutNode::computeSize() {
@@ -171,13 +170,13 @@ KDSize SequenceLayoutNode::computeSize() {
     argumentSize.width() + 2*ParenthesisLayoutNode::ParenthesisWidth(),
     ParenthesisLayoutNode::HeightGivenChildHeight(argumentSize.height()));
   KDSize result = KDSize(
-    maxCoordinate(maxCoordinate(k_symbolWidth, totalLowerBoundSize.width()), upperBoundSize.width())+k_argumentWidthMargin+argumentSizeWithParentheses.width(),
-    baseline() + maxCoordinate(k_symbolHeight/2+k_boundHeightMargin+totalLowerBoundSize.height(), argumentSizeWithParentheses.height() - argumentLayout()->baseline()));
+    std::max(std::max(k_symbolWidth, totalLowerBoundSize.width()), upperBoundSize.width())+k_argumentWidthMargin+argumentSizeWithParentheses.width(),
+    baseline() + std::max(k_symbolHeight/2+k_boundHeightMargin+totalLowerBoundSize.height(), argumentSizeWithParentheses.height() - argumentLayout()->baseline()));
   return result;
 }
 
 KDCoordinate SequenceLayoutNode::computeBaseline() {
-  return maxCoordinate(upperBoundLayout()->layoutSize().height()+k_boundHeightMargin+(k_symbolHeight+1)/2, argumentLayout()->baseline());
+  return std::max(upperBoundLayout()->layoutSize().height()+k_boundHeightMargin+(k_symbolHeight+1)/2, argumentLayout()->baseline());
 }
 
 KDPoint SequenceLayoutNode::positionOfChild(LayoutNode * l) {
@@ -193,10 +192,10 @@ KDPoint SequenceLayoutNode::positionOfChild(LayoutNode * l) {
     x = completeLowerBoundX() + equalSize.width() + variableSize.width();
     y = baseline() + k_symbolHeight/2 + k_boundHeightMargin + subscriptBaseline() - lowerBoundLayout()->baseline();
   } else if (l == upperBoundLayout()) {
-    x = maxCoordinate(maxCoordinate(0, (k_symbolWidth-upperBoundSize.width())/2), (lowerBoundSizeWithVariableEquals().width()-upperBoundSize.width())/2);
+    x = std::max(std::max(0, (k_symbolWidth-upperBoundSize.width())/2), (lowerBoundSizeWithVariableEquals().width()-upperBoundSize.width())/2);
     y = baseline() - (k_symbolHeight+1)/2- k_boundHeightMargin-upperBoundSize.height();
   } else if (l == argumentLayout()) {
-    x = maxCoordinate(maxCoordinate(k_symbolWidth, lowerBoundSizeWithVariableEquals().width()), upperBoundSize.width())+k_argumentWidthMargin+ParenthesisLayoutNode::ParenthesisWidth();
+    x = std::max(std::max(k_symbolWidth, lowerBoundSizeWithVariableEquals().width()), upperBoundSize.width())+k_argumentWidthMargin+ParenthesisLayoutNode::ParenthesisWidth();
     y = baseline() - argumentLayout()->baseline();
   } else {
     assert(false);
@@ -267,12 +266,12 @@ void SequenceLayoutNode::render(KDContext * ctx, KDPoint p, KDColor expressionCo
 
 KDCoordinate SequenceLayoutNode::completeLowerBoundX() {
   KDSize upperBoundSize = upperBoundLayout()->layoutSize();
- return maxCoordinate(maxCoordinate(0, (k_symbolWidth-lowerBoundSizeWithVariableEquals().width())/2),
+ return std::max(std::max(0, (k_symbolWidth-lowerBoundSizeWithVariableEquals().width())/2),
           (upperBoundSize.width()-lowerBoundSizeWithVariableEquals().width())/2);
 }
 
 KDCoordinate SequenceLayoutNode::subscriptBaseline() {
-  return maxCoordinate(maxCoordinate(variableLayout()->baseline(), lowerBoundLayout()->baseline()), k_font->stringSize(k_equal).height()/2);
+  return std::max(std::max(variableLayout()->baseline(), lowerBoundLayout()->baseline()), k_font->stringSize(k_equal).height()/2);
 }
 
 }

--- a/poincare/src/sequence_layout.cpp
+++ b/poincare/src/sequence_layout.cpp
@@ -8,6 +8,8 @@
 
 namespace Poincare {
 
+constexpr KDCoordinate SequenceLayoutNode::k_symbolWidth;
+
 void SequenceLayoutNode::moveCursorLeft(LayoutCursor * cursor, bool * shouldRecomputeLayout, bool forSelection) {
   if (cursor->layoutNode() == upperBoundLayout())
   {

--- a/poincare/src/sequence_layout.cpp
+++ b/poincare/src/sequence_layout.cpp
@@ -176,7 +176,7 @@ KDSize SequenceLayoutNode::computeSize() {
 }
 
 KDCoordinate SequenceLayoutNode::computeBaseline() {
-  return std::max(upperBoundLayout()->layoutSize().height()+k_boundHeightMargin+(k_symbolHeight+1)/2, argumentLayout()->baseline());
+  return std::max<KDCoordinate>(upperBoundLayout()->layoutSize().height()+k_boundHeightMargin+(k_symbolHeight+1)/2, argumentLayout()->baseline());
 }
 
 KDPoint SequenceLayoutNode::positionOfChild(LayoutNode * l) {
@@ -271,7 +271,7 @@ KDCoordinate SequenceLayoutNode::completeLowerBoundX() {
 }
 
 KDCoordinate SequenceLayoutNode::subscriptBaseline() {
-  return std::max(std::max(variableLayout()->baseline(), lowerBoundLayout()->baseline()), k_font->stringSize(k_equal).height()/2);
+  return std::max<KDCoordinate>(std::max(variableLayout()->baseline(), lowerBoundLayout()->baseline()), k_font->stringSize(k_equal).height()/2);
 }
 
 }

--- a/poincare/src/sum_layout.cpp
+++ b/poincare/src/sum_layout.cpp
@@ -1,10 +1,9 @@
 #include <poincare/sum_layout.h>
 #include <poincare/code_point_layout.h>
 #include <poincare/horizontal_layout.h>
+#include <algorithm>
 
 namespace Poincare {
-
-static inline KDCoordinate maxCoordinate(KDCoordinate x, KDCoordinate y) { return x > y ? x : y; }
 
 const uint8_t symbolPixel[SumLayoutNode::k_symbolHeight][SumLayoutNode::k_symbolWidth] = {
   {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
@@ -36,8 +35,8 @@ void SumLayoutNode::render(KDContext * ctx, KDPoint p, KDColor expressionColor, 
 
   // Render the Sum symbol.
   KDColor workingBuffer[k_symbolWidth*k_symbolHeight];
-  KDRect symbolFrame(p.x() + maxCoordinate(maxCoordinate(0, (upperBoundSize.width()-k_symbolWidth)/2), (lowerBoundNEqualsSize.width()-k_symbolWidth)/2),
-      p.y() + maxCoordinate(upperBoundSize.height()+k_boundHeightMargin, argumentLayout()->baseline()-(k_symbolHeight+1)/2),
+  KDRect symbolFrame(p.x() + std::max(std::max(0, (upperBoundSize.width()-k_symbolWidth)/2), (lowerBoundNEqualsSize.width()-k_symbolWidth)/2),
+      p.y() + std::max(upperBoundSize.height()+k_boundHeightMargin, argumentLayout()->baseline()-(k_symbolHeight+1)/2),
       k_symbolWidth, k_symbolHeight);
   ctx->blendRectWithMask(symbolFrame, expressionColor, (const uint8_t *)symbolPixel, (KDColor *)workingBuffer);
 

--- a/poincare/src/symbol_abstract.cpp
+++ b/poincare/src/symbol_abstract.cpp
@@ -9,10 +9,11 @@
 #include <ion/unicode/utf8_decoder.h>
 #include <ion/unicode/utf8_helper.h>
 #include <string.h>
+#include <algorithm>
 
 namespace Poincare {
 
-static inline int minInt(int x, int y) { return x < y ? x : y; }
+static inline int std::min(int x, int y) { return x < y ? x : y; }
 
 size_t SymbolAbstractNode::size() const {
   return nodeSize() + strlen(name()) + 1;
@@ -41,7 +42,7 @@ int SymbolAbstractNode::simplificationOrderSameType(const ExpressionNode * e, bo
 }
 
 int SymbolAbstractNode::serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const {
-  return minInt(strlcpy(buffer, name(), bufferSize), bufferSize - 1);
+  return std::min(strlcpy(buffer, name(), bufferSize), bufferSize - 1);
 }
 
 template <typename T, typename U>

--- a/poincare/src/symbol_abstract.cpp
+++ b/poincare/src/symbol_abstract.cpp
@@ -13,8 +13,6 @@
 
 namespace Poincare {
 
-static inline int std::min(int x, int y) { return x < y ? x : y; }
-
 size_t SymbolAbstractNode::size() const {
   return nodeSize() + strlen(name()) + 1;
 }
@@ -42,7 +40,7 @@ int SymbolAbstractNode::simplificationOrderSameType(const ExpressionNode * e, bo
 }
 
 int SymbolAbstractNode::serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const {
-  return std::min(strlcpy(buffer, name(), bufferSize), bufferSize - 1);
+  return std::min<int>(strlcpy(buffer, name(), bufferSize), bufferSize - 1);
 }
 
 template <typename T, typename U>

--- a/poincare/src/undefined.cpp
+++ b/poincare/src/undefined.cpp
@@ -24,7 +24,7 @@ Layout UndefinedNode::createLayout(Preferences::PrintFloatMode floatDisplayMode,
 }
 
 int UndefinedNode::serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const {
-  return std::min(strlcpy(buffer, Undefined::Name(), bufferSize), bufferSize - 1);
+  return std::min<int>(strlcpy(buffer, Undefined::Name(), bufferSize), bufferSize - 1);
 }
 
 template<typename T> Evaluation<T> UndefinedNode::templatedApproximate() const {

--- a/poincare/src/undefined.cpp
+++ b/poincare/src/undefined.cpp
@@ -1,6 +1,7 @@
 #include <poincare/undefined.h>
 #include <poincare/complex.h>
 #include <poincare/layout_helper.h>
+#include <algorithm>
 
 extern "C" {
 #include <math.h>
@@ -8,8 +9,6 @@ extern "C" {
 }
 
 namespace Poincare {
-
-static inline int minInt(int x, int y) { return x < y ? x : y; }
 
 int UndefinedNode::polynomialDegree(Context * context, const char * symbolName) const {
   return -1;
@@ -25,7 +24,7 @@ Layout UndefinedNode::createLayout(Preferences::PrintFloatMode floatDisplayMode,
 }
 
 int UndefinedNode::serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const {
-  return minInt(strlcpy(buffer, Undefined::Name(), bufferSize), bufferSize - 1);
+  return std::min(strlcpy(buffer, Undefined::Name(), bufferSize), bufferSize - 1);
 }
 
 template<typename T> Evaluation<T> UndefinedNode::templatedApproximate() const {

--- a/poincare/src/unit.cpp
+++ b/poincare/src/unit.cpp
@@ -18,7 +18,7 @@ static inline int absInt(int x) { return x >= 0 ? x : -x; }
 
 int UnitNode::Prefix::serialize(char * buffer, int bufferSize) const {
   assert(bufferSize >= 0);
-  return std::min(strlcpy(buffer, m_symbol, bufferSize), bufferSize - 1);
+  return std::min<int>(strlcpy(buffer, m_symbol, bufferSize), bufferSize - 1);
 }
 
 bool UnitNode::Representative::canParse(const char * symbol, size_t length,
@@ -51,7 +51,7 @@ int UnitNode::Representative::serialize(char * buffer, int bufferSize, const Pre
     bufferSize -= length;
   }
   assert(bufferSize >= 0);
-  length += std::min(strlcpy(buffer, m_rootSymbol, bufferSize), bufferSize - 1);
+  length += std::min<int>(strlcpy(buffer, m_rootSymbol, bufferSize), bufferSize - 1);
   return length;
 }
 
@@ -134,7 +134,7 @@ Layout UnitNode::createLayout(Preferences::PrintFloatMode floatDisplayMode, int 
 
 int UnitNode::serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const {
   assert(bufferSize >= 0);
-  int underscoreLength = std::min(strlcpy(buffer, "_", bufferSize), bufferSize - 1);
+  int underscoreLength = std::min<int>(strlcpy(buffer, "_", bufferSize), bufferSize - 1);
   buffer += underscoreLength;
   bufferSize -= underscoreLength;
   return underscoreLength + m_representative->serialize(buffer, bufferSize, m_prefix);

--- a/poincare/src/unit.cpp
+++ b/poincare/src/unit.cpp
@@ -10,15 +10,15 @@
 #include <assert.h>
 #include <string.h>
 #include <utility>
+#include <algorithm>
 
 namespace Poincare {
 
 static inline int absInt(int x) { return x >= 0 ? x : -x; }
-static inline int minInt(int x, int y) { return x < y ? x : y; }
 
 int UnitNode::Prefix::serialize(char * buffer, int bufferSize) const {
   assert(bufferSize >= 0);
-  return minInt(strlcpy(buffer, m_symbol, bufferSize), bufferSize - 1);
+  return std::min(strlcpy(buffer, m_symbol, bufferSize), bufferSize - 1);
 }
 
 bool UnitNode::Representative::canParse(const char * symbol, size_t length,
@@ -51,7 +51,7 @@ int UnitNode::Representative::serialize(char * buffer, int bufferSize, const Pre
     bufferSize -= length;
   }
   assert(bufferSize >= 0);
-  length += minInt(strlcpy(buffer, m_rootSymbol, bufferSize), bufferSize - 1);
+  length += std::min(strlcpy(buffer, m_rootSymbol, bufferSize), bufferSize - 1);
   return length;
 }
 
@@ -134,7 +134,7 @@ Layout UnitNode::createLayout(Preferences::PrintFloatMode floatDisplayMode, int 
 
 int UnitNode::serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const {
   assert(bufferSize >= 0);
-  int underscoreLength = minInt(strlcpy(buffer, "_", bufferSize), bufferSize - 1);
+  int underscoreLength = std::min(strlcpy(buffer, "_", bufferSize), bufferSize - 1);
   buffer += underscoreLength;
   bufferSize -= underscoreLength;
   return underscoreLength + m_representative->serialize(buffer, bufferSize, m_prefix);

--- a/poincare/src/unreal.cpp
+++ b/poincare/src/unreal.cpp
@@ -1,5 +1,6 @@
 #include <poincare/unreal.h>
 #include <poincare/layout_helper.h>
+#include <algorithm>
 
 extern "C" {
 #include <math.h>
@@ -8,14 +9,12 @@ extern "C" {
 
 namespace Poincare {
 
-static inline int minInt(int x, int y) { return x < y ? x : y; }
-
 Layout UnrealNode::createLayout(Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const {
   return LayoutHelper::String(Unreal::Name(), Unreal::NameSize()-1);
 }
 
 int UnrealNode::serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const {
-  return minInt(strlcpy(buffer, Unreal::Name(), bufferSize), bufferSize - 1);
+  return std::min(strlcpy(buffer, Unreal::Name(), bufferSize), bufferSize - 1);
 }
 
 }

--- a/poincare/src/unreal.cpp
+++ b/poincare/src/unreal.cpp
@@ -14,7 +14,7 @@ Layout UnrealNode::createLayout(Preferences::PrintFloatMode floatDisplayMode, in
 }
 
 int UnrealNode::serialize(char * buffer, int bufferSize, Preferences::PrintFloatMode floatDisplayMode, int numberOfSignificantDigits) const {
-  return std::min(strlcpy(buffer, Unreal::Name(), bufferSize), bufferSize - 1);
+  return std::min<int>(strlcpy(buffer, Unreal::Name(), bufferSize), bufferSize - 1);
 }
 
 }

--- a/poincare/src/vertical_offset_layout.cpp
+++ b/poincare/src/vertical_offset_layout.cpp
@@ -5,10 +5,9 @@
 #include <poincare/right_parenthesis_layout.h>
 #include <string.h>
 #include <assert.h>
+#include <algorithm>
 
 namespace Poincare {
-
-static inline int minInt(int x, int y) { return x < y ? x : y; }
 
 void VerticalOffsetLayoutNode::moveCursorLeft(LayoutCursor * cursor, bool * shouldRecomputeLayout, bool forSelection) {
   if (cursor->layoutNode() == indiceLayout()
@@ -165,7 +164,7 @@ int VerticalOffsetLayoutNode::serialize(char * buffer, int bufferSize, Preferenc
     if (numberOfChar >= bufferSize-1) { return bufferSize-1; }
 
     numberOfChar += SerializationHelper::CodePoint(buffer+numberOfChar, bufferSize-numberOfChar, '}');
-    return minInt(numberOfChar, bufferSize-1);
+    return std::min(numberOfChar, bufferSize-1);
   }
 
   assert(m_position == Position::Superscript);
@@ -177,7 +176,7 @@ int VerticalOffsetLayoutNode::serialize(char * buffer, int bufferSize, Preferenc
   numberOfChar += const_cast<VerticalOffsetLayoutNode *>(this)->indiceLayout()->serialize(buffer+numberOfChar, bufferSize-numberOfChar, floatDisplayMode, numberOfSignificantDigits);
   if (numberOfChar >= bufferSize-1) { return bufferSize-1; }
   numberOfChar += SerializationHelper::CodePoint(buffer+numberOfChar, bufferSize-numberOfChar, UCodePointRightSystemParenthesis);
-  return minInt(numberOfChar, bufferSize-1);
+  return std::min(numberOfChar, bufferSize-1);
 }
 
 KDSize VerticalOffsetLayoutNode::computeSize() {

--- a/python/port/mod/matplotlib/pyplot/plot_store.cpp
+++ b/python/port/mod/matplotlib/pyplot/plot_store.cpp
@@ -1,4 +1,5 @@
 #include "plot_store.h"
+#include <algorithm>
 
 namespace Matplotlib {
 
@@ -160,15 +161,12 @@ void PlotStore::addLabel(mp_obj_t x, mp_obj_t y, mp_obj_t string) {
 
 // Axes
 
-static inline float minFloat(float x, float y) { return x < y ? x : y; }
-static inline float maxFloat(float x, float y) { return x > y ? x : y; }
-
 void updateRange(float * xMin, float * xMax, float * yMin, float * yMax, float x, float y) {
   if (!std::isnan(x) && !std::isinf(x) && !std::isnan(y) && !std::isinf(y)) {
-    *xMin = minFloat(*xMin, x);
-    *xMax = maxFloat(*xMax, x);
-    *yMin = minFloat(*yMin, y);
-    *yMax = maxFloat(*yMax, y);
+    *xMin = std::min(*xMin, x);
+    *xMax = std::max(*xMax, x);
+    *yMin = std::min(*yMin, y);
+    *yMax = std::max(*yMax, y);
   }
 }
 

--- a/python/port/mod/matplotlib/pyplot/plot_view.cpp
+++ b/python/port/mod/matplotlib/pyplot/plot_view.cpp
@@ -76,5 +76,4 @@ void PlotView::traceLabel(KDContext * ctx, KDRect r, PlotStore::Label label) con
   );
 }
 
-
 }

--- a/python/port/mod/matplotlib/pyplot/plot_view.cpp
+++ b/python/port/mod/matplotlib/pyplot/plot_view.cpp
@@ -1,4 +1,5 @@
 #include "plot_view.h"
+#include <algorithm>
 
 namespace Matplotlib {
 
@@ -52,7 +53,6 @@ void PlotView::traceSegment(KDContext * ctx, KDRect r, PlotStore::Segment segmen
   }
 }
 
-static inline KDCoordinate maxKDCoordinate(KDCoordinate x, KDCoordinate y) { return x > y ? x : y; }
 void PlotView::traceRect(KDContext * ctx, KDRect r, PlotStore::Rect rect) const {
   KDCoordinate left = std::round(floatToPixel(Axis::Horizontal, rect.left()));
   KDCoordinate right = std::round(floatToPixel(Axis::Horizontal, rect.right()));
@@ -61,7 +61,7 @@ void PlotView::traceRect(KDContext * ctx, KDRect r, PlotStore::Rect rect) const 
   KDRect pixelRect(
     left,
     top,
-    maxKDCoordinate(right - left, 1), // Rectangle should at least be visible
+    std::max(right - left, 1), // Rectangle should at least be visible
     bottom - top
   );
   ctx->fillRect(pixelRect, rect.color());


### PR DESCRIPTION
This removes an *awful* lot of duplicated code…

Note: Sometimes the templated function (either `std::min` or `std::max`) needs to be explicited (e.g. `std::min<float>(foo, bar)`). This is undesirable, and may be a result of either:

* Unexpected type promotion : For instance, given `KDCoordinate length = 2;` the type of `2*length` will be `int`, not `KDCoordinate`. Maybe it could be a good idea to promote `KDCoordinate` to `int`? It would fix this, and might be a bit faster (albeit a tad bit bigger).
* Floating point mismatch: some function mix `double` and `float` for no apparent reason (e.g. `chi_squared`, `ContinuousFunction::tMin`, or `CurveViewRange::xMin`). We should definitely move those to a single floating-point type (and I think this means `double`).
* Using `size_t` and `int` inconsistently (those aren't the same type)