### PR TITLE
Python garbage collection

### DIFF
--- a/ion/include/ion.h
+++ b/ion/include/ion.h
@@ -17,6 +17,7 @@
 #include <ion/unicode/utf8_helper.h>
 #include <stdint.h>
 #include <string.h>
+#include <setjmp.h>
 
 /* ION is not your regular library. It is a library you link against, but it
  * will take care of configuring the whole environment for you. In POSIX terms,
@@ -47,6 +48,9 @@ void decompress(const uint8_t * src, uint8_t * dst, int srcSize, int dstSize);
 
 // Tells whether the stack pointer is within acceptable bounds
 bool stackSafe();
+
+// Collect registers in a buffer and returns the stack pointer
+uintptr_t collectRegisters(jmp_buf regs);
 
 }
 

--- a/ion/src/device/Makefile
+++ b/ion/src/device/Makefile
@@ -10,6 +10,8 @@ ifeq ($(EPSILON_TELEMETRY),1)
 ion_src += ion/src/shared/telemetry_console.cpp
 endif
 
+ion_src += ion/src/shared/collect_registers.cpp
+
 ION_DEVICE_SFLAGS = -Iion/src/device/$(MODEL) -Iion/src/device/shared
 
 $(call object_for,$(ion_device_src) $(ion_device_flasher_src) $(ion_device_bench_src)): SFLAGS += $(ION_DEVICE_SFLAGS)

--- a/ion/src/shared/collect_registers.cpp
+++ b/ion/src/shared/collect_registers.cpp
@@ -1,0 +1,15 @@
+#include <ion.h>
+#include <setjmp.h>
+
+namespace Ion {
+
+/* Forbid inlining to ensure dummy to be at the top of the stack. Otherwise,
+ * LTO inlining can make regs lower on the stack than some just-allocated
+ * pointers. */
+__attribute__((noinline))uintptr_t collectRegisters(jmp_buf buf) {
+  setjmp(buf);
+  int dummy;
+  return (uintptr_t)&dummy;
+}
+
+}

