### PR TITLE
cppcheck: Same expression 'nextChildType==LayoutNode::Type::CeilingLa…

### DIFF
--- a/poincare/src/horizontal_layout.cpp
+++ b/poincare/src/horizontal_layout.cpp
@@ -224,7 +224,6 @@ int HorizontalLayoutNode::serializeChildrenBetweenIndexes(char * buffer, int buf
             || nextChildType == LayoutNode::Type::BinomialCoefficientLayout
             || nextChildType == LayoutNode::Type::CeilingLayout
             || nextChildType == LayoutNode::Type::ConjugateLayout
-            || nextChildType == LayoutNode::Type::CeilingLayout
             || nextChildType == LayoutNode::Type::FloorLayout
             || nextChildType == LayoutNode::Type::IntegralLayout
             || nextChildType == LayoutNode::Type::LetterAWithSubAndSuperscriptLayout


### PR DESCRIPTION
…yout' found multiple times in chain of '||' operators. [duplicateExpression]

Since 92c5196a38e1b5c02a24ec7c30189b3079a776fd
[poincare] Fix serializing/parsing of layout x|2|
(in 2019)