### PR TITLE
[escher/layout_field] Reset the scroll when clearing the layout

### DIFF
--- a/escher/include/escher/layout_field.h
+++ b/escher/include/escher/layout_field.h
@@ -25,7 +25,7 @@ public:
   Poincare::Context * context() const;
   bool isEditing() const override { return m_contentView.isEditing(); }
   void setEditing(bool isEditing) override;
-  void clearLayout() { m_contentView.clearLayout(); }
+  void clearLayout();
   void scrollToCursor() {
     scrollToBaselinedRect(m_contentView.cursorRect(), m_contentView.cursor()->baselineWithoutSelection());
   }

--- a/escher/src/layout_field.cpp
+++ b/escher/src/layout_field.cpp
@@ -284,6 +284,11 @@ void LayoutField::setEditing(bool isEditing) {
   }
 }
 
+void LayoutField::clearLayout() {
+  m_contentView.clearLayout(); // Replace the layout with an empty horizontal layout
+  reloadScroll(); // Put the scroll to offset 0
+}
+
 Context * LayoutField::context() const {
   return (m_delegate != nullptr) ? m_delegate->context() : nullptr;
 }


### PR DESCRIPTION
Scenario: Go to the graph app, create f(x) = 1 then create g(x) -> there
is a weird big margin in the edition field