### PR TITLE
[Ion/simulator/dummy] Fix serial_number length to device like

### DIFF
--- a/ion/src/simulator/shared/dummy/serial_number.cpp
+++ b/ion/src/simulator/shared/dummy/serial_number.cpp
@@ -1,5 +1,5 @@
 #include <ion.h>
 
 const char * Ion::serialNumber() {
-  return "000000000000";
+  return "0000000000000000";
 }


### PR DESCRIPTION
This is a part of fix of https://github.com/numworks/epsilon/issues/1745