### PR TITLE
Fix: rename all the IS by SI... because even in english we say "SI" a…

### DIFF
--- a/apps/calculation/additional_outputs/unit_list_controller.cpp
+++ b/apps/calculation/additional_outputs/unit_list_controller.cpp
@@ -30,7 +30,7 @@ void UnitListController::setExpression(Poincare::Expression e) {
   bool requireSimplification = false;
   bool canChangeUnitPrefix = false;
 
-  if (Unit::IsISSpeed(units)) {
+  if (Unit::IsSISpeed(units)) {
     // 1.a. Turn speed into km/h
     m_memoizedExpressions[numberOfMemoizedExpressions++] = UnitConvert::Builder(
         m_expression.clone(),
@@ -43,7 +43,7 @@ void UnitListController::setExpression(Poincare::Expression e) {
           )
         );
     requireSimplification = true; // Simplify the conversion
-  } else if (Unit::IsISVolume(units)) {
+  } else if (Unit::IsSIVolume(units)) {
     // 1.b. Turn volume into L
     m_memoizedExpressions[numberOfMemoizedExpressions++] = UnitConvert::Builder(
         m_expression.clone(),
@@ -51,7 +51,7 @@ void UnitListController::setExpression(Poincare::Expression e) {
         );
     requireSimplification = true; // Simplify the conversion
     canChangeUnitPrefix = true; // Pick best prefix (mL)
-  } else if (Unit::IsISEnergy(units)) {
+  } else if (Unit::IsSIEnergy(units)) {
     // 1.c. Turn energy into Wh
     m_memoizedExpressions[numberOfMemoizedExpressions++] = UnitConvert::Builder(
         m_expression.clone(),
@@ -66,7 +66,7 @@ void UnitListController::setExpression(Poincare::Expression e) {
         );
     requireSimplification = true; // Simplify the conversion
     canChangeUnitPrefix = true; // Pick best prefix (kWh)
-  } else if (Unit::IsISTime(units)) {
+  } else if (Unit::IsSITime(units)) {
     // Turn time into ? year + ? month + ? day + ? h + ? min + ? s
     double value = Shared::PoincareHelpers::ApproximateToScalar<double>(copy, App::app()->localContext());
     m_memoizedExpressions[numberOfMemoizedExpressions++] = Unit::BuildTimeSplit(value, App::app()->localContext(), Preferences::sharedPreferences()->complexFormat(), Preferences::sharedPreferences()->angleUnit());

--- a/apps/calculation/calculation.cpp
+++ b/apps/calculation/calculation.cpp
@@ -112,7 +112,7 @@ Layout Calculation::createExactOutputLayout(bool * couldNotCreateExactLayout) {
     return PoincareHelpers::CreateLayout(exactOutput());
   } else {
     *couldNotCreateExactLayout = true;
-    return Layout(); 
+    return Layout();
   }
 }
 

--- a/apps/calculation/calculation.cpp
+++ b/apps/calculation/calculation.cpp
@@ -112,7 +112,7 @@ Layout Calculation::createExactOutputLayout(bool * couldNotCreateExactLayout) {
     return PoincareHelpers::CreateLayout(exactOutput());
   } else {
     *couldNotCreateExactLayout = true;
-    return Layout();
+    return Layout(); 
   }
 }
 

--- a/apps/calculation/calculation.cpp
+++ b/apps/calculation/calculation.cpp
@@ -258,13 +258,13 @@ Calculation::AdditionalInformationType Calculation::additionalInformationType(Co
     Expression unit;
     PoincareHelpers::Reduce(&o, App::app()->localContext(), ExpressionNode::ReductionTarget::User,ExpressionNode::SymbolicComputation::ReplaceAllSymbolsWithDefinitionsOrUndefined, ExpressionNode::UnitConversion::None);
     o = o.removeUnit(&unit);
-    if (Unit::IsIS(unit)) {
-      if (Unit::IsISSpeed(unit) || Unit::IsISVolume(unit) || Unit::IsISEnergy(unit)) {
+    if (Unit::IsSI(unit)) {
+      if (Unit::IsSISpeed(unit) || Unit::IsSIVolume(unit) || Unit::IsSIEnergy(unit)) {
         /* All these units will provide misc. classic representatives in
          * addition to the SI unit in additional information. */
         return AdditionalInformationType::Unit;
       }
-      if (Unit::IsISTime(unit)) {
+      if (Unit::IsSITime(unit)) {
         /* If the number of seconds is above 60s, we can write it in the form
          * of an addition: 23_min + 12_s for instance. */
         double value = Shared::PoincareHelpers::ApproximateToScalar<double>(o, App::app()->localContext());

--- a/poincare/include/poincare/unit.h
+++ b/poincare/include/poincare/unit.h
@@ -767,11 +767,11 @@ public:
   static Unit Watt() { return Builder(PowerDimension, WattRepresentative, &EmptyPrefix); }
   static Expression BuildTimeSplit(double seconds, Context * context, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit);
 
-  static bool IsIS(Expression & e);
-  static bool IsISSpeed(Expression & e);
-  static bool IsISVolume(Expression & e);
-  static bool IsISEnergy(Expression & e);
-  static bool IsISTime(Expression & e);
+  static bool IsSI(Expression & e);
+  static bool IsSISpeed(Expression & e);
+  static bool IsSIVolume(Expression & e);
+  static bool IsSIEnergy(Expression & e);
+  static bool IsSITime(Expression & e);
   bool isMeter() const;
   bool isSecond() const;
   bool isKilogram() const;
@@ -791,7 +791,7 @@ private:
   static constexpr double MonthPerYear = 12.0;
   static constexpr double DaysPerMonth = DaysPerYear/MonthPerYear;
   UnitNode * node() const { return static_cast<UnitNode *>(Expression::node()); }
-  bool isIS() const;
+  bool isSI() const;
   static void ChooseBestMultipleForValue(Expression * units, double * value, bool tuneRepresentative, ExpressionNode::ReductionContext reductionContext);
   void chooseBestMultipleForValue(double * value, const int exponent, bool tuneRepresentative, ExpressionNode::ReductionContext reductionContext);
   Expression removeUnit(Expression * unit);

--- a/poincare/src/unit.cpp
+++ b/poincare/src/unit.cpp
@@ -421,7 +421,7 @@ bool Unit::isKilogram() const {
   return node()->dimension() == MassDimension && node()->representative() == KilogramRepresentative && node()->prefix() == &KiloPrefix;
 }
 
-bool Unit::isIS() const {
+bool Unit::isSI() const {
   UnitNode * unitNode = node();
   const Dimension * dim = unitNode->dimension();
   const Representative * rep = unitNode->representative();
@@ -430,12 +430,12 @@ bool Unit::isIS() const {
          unitNode->prefix() == dim->stdRepresentativePrefix();
 }
 
-bool Unit::IsIS(Expression & e) {
+bool Unit::IsSI(Expression & e) {
   if (e.type() == ExpressionNode::Type::Multiplication) {
     for (int i = 0; i < e.numberOfChildren(); i++) {
       Expression child = e.childAtIndex(i);
       assert(child.type() == ExpressionNode::Type::Power || child.type() == ExpressionNode::Type::Unit);
-      if (!IsIS(child)) {
+      if (!IsSI(child)) {
         return false;
       }
     }
@@ -445,13 +445,13 @@ bool Unit::IsIS(Expression & e) {
     assert(e.childAtIndex(1).type() == ExpressionNode::Type::Rational && e.childAtIndex(1).convert<Rational>().isInteger());
     Expression child = e.childAtIndex(0);
     assert(child.type() == ExpressionNode::Type::Unit);
-    return IsIS(child);
+    return IsSI(child);
   }
   assert(e.type() == ExpressionNode::Type::Unit);
-  return static_cast<Unit &>(e).isIS();
+  return static_cast<Unit &>(e).isSI();
 }
 
-bool Unit::IsISSpeed(Expression & e) {
+bool Unit::IsSISpeed(Expression & e) {
   // Form m*s^-1
   return e.type() == ExpressionNode::Type::Multiplication && e.numberOfChildren() == 2 &&
     e.childAtIndex(0).type() == ExpressionNode::Type::Unit && e.childAtIndex(0).convert<Unit>().isMeter() &&
@@ -460,14 +460,14 @@ bool Unit::IsISSpeed(Expression & e) {
     e.childAtIndex(1).childAtIndex(0).type() == ExpressionNode::Type::Unit && e.childAtIndex(1).childAtIndex(0).convert<Unit>().isSecond();
 }
 
-bool Unit::IsISVolume(Expression & e) {
+bool Unit::IsSIVolume(Expression & e) {
   // Form m^3
   return e.type() == ExpressionNode::Type::Power &&
     e.childAtIndex(0).type() == ExpressionNode::Type::Unit && e.childAtIndex(0).convert<Unit>().isMeter() &&
     e.childAtIndex(1).type() == ExpressionNode::Type::Rational && e.childAtIndex(1).convert<const Rational>().isThree();
 }
 
-bool Unit::IsISEnergy(Expression & e) {
+bool Unit::IsSIEnergy(Expression & e) {
   // Form _kg*_m^2*_s^-2
   return e.type() == ExpressionNode::Type::Multiplication && e.numberOfChildren() == 3 &&
     e.childAtIndex(0).type() == ExpressionNode::Type::Unit && e.childAtIndex(0).convert<Unit>().isKilogram() &&
@@ -479,7 +479,7 @@ bool Unit::IsISEnergy(Expression & e) {
     e.childAtIndex(2).childAtIndex(1).type() == ExpressionNode::Type::Rational && e.childAtIndex(2).childAtIndex(1).convert<const Rational>().isMinusTwo();
 }
 
-bool Unit::IsISTime(Expression & e) {
+bool Unit::IsSITime(Expression & e) {
   return e.type() == ExpressionNode::Type::Unit && static_cast<Unit &>(e).isSecond();
 }
 

--- a/poincare/test/expression_properties.cpp
+++ b/poincare/test/expression_properties.cpp
@@ -420,22 +420,22 @@ QUIZ_CASE(poincare_expression_unit_helper) {
 
   // 2. Speed
   Expression meterPerSecond = extract_unit("_m×_s^-1");
-  quiz_assert(Unit::IsISSpeed(meterPerSecond));
+  quiz_assert(Unit::IsSISpeed(meterPerSecond));
 
   // 3. Volume
   Expression meter3 = extract_unit("_m^3");
-  quiz_assert(Unit::IsISVolume(meter3));
+  quiz_assert(Unit::IsSIVolume(meter3));
 
   // 4. Energy
   Expression kilogramMeter2PerSecond2 = extract_unit("_kg×_m^2×_s^-2");
-  quiz_assert(Unit::IsISEnergy(kilogramMeter2PerSecond2));
+  quiz_assert(Unit::IsSIEnergy(kilogramMeter2PerSecond2));
   Expression kilogramMeter3PerSecond2 = extract_unit("_kg×_m^3×_s^-2");
-  quiz_assert(!Unit::IsISEnergy(kilogramMeter3PerSecond2));
+  quiz_assert(!Unit::IsSIEnergy(kilogramMeter3PerSecond2));
 
   // 5. International System
-  quiz_assert(Unit::IsIS(kilogramMeter2PerSecond2));
-  quiz_assert(Unit::IsIS(meter3));
-  quiz_assert(Unit::IsIS(meterPerSecond));
+  quiz_assert(Unit::IsSI(kilogramMeter2PerSecond2));
+  quiz_assert(Unit::IsSI(meter3));
+  quiz_assert(Unit::IsSI(meterPerSecond));
   Expression joule = extract_unit("_J");
-  quiz_assert(!Unit::IsIS(joule));
+  quiz_assert(!Unit::IsSI(joule));
 }


### PR DESCRIPTION
The International System of Units is shortened "SI" in all the languages because it's french :), same as we use UTC ( which is a chimere between french&english )
It matters a lot to me, a fellow fan of the International System of Units :) 
cf: https://en.wikipedia.org/wiki/International_System_of_Units :)

TODO: well compilation :kappa:
*it's not funny when the CI is broken*
