### PR TITLE
[apps/shared] Fixed a small mistake in parameter_text_field_delegate.cpp

### DIFF
--- a/apps/shared/parameter_text_field_delegate.cpp
+++ b/apps/shared/parameter_text_field_delegate.cpp
@@ -5,6 +5,7 @@ namespace Shared {
 
 bool ParameterTextFieldDelegate::textFieldDidReceiveEvent(TextField * textField, Ion::Events::Event event) {
   if (event == Ion::Events::Backspace && !textField->isEditing()) {
+    textField->reinitDraftTextBuffer();
     textField->setEditing(true);
     return true;
   }


### PR DESCRIPTION
In this commit, there was a small oversight in https://github.com/numworks/epsilon/commit/7a4ee746b2a49a090cf920cfe53935ccdea7d607, which caused https://github.com/numworks/epsilon/issues/1570

So this PR fixes #1570 