--- a/ion/src/shared/collect_registers.cpp
+++ b/ion/src/shared/collect_registers.cpp
@@ -7,6 +7,10 @@ namespace Ion {
  * LTO inlining can make regs lower on the stack than some just-allocated
  * pointers. */
 __attribute__((noinline))uintptr_t collectRegisters(jmp_buf buf) {
+  /* TODO: we use setjmp to get the registers values to look for python heap
+   * root. However, the 'setjmp' does not guarantee that it gets all registers
+   * values. We should check our setjmp implementation for the device and
+   * ensure that it also works for other platforms. */
   setjmp(buf);
   int dummy;
   return (uintptr_t)&dummy;

--- a/ion/src/simulator/android/Makefile
+++ b/ion/src/simulator/android/Makefile
@@ -7,6 +7,8 @@ ion_src += $(addprefix ion/src/simulator/shared/, \
   dummy/language.cpp \
 )
 
+ion_src += ion/src/shared/collect_registers.cpp
+
 ifeq ($(EPSILON_TELEMETRY),1)
 ion_src += ion/src/simulator/android/src/cpp/telemetry.cpp
 endif

--- a/ion/src/simulator/ios/Makefile
+++ b/ion/src/simulator/ios/Makefile
@@ -7,6 +7,8 @@ ion_src += $(addprefix ion/src/simulator/shared/, \
   dummy/callback.cpp \
 )
 
+ion_src += ion/src/shared/collect_registers.cpp
+
 $(call object_for,ion/src/simulator/shared/main.cpp) : SFLAGS += -DEPSILON_SDL_FULLSCREEN=1
 
 ifeq ($(EPSILON_TELEMETRY),1)

--- a/ion/src/simulator/linux/Makefile
+++ b/ion/src/simulator/linux/Makefile
@@ -15,6 +15,8 @@ ion_src += $(addprefix ion/src/simulator/linux/, \
 
 ion_src += $(addprefix ion/src/simulator/shared/, \
   dummy/callback.cpp \
+  collect_registers_x86_64.s \
+  collect_registers.cpp \
 )
 
 ifeq ($(EPSILON_TELEMETRY),1)

--- a/ion/src/simulator/macos/Makefile
+++ b/ion/src/simulator/macos/Makefile
@@ -5,6 +5,8 @@ ion_src += $(addprefix ion/src/simulator/macos/, \
 ion_src += $(addprefix ion/src/simulator/shared/, \
   apple/language.m \
   dummy/callback.cpp \
+  collect_registers_x86_64.s \
+  collect_registers.cpp \
 )
 
 ifeq ($(EPSILON_TELEMETRY),1)

--- a/ion/src/simulator/shared/collect_registers.cpp
+++ b/ion/src/simulator/shared/collect_registers.cpp
@@ -5,10 +5,12 @@ extern "C" {
 // define in assembly code
 // Force the name as archs (linux/macos) don't mangle C names the same way
 extern uintptr_t collect_registers(uintptr_t * regs) asm ("_collect_registers");
+
 }
 namespace Ion {
 
-// Wrapper to avoid
+// Wrapper to avoid handling c++ name mangling when writing assembly code
+
 uintptr_t collectRegisters(jmp_buf buf) {
   uintptr_t * regs = (uintptr_t *)buf;
   return collect_registers(regs);

--- a/ion/src/simulator/shared/collect_registers.cpp
+++ b/ion/src/simulator/shared/collect_registers.cpp
@@ -1,0 +1,17 @@
+#include <ion.h>
+
+extern "C" {
+
+// define in assembly code
+// Force the name as archs (linux/macos) don't mangle C names the same way
+extern uintptr_t collect_registers(uintptr_t * regs) asm ("_collect_registers");
+}
+namespace Ion {
+
+// Wrapper to avoid
+uintptr_t collectRegisters(jmp_buf buf) {
+  uintptr_t * regs = (uintptr_t *)buf;
+  return collect_registers(regs);
+}
+
+}

--- a/ion/src/simulator/shared/collect_registers_x86_64.s
+++ b/ion/src/simulator/shared/collect_registers_x86_64.s
@@ -1,0 +1,25 @@
+.text
+
+.global _collect_registers
+
+_collect_registers:
+        pushq   %r15
+        pushq   %r14
+        pushq   %r13
+        pushq   %r12
+        pushq   %rbp
+        pushq   %rbx
+        movq    %rbx, (%rdi)
+        movq    %rbp, 8(%rdi)
+        movq    %r12, 16(%rdi)
+        popq    %rbx
+        popq    %rbp
+        popq    %r12
+        movq    %r13, 24(%rdi)
+        movq    %r14, 32(%rdi)
+        popq    %r13
+        movq    %r15, 40(%rdi)
+        popq    %r14
+        popq    %r15
+        movq    %rsp, %rax
+        ret

--- a/ion/src/simulator/web/Makefile
+++ b/ion/src/simulator/web/Makefile
@@ -22,6 +22,8 @@ ion_src += $(addprefix ion/src/simulator/shared/, \
   dummy/language.cpp \
 )
 
+ion_src += ion/src/shared/collect_registers.cpp
+
 ifeq ($(EPSILON_TELEMETRY),1)
 ion_src += ion/src/simulator/shared/dummy/telemetry_init.cpp
 ion_src += ion/src/shared/telemetry_console.cpp

--- a/ion/src/simulator/windows/Makefile
+++ b/ion/src/simulator/windows/Makefile
@@ -8,6 +8,8 @@ ion_src += $(addprefix ion/src/simulator/shared/, \
   dummy/callback.cpp \
 )
 
+ion_src += ion/src/shared/collect_registers.cpp
+
 ifeq ($(EPSILON_TELEMETRY),1)
 ion_src += ion/src/simulator/shared/dummy/telemetry_init.cpp
 ion_src += ion/src/shared/telemetry_console.cpp

--- a/liba/include/setjmp.h
+++ b/liba/include/setjmp.h
@@ -1,6 +1,7 @@
 #ifndef LIBA_SETJMP_H
 #define LIBA_SETJMP_H
 
+#include <stdint.h>
 #include "private/macros.h"
 
 /* We are preseving registers:
@@ -14,7 +15,7 @@
 
 LIBA_BEGIN_DECLS
 
-typedef int jmp_buf[31];
+typedef uintptr_t jmp_buf[31];
 void longjmp(jmp_buf env, int val);
 int setjmp(jmp_buf env);
 

--- a/python/port/port.cpp
+++ b/python/port/port.cpp
@@ -155,8 +155,8 @@ void MicroPython::registerScriptProvider(ScriptProvider * s) {
 }
 
 void MicroPython::collectRootsAtAddress(char * address, int byteLength) {
-  /* All pointers on the stack are aligned on sizeof(void *), as asserted.
-   * This is a consequence of the alignment requireduirements of compilers as long
+  /* All addresses stored on the stack are aligned on sizeof(void *), as
+   * asserted. This is a consequence of the alignment requirements of compilers
    * (Cf http://www.catb.org/esr/structure-packing/). */
   assert(((unsigned long)address) % ((unsigned long)sizeof(void *)) == 0);
   assert(byteLength % sizeof(void *) == 0);

--- a/python/port/port.cpp
+++ b/python/port/port.cpp
@@ -248,7 +248,10 @@ KDColor MicroPython::ColorParser::ParseColor(mp_obj_t input, ColorMode ColorMode
   mp_raise_TypeError("Color couldn't be parsed");
 }
 
-void gc_collect(void) {
+/* Forbid inlining to ensure regs to be at the top of the stack. Otherwise,
+ * LTO inlining can make regs lower on the stack than some just-allocated
+ * pointers. */
+__attribute__((noinline)) void gc_collect(void) {
   void * python_stack_top = MP_STATE_THREAD(stack_top);
   assert(python_stack_top != NULL);
 

--- a/python/port/port.cpp
+++ b/python/port/port.cpp
@@ -123,7 +123,7 @@ void MicroPython::init(void * heapStart, void * heapEnd) {
   mp_pystack_init(pystack, &pystack[MP_ARRAY_SIZE(pystack)]);
 #endif
 
-  volatile uintptr_t stackTop;
+  volatile int stackTop;
   void * stackTopAddress = (void *)(&stackTop);
   /* We delimit the stack part that will be used by Python. The stackTop is the
    * address of the first object that can be allocated on Python stack. This


### PR DESCRIPTION
The Python garbage collection failed to mark some allocated objects for x86-64 architecture. We used to rely on the setjmp to get the registers values but this was not true for all architectures. 