### PR TITLE
Correctly blend identical colors

### DIFF
--- a/kandinsky/src/color.cpp
+++ b/kandinsky/src/color.cpp
@@ -7,7 +7,11 @@ KDColor KDColor::blend(KDColor first, KDColor second, uint8_t alpha) {
    * dealt with. So let's make a special case for them. */
   if (alpha == 0) {
     return second;
-  } else if (alpha == 0xFF) {
+  }
+  if (alpha == 0xFF) {
+    return first;
+  }
+  if (first == second) {
     return first;
   }
 
@@ -21,8 +25,8 @@ KDColor KDColor::blend(KDColor first, KDColor second, uint8_t alpha) {
   uint16_t blue = first.blue()*alpha + second.blue()*oneMinusAlpha;
   return RGB888(red>>8, green>>8, blue>>8);
 
-
-  // Blend White + black, ask for white
-  // white.red() = 0x1F << 3 = 0xF8
-//  white.red() * 0xFF = 0xF708, we wanted 0xF800
+  /* The formula used to blend colors produces some unwanted results :
+   * blend white + black, alpha = OxFF (should be white)
+   * white.red() * OxFF = OxF708, while we would like 0xF800
+   * Escaping early solves this issue. */
 }

--- a/kandinsky/src/color.cpp
+++ b/kandinsky/src/color.cpp
@@ -4,7 +4,8 @@ KDColor KDColor::blend(KDColor first, KDColor second, uint8_t alpha) {
   /* This function is a hot path since it's being called for every single pixel
    * whenever we want to display a string. In this context, we're quite often
    * calling it with a value of either 0 or 0xFF, which can be very trivially
-   * dealt with. So let's make a special case for them. */
+   * dealt with. Similarly, blending the same two colors yields a trivial
+   * result and can be bypassed. Let's make a special case for them. */
   if (alpha == 0) {
     return second;
   }

--- a/kandinsky/src/color.cpp
+++ b/kandinsky/src/color.cpp
@@ -19,14 +19,9 @@ KDColor KDColor::blend(KDColor first, KDColor second, uint8_t alpha) {
   // First is RRRRR GGGGGG BBBBB
   // Second is same
 
-  uint8_t oneMinusAlpha = 0xFF-alpha;
+  uint16_t oneMinusAlpha = 0x100-alpha;
   uint16_t red = first.red()*alpha + second.red()*oneMinusAlpha;
   uint16_t green = first.green()*alpha + second.green()*oneMinusAlpha;
   uint16_t blue = first.blue()*alpha + second.blue()*oneMinusAlpha;
   return RGB888(red>>8, green>>8, blue>>8);
-
-  /* The formula used to blend colors produces some unwanted results :
-   * blend white + black, alpha = OxFF (should be white)
-   * white.red() * OxFF = OxF708, while we would like 0xF800
-   * Escaping early solves this issue. */
 }

--- a/kandinsky/test/color.cpp
+++ b/kandinsky/test/color.cpp
@@ -17,10 +17,25 @@ QUIZ_CASE(kandinsky_color_rgb) {
   quiz_assert(KDColor::RGB24(0x123456) == 0x11AA);
 }
 
+void assert_colors_blend_to(KDColor c1, KDColor c2, uint8_t alpha, KDColor res) {
+  quiz_assert(KDColor::blend(c1, c2, alpha) == res );
+}
+
 QUIZ_CASE(kandinsky_color_blend) {
   KDColor midGray = KDColor::RGB24(0x7F7F7F);
-  KDColor res = KDColor::blend(KDColorWhite, KDColorBlack, 0xFF);
-  quiz_assert(res == KDColorWhite);
-  quiz_assert(KDColor::blend(KDColorWhite, KDColorBlack, 0) == KDColorBlack);
-  quiz_assert(KDColor::blend(KDColorWhite, KDColorBlack, 0x7F) == midGray);
+  KDColor midTurquoise = KDColor::RGB24(0x007F7F);
+
+  assert_colors_blend_to(KDColorWhite, KDColorBlack, 0x00, KDColorBlack);
+  assert_colors_blend_to(KDColorWhite, KDColorBlack, 0xFF, KDColorWhite);
+  assert_colors_blend_to(KDColorWhite, KDColorBlack, 0x7F, midGray);
+
+  assert_colors_blend_to(KDColorGreen, KDColorBlue, 0x00, KDColorBlue);
+  assert_colors_blend_to(KDColorGreen, KDColorBlue, 0xFF, KDColorGreen);
+  assert_colors_blend_to(KDColorGreen, KDColorBlue, 0x7F, midTurquoise);
+
+  // Assert that blending two identical colors does not produce strange colors.
+  for (uint16_t col = 0; col < 0xFFFF; col++) {
+    KDColor color = KDColor::RGB16(col);
+    assert_colors_blend_to(color, color, col>>8, color);
+  }
 }


### PR DESCRIPTION
This fixes issue #1643 : "White text using draw_string isn't really white/invisible."