### PR TITLE
Put python interruptions on a timer

### DIFF
--- a/apps/code/console_controller.cpp
+++ b/apps/code/console_controller.cpp
@@ -450,26 +450,6 @@ void ConsoleController::printText(const char * text, size_t length) {
     flushOutputAccumulationBufferToStore();
     micropython_port_vm_hook_refresh_print();
   }
-#if __EMSCRIPTEN__
-  /* If we called micropython_port_interrupt_if_needed here, we would need to
-   * put in the WHITELIST all the methods that call
-   * ConsoleController::printText, which means all the MicroPython methods that
-   * call print... This is a lot of work + might reduce the performance as
-   * emterpreted code is slower.
-   *
-   * We thus do not allow print interruption on the web simulator. It would be
-   * better to allow it, but the biggest problem was on the device anyways
-   * -> It is much quicker to interrupt Python on the web simulator than on the
-   * device.
-   *
-   * TODO: Allow print interrpution on emscripten -> maybe by using WASM=1 ? */
-#else
-  /* micropython_port_vm_hook_loop is not enough to detect user interruptions,
-   * because it calls micropython_port_interrupt_if_needed every 20000
-   * operations, and a print operation is quite long. We thus explicitely call
-   * micropython_port_interrupt_if_needed here. */
-  micropython_port_interrupt_if_needed();
-#endif
 }
 
 void ConsoleController::autoImportScript(Script script, bool force) {

--- a/python/port/helpers.cpp
+++ b/python/port/helpers.cpp
@@ -12,12 +12,15 @@ bool micropython_port_vm_hook_loop() {
 
   /* Doing too many things here slows down Python execution quite a lot. So we
    * only do things once in a while and return as soon as possible otherwise. */
-  static int c = 0;
 
-  c = (c + 1) % 20000;
-  if (c != 0) {
+  static uint64_t t = Ion::Timing::millis();
+  static constexpr uint64_t delay = 100;
+
+  uint64_t t2 = Ion::Timing::millis();
+  if (t2 - t < delay) {
     return false;
   }
+  t = t2;
 
   micropython_port_vm_hook_refresh_print();
   // Check if the user asked for an interruption from the keyboard

--- a/python/port/mod/kandinsky/modkandinsky.cpp
+++ b/python/port/mod/kandinsky/modkandinsky.cpp
@@ -62,16 +62,6 @@ mp_obj_t modkandinsky_draw_string(size_t n_args, const mp_obj_t * args) {
   KDColor backgroundColor = (n_args >= 5) ? MicroPython::Color::Parse(args[4]) : KDColorWhite;
   MicroPython::ExecutionEnvironment::currentExecutionEnvironment()->displaySandbox();
   KDIonContext::sharedContext()->drawString(text, point, KDFont::LargeFont, textColor, backgroundColor);
-  /* Before and after execution of "modkandinsky_draw_string",
-   * "micropython_port_vm_hook_loop" is called by "mp_execute_bytecode" and will
-   * call "micropython_port_interrupt_if_needed" every 20000 calls.
-   * However, "drawString" function might take some time to execute leading to
-   * drastically decrease the frequency of calls to
-   * "micropython_port_vm_hook_loop" and thus to
-   * "micropython_port_interrupt_if_needed". So we add an extra
-   * check for user interruption here. This way the user can still interrupt an
-   * infinite loop calling 'drawString' for instance. */
-  micropython_port_interrupt_if_needed();
   return mp_const_none;
 }
 
@@ -92,7 +82,5 @@ mp_obj_t modkandinsky_fill_rect(size_t n_args, const mp_obj_t * args) {
   KDColor color = MicroPython::Color::Parse(args[4]);
   MicroPython::ExecutionEnvironment::currentExecutionEnvironment()->displaySandbox();
   KDIonContext::sharedContext()->fillRect(rect, color);
-  // Cf comment on modkandinsky_draw_string
-  micropython_port_interrupt_if_needed();
   return mp_const_none;
 }


### PR DESCRIPTION
Instead of checking interruptions every 20000 calls to `micropython_port_vm_hook_loop`, do it if 100ms have passed since the last check.
This fixes issue #1649 and improves performances for the Kandinsky module's `drawString` and `fillRect` methods.