### PR TITLE
[apps/shared] ToolBoxHelpers: don't overflow buffer

### DIFF
--- a/apps/shared/toolbox_helpers.cpp
+++ b/apps/shared/toolbox_helpers.cpp
@@ -41,7 +41,7 @@ void TextToInsertForCommandText(const char * command, int commandLength, char * 
 
   UTF8Decoder decoder(command);
   CodePoint codePoint = decoder.nextCodePoint();
-  while (codePoint != UCodePointNull && (commandLength < 0 || (decoder.stringPosition() - command <=  commandLength))) {
+  while (codePoint != UCodePointNull && index < bufferSize - 1 && (commandLength < 0 || (decoder.stringPosition() - command <=  commandLength))) {
     if (codePoint == ')') {
       numberOfOpenParentheses--;
     } else if (codePoint == ']') {


### PR DESCRIPTION
If the commandLength is > than the buffer size, we have to escape at
some point to avoid overflowing the buffer.