### PR TITLE
Fix Issue #1637: Incorrect Astronomical Unit's value

### DIFF
--- a/poincare/include/poincare/unit.h
+++ b/poincare/include/poincare/unit.h
@@ -291,7 +291,7 @@ public:
         Representative("m",   nullptr,
             Representative::Prefixable::Yes,
             LongScalePrefixes),
-        Representative("au",  "149587870700*_m",
+        Representative("au",  "149597870700*_m",
             Representative::Prefixable::No,
             NoPrefix),
         Representative("ly",  "299792458*_m/_s*_year",


### PR DESCRIPTION
I fixed the typo reported by issue #1637 that reported that the astronomical unit's value in meters had a typo:

> Expected behavior
> That the result would be shown as 149 597 870 700 m instead of 149 587 870 700 m

I simply modified its value in `poincare/include/poincare/unit.h:294` to be the correct one.
Thanks for creating epsilon!