### PR TITLE
[simulator] Make the calculator's screen pixel-perfect

### DIFF
--- a/ion/src/simulator/shared/layout.cpp
+++ b/ion/src/simulator/shared/layout.cpp
@@ -11,7 +11,7 @@ static constexpr float X(int x) { return static_cast<float>(x)/static_cast<float
 static constexpr float Y(int y) { return static_cast<float>(y)/static_cast<float>(backgroundHeight); }
 
 static constexpr SDL_FRect areaOfInterest = {X(110), Y(30), X(940), Y(2150)};
-static constexpr SDL_FRect screenRect = {X(192), Y(191), X(779), Y(582)};
+static constexpr SDL_FRect screenRect = {X(192), Y(191), X(776), Y(582)};
 
 static SDL_Rect sFrame;
 

--- a/ion/src/simulator/shared/main_sdl.cpp
+++ b/ion/src/simulator/shared/main_sdl.cpp
@@ -73,7 +73,7 @@ void init() {
     Ion::Display::Height,
     0 // Default flags: no high-dpi, not resizeable.
 #else
-    290, 555, // Otherwise use a default size that matches the whole calculator
+    458, 888, // Otherwise use a default size that makes the screen pixel-perfect
     SDL_WINDOW_ALLOW_HIGHDPI
 #if EPSILON_SDL_FULLSCREEN
     | SDL_WINDOW_FULLSCREEN


### PR DESCRIPTION
Try to make the calculator's screen fit perfectly on the host's pixel grid. This is **so** much easier on the eyes 😄 