### PR TITLE
Use semantic branches on setup-arm-toolchain

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: sudo apt-get install build-essential imagemagick libfreetype6-dev libjpeg-dev libpng-dev pkg-config
-      - uses: numworks/setup-arm-toolchain@v1
+      - uses: numworks/setup-arm-toolchain@2020-q2
       - uses: actions/checkout@v2
       - run: make -j2 MODEL=n0100 epsilon.dfu
       - run: make -j2 MODEL=n0100 epsilon.onboarding.dfu
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: sudo apt-get install build-essential imagemagick libfreetype6-dev libjpeg-dev libpng-dev pkg-config
-      - uses: numworks/setup-arm-toolchain@v1
+      - uses: numworks/setup-arm-toolchain@2020-q2
       - uses: actions/checkout@v2
       - run: make -j2 epsilon.dfu
       - run: make -j2 epsilon.onboarding.dfu

--- a/.github/workflows/metrics-workflow.yml
+++ b/.github/workflows/metrics-workflow.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get install build-essential imagemagick libfreetype6-dev libjpeg-dev libpng-dev pkg-config
       - name: Install ARM toolchain
-        uses: numworks/setup-arm-toolchain@v1
+        uses: numworks/setup-arm-toolchain@2020-q2
       - name: Checkout PR base
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Fix the broken CI on Arm targets. See [this issue](https://github.com/numworks/setup-arm-toolchain/issues/5) on the `setup-arm-toolchain` action.