### PR TITLE
Execute only two times libpng-config

### DIFF
--- a/build/platform.simulator.mak
+++ b/build/platform.simulator.mak
@@ -15,6 +15,6 @@ include build/platform.simulator.$(TARGET).mak
 SFLAGS += -DEPSILON_SIMULATOR_HAS_LIBPNG=$(EPSILON_SIMULATOR_HAS_LIBPNG)
 
 ifeq ($(EPSILON_SIMULATOR_HAS_LIBPNG),1)
-SFLAGS += `libpng-config --cflags`
-LDFLAGS += `libpng-config --ldflags`
+SFLAGS += $(shell libpng-config --cflags)
+LDFLAGS += $(shell libpng-config --ldflags)
 endif


### PR DESCRIPTION
This is a bit cleaner, and make win one second of compile time, I think