### PR TITLE
[poincare/normal_distribution] Fix StandardNormalCumulDistFuncAtAbs

### DIFF
--- a/poincare/src/normal_distribution.cpp
+++ b/poincare/src/normal_distribution.cpp
@@ -88,8 +88,8 @@ T NormalDistribution::StandardNormalCumulativeDistributiveFunctionAtAbscissa(T a
   if (std::isnan(abscissa)) {
     return NAN;
   }
-  if (std::isinf(abscissa) || abscissa > k_boundStandardNormalDistribution) {
-    return (T)1.0;
+  if (std::isinf(abscissa) || std::fabs(abscissa) > k_boundStandardNormalDistribution) {
+    return abscissa > (T)0.0 ? (T)1.0 : (T)0.0;
   }
   if (abscissa == (T)0.0) {
     return (T)0.5;

--- a/poincare/test/approximation.cpp
+++ b/poincare/test/approximation.cpp
@@ -303,6 +303,10 @@ QUIZ_CASE(poincare_approximation_function) {
 
   assert_expression_approximates_to<float>("normcdf(1.2, 3.4, 31.36)", "0.3472125");
   assert_expression_approximates_to<double>("normcdf(1.2, 3.4, 31.36)", "3.4721249841587ᴇ-1");
+  assert_expression_approximates_to<float>("normcdf(-1ᴇ99,3.4,31.36)", "0");
+  assert_expression_approximates_to<float>("normcdf(1ᴇ99,3.4,31.36)", "1");
+  assert_expression_approximates_to<float>("normcdf(-6,0,1)", "0");
+  assert_expression_approximates_to<float>("normcdf(6,0,1)", "1");
 
   assert_expression_approximates_to<float>("normcdf2(0.5, 3.6, 1.3, 11.56)", "0.3436388");
   assert_expression_approximates_to<double>("normcdf2(0.5, 3.6, 1.3, 11.56)", "3.4363881299147ᴇ-1");


### PR DESCRIPTION
In the probability app, standard normal distribution, P(-1E99 <=X<=0) was quite false (-0.5).