### PR TITLE
Fix graph black trail bug

### DIFF
--- a/apps/shared/interactive_curve_view_controller.cpp
+++ b/apps/shared/interactive_curve_view_controller.cpp
@@ -57,7 +57,11 @@ float InteractiveCurveViewController::addMargin(float y, float range, bool isVer
   assert(topMarginRatio + bottomMarginRatio < 1); // Assertion so that the formula is correct
   float ratioDenominator = 1 - bottomMarginRatio - topMarginRatio;
   float ratio = isMin ? -bottomMarginRatio : topMarginRatio;
-  ratio = ratio / ratioDenominator;
+  /* We want to add slightly more than the required margin, so that
+   * InteractiveCurveViewRange::panToMakePointVisible does not think a point is
+   * invisible due to precision problems when checking if it is outside the
+   * required margin. This is why we add a 1.05f factor. */
+  ratio = 1.05f * ratio / ratioDenominator;
   return y + ratio * range;
 }
 

--- a/apps/shared/interactive_curve_view_range.cpp
+++ b/apps/shared/interactive_curve_view_range.cpp
@@ -1,7 +1,6 @@
 #include "interactive_curve_view_range.h"
 #include <ion.h>
 #include <cmath>
-#include <float.h>
 #include <stddef.h>
 #include <assert.h>
 #include <poincare/preferences.h>
