### PR TITLE
[apps/calculation] HistoryController: reload the subview selection when deleting row

### DIFF
--- a/apps/calculation/history_controller.cpp
+++ b/apps/calculation/history_controller.cpp
@@ -129,7 +129,9 @@ bool HistoryController::handleEvent(Ion::Events::Event event) {
       return true;
     }
     m_selectableTableView.selectCellAtLocation(0, focusRow > 0 ? focusRow - 1 : 0);
-    setSelectedSubviewType(subviewType, true, 0, selectedRow());
+    /* The parameters 'sameCell' and 'previousSelectedY' are chosen to enforce
+     * toggling of the output when necessary. */
+    setSelectedSubviewType(subviewType, false, 0, (subviewType == SubviewType::Input) ? selectedRow() : -1);
     return true;
   }
   if (event == Ion::Events::Clear) {


### PR DESCRIPTION
This fixes the following bug: input 1, OK, 1.2 OK, delete the row whose
input is '1' with the selection on the output view. The output of 1.2
does not toggle and it should.