### PR TITLE
[github/workflows] Update Metrics to remove NumWorksBot

### DIFF
--- a/.github/workflows/metrics-workflow.yml
+++ b/.github/workflows/metrics-workflow.yml
@@ -1,5 +1,5 @@
 name: Metrics
-on: [pull_request]
+on: [pull_request_target]
 
 jobs:
   binary-size:
@@ -26,11 +26,14 @@ jobs:
       - name: Retrieve binary size analysis
         id: binary_size
         run: echo "::set-output name=table::$(python3 head/build/metrics/binary_size.py base/output/release/device/n0110/epsilon.elf head/output/release/device/n0110/epsilon.elf --labels Base Head --sections .text .rodata .bss .data --escape)"
-      - name: Prepare comment auth
-        run: echo "::set-env name=GITHUB_TOKEN::$(echo ZGExNWM1YzNlMjVkMWU5ZGFmOWQyY2UxMmRhYjJiN2ZhMWM4ODVhMA== | base64 --decode)"
       - name: Add comment
-        uses: actions/github@v1.0.0
-        env:
-          GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
+        uses: actions/github-script@v3.0.0
         with:
-          args: comment ${{ steps.binary_size.outputs.table }}
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            await github.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: `${{ steps.binary_size.outputs.table }}`,
+            });


### PR DESCRIPTION
Change-Id: Icfd19cbad5472f6bf81a2a1accb88e79ab7a115b

Triggering on pull_request_target event, the base version of Metrics will always run on future PR, preventing misuse of this workflow.

Additionally, comment is generated using github-script API. We don't need NumWorksBot anymore.
<img width="939" alt="image" src="https://user-images.githubusercontent.com/67104016/100070304-0e6df480-2e3a-11eb-8aa4-df90ad7c7a23.png">
