### PR TITLE
Lock Hardware Test while Exam Mode enabled

### DIFF
--- a/apps/settings/sub_menu/about_controller.cpp
+++ b/apps/settings/sub_menu/about_controller.cpp
@@ -31,7 +31,7 @@ AboutController::AboutController(Responder * parentResponder) :
 bool AboutController::handleEvent(Ion::Events::Event event) {
   /* We hide here the activation hardware test app: in the menu "about", by
    * clicking on '6' on the last row. */
-  if ((event == Ion::Events::Six || event == Ion::Events::LowerT || event == Ion::Events::UpperT) && m_messageTreeModel->label() == I18n::Message::About && selectedRow() == numberOfRows()-1) {
+  if ((event == Ion::Events::Six || event == Ion::Events::LowerT || event == Ion::Events::UpperT) && m_messageTreeModel->label() == I18n::Message::About && selectedRow() == numberOfRows()-1 && !GlobalPreferences::sharedGlobalPreferences()->isInExamMode()) {
     m_hardwareTestPopUpController.presentModally();
     return true;
   }


### PR DESCRIPTION
This allow to avoid any inconvenience around LED usage such as overirding colours and taking LED off
Security measure to avoid any inconvenience during Exam