@@ -203,24 +202,24 @@ void InteractiveCurveViewRange::centerAxisAround(Axis axis, float position) {
 void InteractiveCurveViewRange::panToMakePointVisible(float x, float y, float topMarginRatio, float rightMarginRatio, float bottomMarginRation, float leftMarginRation) {
   float xRange = xMax() - xMin();
   float yRange = yMax() - yMin();
-  if (x < xMin() + leftMarginRation*xRange - FLT_EPSILON && !std::isinf(x) && !std::isnan(x)) {
+  if (x < xMin() + leftMarginRation*xRange && !std::isinf(x) && !std::isnan(x)) {
     m_yAuto = false;
     float newXMin = x - leftMarginRation*xRange;
     m_xRange.setMax(newXMin + xRange, k_lowerMaxFloat, k_upperMaxFloat);
     MemoizedCurveViewRange::protectedSetXMin(newXMin, k_lowerMaxFloat, k_upperMaxFloat);
   }
-  if (x > xMax() - rightMarginRatio*xRange + FLT_EPSILON && !std::isinf(x) && !std::isnan(x)) {
+  if (x > xMax() - rightMarginRatio*xRange && !std::isinf(x) && !std::isnan(x)) {
     m_yAuto = false;
     m_xRange.setMax(x + rightMarginRatio*xRange, k_lowerMaxFloat, k_upperMaxFloat);
     MemoizedCurveViewRange::protectedSetXMin(xMax() - xRange, k_lowerMaxFloat, k_upperMaxFloat);
   }
-  if (y < yMin() + bottomMarginRation*yRange - FLT_EPSILON && !std::isinf(y) && !std::isnan(y)) {
+  if (y < yMin() + bottomMarginRation*yRange && !std::isinf(y) && !std::isnan(y)) {
     m_yAuto = false;
     float newYMin = y - bottomMarginRation*yRange;
     m_yRange.setMax(newYMin + yRange, k_lowerMaxFloat, k_upperMaxFloat);
     MemoizedCurveViewRange::protectedSetYMin(newYMin, k_lowerMaxFloat, k_upperMaxFloat);
   }
-  if (y > yMax() - topMarginRatio*yRange + FLT_EPSILON && !std::isinf(y) && !std::isnan(y)) {
+  if (y > yMax() - topMarginRatio*yRange && !std::isinf(y) && !std::isnan(y)) {
     m_yAuto = false;
     m_yRange.setMax(y + topMarginRatio*yRange, k_lowerMaxFloat, k_upperMaxFloat);
     MemoizedCurveViewRange::protectedSetYMin(yMax() - yRange, k_lowerMaxFloat, k_upperMaxFloat);

--- a/apps/shared/interactive_curve_view_range.cpp
+++ b/apps/shared/interactive_curve_view_range.cpp
@@ -199,30 +199,38 @@ void InteractiveCurveViewRange::centerAxisAround(Axis axis, float position) {
   }
 }
 
-void InteractiveCurveViewRange::panToMakePointVisible(float x, float y, float topMarginRatio, float rightMarginRatio, float bottomMarginRation, float leftMarginRation) {
-  float xRange = xMax() - xMin();
-  float yRange = yMax() - yMin();
-  if (x < xMin() + leftMarginRation*xRange && !std::isinf(x) && !std::isnan(x)) {
-    m_yAuto = false;
-    float newXMin = x - leftMarginRation*xRange;
-    m_xRange.setMax(newXMin + xRange, k_lowerMaxFloat, k_upperMaxFloat);
-    MemoizedCurveViewRange::protectedSetXMin(newXMin, k_lowerMaxFloat, k_upperMaxFloat);
+void InteractiveCurveViewRange::panToMakePointVisible(float x, float y, float topMarginRatio, float rightMarginRatio, float bottomMarginRatio, float leftMarginRatio) {
+  if (!std::isinf(x) && !std::isnan(x)) {
+    const float xRange = xMax() - xMin();
+    const float leftMargin = leftMarginRatio * xRange;
+    if (x < xMin() + leftMargin) {
+      m_yAuto = false;
+      const float newXMin = x - leftMargin;
+      m_xRange.setMax(newXMin + xRange, k_lowerMaxFloat, k_upperMaxFloat);
+      MemoizedCurveViewRange::protectedSetXMin(newXMin, k_lowerMaxFloat, k_upperMaxFloat);
+    }
+    const float rightMargin = rightMarginRatio * xRange;
+    if (x > xMax() - rightMargin) {
+      m_yAuto = false;
+      m_xRange.setMax(x + rightMargin, k_lowerMaxFloat, k_upperMaxFloat);
+      MemoizedCurveViewRange::protectedSetXMin(xMax() - xRange, k_lowerMaxFloat, k_upperMaxFloat);
+    }
   }
-  if (x > xMax() - rightMarginRatio*xRange && !std::isinf(x) && !std::isnan(x)) {
-    m_yAuto = false;
-    m_xRange.setMax(x + rightMarginRatio*xRange, k_lowerMaxFloat, k_upperMaxFloat);
-    MemoizedCurveViewRange::protectedSetXMin(xMax() - xRange, k_lowerMaxFloat, k_upperMaxFloat);
-  }
-  if (y < yMin() + bottomMarginRation*yRange && !std::isinf(y) && !std::isnan(y)) {
-    m_yAuto = false;
-    float newYMin = y - bottomMarginRation*yRange;
-    m_yRange.setMax(newYMin + yRange, k_lowerMaxFloat, k_upperMaxFloat);
-    MemoizedCurveViewRange::protectedSetYMin(newYMin, k_lowerMaxFloat, k_upperMaxFloat);
-  }
-  if (y > yMax() - topMarginRatio*yRange && !std::isinf(y) && !std::isnan(y)) {
-    m_yAuto = false;
-    m_yRange.setMax(y + topMarginRatio*yRange, k_lowerMaxFloat, k_upperMaxFloat);
-    MemoizedCurveViewRange::protectedSetYMin(yMax() - yRange, k_lowerMaxFloat, k_upperMaxFloat);
+  if (!std::isinf(y) && !std::isnan(y)) {
+    const float yRange = yMax() - yMin();
+    const float bottomMargin = bottomMarginRatio * yRange;
+    if (y < yMin() + bottomMargin) {
+      m_yAuto = false;
+      const float newYMin = y - bottomMargin;
+      m_yRange.setMax(newYMin + yRange, k_lowerMaxFloat, k_upperMaxFloat);
+      MemoizedCurveViewRange::protectedSetYMin(newYMin, k_lowerMaxFloat, k_upperMaxFloat);
+    }
+    const float topMargin = topMarginRatio * yRange;
+    if (y > yMax() - topMargin) {
+      m_yAuto = false;
+      m_yRange.setMax(y + topMargin, k_lowerMaxFloat, k_upperMaxFloat);
+      MemoizedCurveViewRange::protectedSetYMin(yMax() - yRange, k_lowerMaxFloat, k_upperMaxFloat);
+    }
   }
 }
 

--- a/apps/shared/round_cursor_view.cpp
+++ b/apps/shared/round_cursor_view.cpp
@@ -66,11 +66,40 @@ bool RoundCursorView::eraseCursorIfPossible() {
     return false;
   }
   // Erase the cursor
-  KDColor cursorWorkingBuffer[Dots::LargeDotDiameter*Dots::LargeDotDiameter];
+  KDColor cursorWorkingBuffer[k_cursorSize * k_cursorSize];
   KDContext * ctx = KDIonContext::sharedContext();
   ctx->setOrigin(currentFrame.origin());
   ctx->setClippingRect(currentFrame);
-  ctx->fillRectWithPixels(KDRect(0,0,k_cursorSize, k_cursorSize), m_underneathPixelBuffer, cursorWorkingBuffer);
+  KDSize cursorSize = KDSize(k_cursorSize, k_cursorSize);
+
+  /* We assert that the visible frame is not cropped (indeed a cursor is always
+   * fully inside the window, thanks to panToMakeCursorVisible). Otherwise, we
+   * would need to change this algorithm.
+   *
+   *       +---+
+   *       |   |<- frame                    m_underneathPixelBuffer: +---+
+   *  +----+---+--------+                                            |000|
+   *  |    |xxx|        |<- parentVisibleFrame                       |xxx|
+   *  |    +---+        |                                            +---+
+   *  |                 |
+   *  +-----------------+
+   *
+   * +---+
+   * |xxx|: absoluteVisibleFrame
+   * +---+
+   *
+   * What we would draw with the current algorithm:
+   *       +---+
+   *       |   |<- frame
+   *  +----+---+--------+
+   *  |    |000|        |<- parentVisibleFrame
+   *  |    +---+        |
+   *  |                 |
+   *  +-----------------+
+   *
+   * */
+  assert(currentFrame.size() == cursorSize);
+  ctx->fillRectWithPixels(KDRect(0, 0, cursorSize), m_underneathPixelBuffer, cursorWorkingBuffer);
   // TODO Restore the context to previous values?
   return true;
 }

--- a/kandinsky/include/kandinsky/size.h
+++ b/kandinsky/include/kandinsky/size.h
@@ -9,6 +9,9 @@ public:
     m_width(width), m_height(height) {}
   constexpr KDCoordinate width() const { return m_width; }
   constexpr KDCoordinate height() const { return m_height; }
+  bool operator==(const KDSize &other) const {
+    return m_width == other.width() && m_height == other.height();
+  }
 private:
   KDCoordinate m_width;
   KDCoordinate m_height;


### PR DESCRIPTION
Fixes #1458

The problem only appeared on the device and was not on the macOS simulator due to the different values of FLT_EPSILON: 1e-5 on the device, around 1e-7 on the simulator.

Now the cursor cannot be on the edge of the graph view: panToMakePointVisible and addMargins change the X and Y ranges to put the cursor fully in the view.