### PR TITLE
[poincare/addition] Fix issue with symbolic computation

### DIFF
--- a/apps/calculation/test/calculation_store.cpp
+++ b/apps/calculation/test/calculation_store.cpp
@@ -151,6 +151,12 @@ QUIZ_CASE(calculation_symbolic_computation) {
 
   Ion::Storage::sharedStorage()->recordNamed("f.func").destroy();
   Ion::Storage::sharedStorage()->recordNamed("x.exp").destroy();
+
+  assertCalculationIs("int(x+1/x,x,1,2)", DisplayOutput::ApproximateOnly, EqualSign::Unknown, nullptr, "2.193147", nullptr, &globalContext, &store);
+  assertCalculationIs("1→x", DisplayOutput::ApproximateOnly, EqualSign::Equal, "1", nullptr, nullptr, &globalContext, &store);
+  assertCalculationIs("int(x+1/x,x,1,2)", DisplayOutput::ApproximateOnly, EqualSign::Unknown, nullptr, "2.193147", nullptr, &globalContext, &store);
+
+  Ion::Storage::sharedStorage()->recordNamed("x.exp").destroy();
 }
 
 QUIZ_CASE(calculation_symbolic_computation_and_parametered_expressions) {

--- a/poincare/include/poincare/expression_node.h
+++ b/poincare/include/poincare/expression_node.h
@@ -205,6 +205,7 @@ public:
     Preferences::UnitFormat unitFormat() const { return m_unitFormat; }
     ReductionTarget target() const { return m_target; }
     SymbolicComputation symbolicComputation() const { return m_symbolicComputation; }
+    void setSymbolicComputation(SymbolicComputation symbolicComputation) { m_symbolicComputation = symbolicComputation; }
     UnitConversion unitConversion() const { return m_unitConversion; }
   private:
     Preferences::UnitFormat m_unitFormat;

--- a/poincare/src/addition.cpp
+++ b/poincare/src/addition.cpp
@@ -436,19 +436,17 @@ Expression Addition::factorizeOnCommonDenominator(ExpressionNode::ReductionConte
    * parent here), which would be replaced with undef.
    * Example: int((ℯ^(-x))-x^(0.5), x, 0, 3), when creating the common
    * denominator for the integrand. */
-  ExpressionNode::ReductionContext contextWithSymbolicComputation = ExpressionNode::ReductionContext(
-      reductionContext.context(),
-      reductionContext.complexFormat(),
-      reductionContext.angleUnit(),
-      reductionContext.unitFormat(),
-      reductionContext.target(),
-      ExpressionNode::SymbolicComputation::DoNotReplaceAnySymbol);
+  ExpressionNode::SymbolicComputation previousSymbolicComputation = reductionContext.symbolicComputation();
+  reductionContext.setSymbolicComputation(ExpressionNode::SymbolicComputation::DoNotReplaceAnySymbol);
 
   // Step 4: Simplify the numerator
-  numerator.shallowReduce(contextWithSymbolicComputation);
+  numerator.shallowReduce(reductionContext);
 
   // Step 5: Simplify the denominator (in case it's a rational number)
-  inverseDenominator.deepReduce(contextWithSymbolicComputation);
+  inverseDenominator.deepReduce(reductionContext);
+
+  // Restore symbolicComputation status
+  reductionContext.setSymbolicComputation(previousSymbolicComputation);
 
   /* Step 6: We simplify the resulting multiplication forbidding any
    * distribution of multiplication on additions (to avoid an infinite loop).

--- a/poincare/src/addition.cpp
+++ b/poincare/src/addition.cpp
@@ -429,11 +429,11 @@ Expression Addition::factorizeOnCommonDenominator(ExpressionNode::ReductionConte
   Power inverseDenominator = Power::Builder(commonDenominator, Rational::Builder(-1));
   Multiplication result = Multiplication::Builder(numerator, inverseDenominator);
 
-  /* To simplify the numerator and the denominator, we allow symbolic
-   * computation: all unwanted symbols should have already disappeared by now,
-   * and if we checked again for symbols we might find "parameter" symbols
-   * disconnected from the parametered expression, which would be replaced with
-   * undef.
+  /* To simplify the numerator and the denominator, we temporarily disable
+   * symbolic computation: all unwanted symbols should have already disappeared
+   * by now, and if we checked again for symbols we might find "parameter"
+   * symbols disconnected from the parametered expression (which is no longer a
+   * parent here), which would be replaced with undef.
    * Example: int((ℯ^(-x))-x^(0.5), x, 0, 3), when creating the common
    * denominator for the integrand. */
   ExpressionNode::ReductionContext contextWithSymbolicComputation = ExpressionNode::ReductionContext(
@@ -442,7 +442,7 @@ Expression Addition::factorizeOnCommonDenominator(ExpressionNode::ReductionConte
       reductionContext.angleUnit(),
       reductionContext.unitFormat(),
       reductionContext.target(),
-      ExpressionNode::SymbolicComputation::ReplaceAllDefinedSymbolsWithDefinition);
+      ExpressionNode::SymbolicComputation::DoNotReplaceAnySymbol);
 
   // Step 4: Simplify the numerator
   numerator.shallowReduce(contextWithSymbolicComputation);


### PR DESCRIPTION
This PR fixes https://github.com/numworks/epsilon/issues/1831

When factorizing on a common denominator, the temporary expressions don't have parents, and don't know about `x`'s definition from the integral.

Therefore, symbols should not be replaced with their definition here.

I also added a unit tests.