### PR TITLE
Fix #1777 and #1276

### DIFF
--- a/apps/Makefile
+++ b/apps/Makefile
@@ -88,6 +88,7 @@ $(BUILD_DIR)/apps/i18n.h: $(BUILD_DIR)/apps/i18n.cpp
 $(eval $(call depends_on_image,apps/title_bar_view.cpp,apps/exam_icon.png))
 
 $(call object_for,$(apps_src) $(tests_src)): $(BUILD_DIR)/apps/i18n.h
+$(call object_for,$(apps_src) $(tests_src)): $(BUILD_DIR)/apps/home/apps_layout.h
 $(call object_for,$(apps_src) $(tests_src)): $(BUILD_DIR)/python/port/genhdr/qstrdefs.generated.h
 
 apps_tests_src = $(app_calculation_test_src) $(app_code_test_src) $(app_graph_test_src) $(app_probability_test_src) $(app_regression_test_src) $(app_sequence_test_src) $(app_shared_test_src) $(app_statistics_test_src) $(app_settings_test_src) $(app_solver_test_src)

--- a/python/port/mpconfigport.h
+++ b/python/port/mpconfigport.h
@@ -144,3 +144,10 @@ extern const struct _mp_obj_module_t modturtle_module;
     { MP_ROM_QSTR(MP_QSTR_time), MP_ROM_PTR(&modtime_module) }, \
     { MP_ROM_QSTR(MP_QSTR_turtle), MP_ROM_PTR(&modturtle_module) }, \
 
+// Enable setjmp in debug mode. This is to avoid some optimizations done
+// specifically for x86_64 using inline assembly, which makes the debug binary
+// crash with an illegal instruction
+#ifndef NDEBUG
+  #define MICROPY_NLR_SETJMP 1
+#endif
+


### PR DESCRIPTION
This fixes #1777 by adding apps_layout.h as a dependency and fixes #1276 by enabling setjmp in debug mode. This is less optimized than what is in place using inline assembly, but is enabled only on debug and makes it not crash.