### PR TITLE
[Poincare] Added more talktative tests

### DIFF
--- a/apps/calculation/test/calculation_store.cpp
+++ b/apps/calculation/test/calculation_store.cpp
@@ -83,18 +83,42 @@ QUIZ_CASE(calculation_ans) {
 void assertCalculationIs(const char * input, DisplayOutput display, EqualSign sign, const char * exactOutput, const char * displayedApproximateOutput, const char * storedApproximateOutput, Context * context, CalculationStore * store) {
   store->push(input, context, dummyHeight);
   Shared::ExpiringPointer<::Calculation::Calculation> lastCalculation = store->calculationAtIndex(0);
-  quiz_assert(lastCalculation->displayOutput(context) == display);
+
+  static_assert(static_cast<int>(DisplayOutput::Unknown) == 0 &&
+                static_cast<int>(DisplayOutput::ExactOnly) == 1 &&
+                static_cast<int>(DisplayOutput::ApproximateOnly) == 2 &&
+                static_cast<int>(DisplayOutput::ExactAndApproximate) == 3 &&
+                static_cast<int>(DisplayOutput::ExactAndApproximateToggle) == 4, 
+                "Display output has changed. Change symbols under this line.");
+  const char * symbolForDisplayOutput[5] = {
+    "Unknown",
+    "ExactOnly",
+    "ApproximateOnly",
+    "ExactAndApproximate",
+    "ExactAndApproximateToggle"
+  };
+  assert_and_dispplay_result_for_enum(input, (uint8_t)lastCalculation->displayOutput(context), (uint8_t)display, symbolForDisplayOutput, "DisplayOutput");
+
   if (sign != EqualSign::Unknown) {
-    quiz_assert(lastCalculation->exactAndApproximateDisplayedOutputsAreEqual(context) == sign);
+    static_assert(static_cast<int>(EqualSign::Unknown) == 0 &&
+                static_cast<int>(EqualSign::Approximation) == 1 &&
+                static_cast<int>(EqualSign::Equal) == 2, 
+                "Equal Sign has changed. Change symbols under this line.");
+    const char * symbolForEqualSign[3] = {
+      "Unkown",
+      "Approximation",
+      "Equal"
+    };
+    assert_and_dispplay_result_for_enum(input, (uint8_t)lastCalculation->exactAndApproximateDisplayedOutputsAreEqual(context), (uint8_t)sign, symbolForEqualSign, "EqualSign");
   }
   if (exactOutput) {
-    quiz_assert_print_if_failure(strcmp(lastCalculation->exactOutputText(), exactOutput) == 0, input);
+    assert_compare_string(input, lastCalculation->exactOutputText(), exactOutput, "exact output");
   }
   if (displayedApproximateOutput) {
-    quiz_assert_print_if_failure(strcmp(lastCalculation->approximateOutputText(NumberOfSignificantDigits::UserDefined), displayedApproximateOutput) == 0, input);
+    assert_compare_string(input, lastCalculation->approximateOutputText(NumberOfSignificantDigits::UserDefined), displayedApproximateOutput, "displayed approximate output");
   }
   if (storedApproximateOutput) {
-    quiz_assert_print_if_failure(strcmp(lastCalculation->approximateOutputText(NumberOfSignificantDigits::Maximal), storedApproximateOutput) == 0, input);
+    assert_compare_string(input, lastCalculation->approximateOutputText(NumberOfSignificantDigits::Maximal), storedApproximateOutput, "storedf Approximate Output");
   }
   store->deleteAll();
 }

--- a/poincare/test/helper.cpp
+++ b/poincare/test/helper.cpp
@@ -37,6 +37,64 @@ void quiz_assert_log_if_failure(bool test, TreeHandle tree) {
   quiz_assert(test);
 }
 
+void assert_and_dispplay_result_for_enum(const char * input, uint8_t result, uint8_t expectedResult, const char ** stringArrayForEnum, const char * type) {
+  constexpr int bufferSize = 500;
+  char buffer[bufferSize] = "";
+  if(!(result == expectedResult)) {
+    char * position = buffer;
+    size_t remainingLength = bufferSize;
+    static constexpr size_t numberOfPieces = 8;
+    const char * piecesOfInformation[numberOfPieces] = {
+      "  ",
+      input,
+      "\n  has as ",
+      type,
+      "\n  ",
+      stringArrayForEnum[result],
+      "\n  instead of\n  ",
+      stringArrayForEnum[expectedResult],
+    };
+    for (size_t piece = 0; piece < numberOfPieces; piece++) {
+      const size_t length = strlcpy(position, piecesOfInformation[piece], remainingLength);
+      if (length > remainingLength) {
+        break;
+      }
+      remainingLength -= length;
+      position += length;
+    }
+  }
+  quiz_assert_print_if_failure(result == expectedResult, buffer);
+}
+
+void assert_compare_string(const char * input, const char * output, const char * expectedResult, const char * type) {
+  constexpr int bufferSize = 500;
+  char buffer[bufferSize] = "";
+  if(!(strcmp(output, expectedResult) == 0)) {
+    char * position = buffer;
+    size_t remainingLength = bufferSize;
+    static constexpr size_t numberOfPieces = 8;
+    const char * piecesOfInformation[numberOfPieces] = {
+      "  ",
+      input,
+      "\n  has as ",
+      type,
+      "\n  ",
+      output,
+      "\n  instead of\n  ",
+      expectedResult,
+    };
+    for (size_t piece = 0; piece < numberOfPieces; piece++) {
+      const size_t length = strlcpy(position, piecesOfInformation[piece], remainingLength);
+      if (length > remainingLength) {
+        break;
+      }
+      remainingLength -= length;
+      position += length;
+    }
+  }
+  quiz_assert_print_if_failure(strcmp(output, expectedResult) == 0, buffer);
+}
+
 void assert_parsed_expression_process_to(const char * expression, const char * result, ExpressionNode::ReductionTarget target, Preferences::ComplexFormat complexFormat, Preferences::AngleUnit angleUnit, Preferences::UnitFormat unitFormat, ExpressionNode::SymbolicComputation symbolicComputation, ExpressionNode::UnitConversion unitConversion, ProcessExpression process, int numberOfSignifiantDigits) {
   Shared::GlobalContext globalContext;
   Expression e = parse_expression(expression, &globalContext, false);

--- a/poincare/test/helper.h
+++ b/poincare/test/helper.h
@@ -33,6 +33,9 @@ void quiz_assert_log_if_failure(bool test, Poincare::TreeHandle tree);
 
 typedef Poincare::Expression (*ProcessExpression)(Poincare::Expression, Poincare::ExpressionNode::ReductionContext reductionContext);
 
+void assert_and_dispplay_result_for_enum(const char * input, uint8_t result, uint8_t expectedResult, const char ** stringArrayForEnum, const char * type);
+void assert_compare_string(const char * input, const char * output, const char * expectedResult, const char * type);
+
 void assert_parsed_expression_process_to(const char * expression, const char * result, Poincare::ExpressionNode::ReductionTarget target, Poincare::Preferences::ComplexFormat complexFormat, Poincare::Preferences::AngleUnit angleUnit, Poincare::Preferences::UnitFormat unitFormat, Poincare::ExpressionNode::SymbolicComputation symbolicComputation, Poincare::ExpressionNode::UnitConversion unitConversion, ProcessExpression process, int numberOfSignifiantDigits = Poincare::PrintFloat::k_numberOfStoredSignificantDigits);
 
 // Parsing


### PR DESCRIPTION
Added on calculation_store tests some usefull infos :
```
TEST FAILURE WHILE TESTING:
  1/2
  has as DisplayOutput
  ExactAndApproximate
  instead of
  ApproximateOnly
  ```
  ```
  TEST FAILURE WHILE TESTING:
  1/0
  has as exact output
  undef
  instead of
  a
  ```
  
#### context
It is very usefull to correct the unit tests of omega
And for new contributor it will be way easier to understand why the CI fails