### PR TITLE
Fix Wmaybe-uninitialized in apps/regression/model/trigonometric_model…

### DIFF
--- a/apps/regression/model/trigonometric_model.cpp
+++ b/apps/regression/model/trigonometric_model.cpp
@@ -151,7 +151,7 @@ static void findExtrema(double* xMinExtremum, double* xMaxExtremum,
       foundMin = foundMin && foundMax;
     }
     if (foundMin && foundMax) {
-      return;  // Two extremum have been found
+      break;  // Two extremum have been found
     }
     lastMinExtremum++;
     lastMaxExtremum++;


### PR DESCRIPTION
….cpp

Fixes these:
apps/regression/model/trigonometric_model.cpp: In member function ‘virtual void Regression::TrigonometricModel::specializedInitCoefficientsForFit(double*, double, Regression::Store*, int) const’:
apps/regression/model/trigonometric_model.cpp:194:40: warning: ‘xMin’ may be used uninitialized [-Wmaybe-uninitialized]
  194 |   double period = 2.0 * std::fabs(xMax - xMin);
      |                                   ~~~~~^~~~~~
apps/regression/model/trigonometric_model.cpp:187:10: note: ‘xMin’ was declared here
  187 |   double xMin, xMax, yMin, yMax;
      |          ^~~~
apps/regression/model/trigonometric_model.cpp:194:40: warning: ‘xMax’ may be used uninitialized [-Wmaybe-uninitialized]
  194 |   double period = 2.0 * std::fabs(xMax - xMin);
      |                                   ~~~~~^~~~~~
apps/regression/model/trigonometric_model.cpp:187:16: note: ‘xMax’ was declared here
  187 |   double xMin, xMax, yMin, yMax;
      |                ^~~~
apps/regression/model/trigonometric_model.cpp:190:32: warning: ‘yMin’ may be used uninitialized [-Wmaybe-uninitialized]
  190 |   modelCoefficients[0] = (yMax - yMin) / 2.0;
      |                          ~~~~~~^~~~~~~
apps/regression/model/trigonometric_model.cpp:187:22: note: ‘yMin’ was declared here
  187 |   double xMin, xMax, yMin, yMax;
      |                      ^~~~
apps/regression/model/trigonometric_model.cpp:190:32: warning: ‘yMax’ may be used uninitialized [-Wmaybe-uninitialized]
  190 |   modelCoefficients[0] = (yMax - yMin) / 2.0;
      |                          ~~~~~~^~~~~~~
apps/regression/model/trigonometric_model.cpp:187:28: note: ‘yMax’ was declared here
  187 |   double xMin, xMax, yMin, yMax;
      |                            ^~~~
LD      epsilon.bin
