### PR TITLE
[Apps layout] add non ordered apps at the end

### DIFF
--- a/apps/home/apps_layout.py
+++ b/apps/home/apps_layout.py
@@ -22,6 +22,10 @@ def build_permutation(apps, appsOrdered):
         if app in apps:
             res[i] = apps.index(app) + 1
             i += 1
+    for app in apps:
+        index = apps.index(app) + 1
+        if not index in res:
+            res[res[1:].index(0)+1]=index # Place the non ordered apps at the end
     return res
 
 def parse_config_file(layouts, apps):


### PR DESCRIPTION
When an app isn't in the apps_layout.csv, it will be still displayed in menu (but it will be the home app displayed). This fixes this "glitchy" display, and make easier the installation of custom apps.