### PR TITLE
[apps/shared] CurveView: avoid overflowing KDCoordinate

### DIFF
--- a/apps/shared/curve_view.cpp
+++ b/apps/shared/curve_view.cpp
@@ -412,6 +412,10 @@ void CurveView::drawHorizontalOrVerticalSegment(KDContext * ctx, KDRect rect, Ax
   if (dashSize < 0) {
     // Continuous segment is equivalent to one big dash
     dashSize = end - start;
+    if (dashSize < 0) {
+      // end-start overflowed
+      dashSize = KDCOORDINATE_MAX;
+    }
   }
   KDRect lineRect = KDRectZero;
   for (KDCoordinate i = start; i < end; i += 2*dashSize) {

--- a/apps/shared/curve_view.cpp
+++ b/apps/shared/curve_view.cpp
@@ -426,6 +426,10 @@ void CurveView::drawHorizontalOrVerticalSegment(KDContext * ctx, KDRect rect, Ax
     if (rect.intersects(lineRect)) {
       ctx->fillRect(lineRect, color);
     }
+    if (i > KDCOORDINATE_MAX - 2*dashSize) {
+      // Avoid overflowing KDCoordinate
+      break;
+    }
   }
 }
 


### PR DESCRIPTION
This fixes the following bug: add the sequence, u(n)=2^n. On the graph,
go to "sum of terms" and try to sum terms from 0 to 18 by moving the
cursor. It hangs.