### PR TITLE
[Inliner] Fixed memory leak

### DIFF
--- a/escher/image/inliner.c
+++ b/escher/image/inliner.c
@@ -104,6 +104,13 @@ int main(int argc, char * argv[]) {
   FILE * implementation = fopen(implementationPath, "w");
   generateImplementationFromImage(implementation, lowerSnakeCaseName, camelCaseName, width, height, rowPointers);
   fclose(implementation);
+  
+  for (int i=0; i<height; i++) {
+    free(rowPointers[i]);
+  }
+  free(rowPointers);
+  free(png);
+  free(info);
 
   fclose(inputFile);
 }

--- a/escher/image/inliner.c
+++ b/escher/image/inliner.c
@@ -109,8 +109,7 @@ int main(int argc, char * argv[]) {
     free(rowPointers[i]);
   }
   free(rowPointers);
-  free(png);
-  free(info);
+  png_destroy_read_struct(&png, &info, NULL);
 
   fclose(inputFile);
 }


### PR DESCRIPTION
While debugging something with the inliner, was using ASAN, I saw there was lot of memory leak with this script. I still get some, but they're located in libpng.