### PR TITLE
[Web simulator] Fix screenshot

### DIFF
--- a/ion/src/simulator/web/simulator-setup.js
+++ b/ion/src/simulator/web/simulator-setup.js
@@ -59,7 +59,10 @@ function screenshot() {
 
   var canvas = document.getElementById('canvas');
   var link = document.createElement('a');
+  link.setAttribute("type", "hidden");
   link.download = 'screenshot.png';
   link.href = canvas.toDataURL('image/png').replace('image/png', 'image/octet-stream');
+  document.body.appendChild(link);
   link.click();
+  link.remove();
 }


### PR DESCRIPTION
on windows 10 32 bits with Firefox 64.0.2 , when using `.click()` on a dom element which isn't in the body, the function returns `undef` but doesn't open the link, and fails silently.
This fixes this issue