### PR TITLE
[.github/workflow] ci-workflow: fix emscripten version to 1.39.16

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -70,7 +70,7 @@ jobs:
     steps:
       - uses: numworks/setup-emscripten@v2
         with:
-          sdk: latest-fastcomp
+          sdk: 1.39.16-fastcomp
       - uses: actions/checkout@v2
       - run: make -j2 PLATFORM=simulator TARGET=web
       - run: make -j2 PLATFORM=simulator TARGET=web epsilon.official.zip


### PR DESCRIPTION
Later versions of emscripten removed EMTERPRETER option.